### PR TITLE
Base for system specific ChatMessage Data and Documents

### DIFF
--- a/module/data/_module.mjs
+++ b/module/data/_module.mjs
@@ -2,6 +2,7 @@ export {default as SystemDataModel, SparseDataModel, getLocalizeKey} from "./abs
 
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
+export * as chat from "./chat/_module.mjs";
 export * as fields from "./fields/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as other from "./other/_module.mjs";

--- a/module/data/chat/_module.mjs
+++ b/module/data/chat/_module.mjs
@@ -1,0 +1,12 @@
+import AttackMessageData from "./attack.mjs";
+import BaseMessageData from "./base-message.mjs";
+
+export {
+  AttackMessageData,
+  BaseMessageData,
+};
+
+export const config = {
+  base:   BaseMessageData,
+  attack: AttackMessageData,
+};

--- a/module/data/chat/attack.mjs
+++ b/module/data/chat/attack.mjs
@@ -1,0 +1,31 @@
+import BaseMessageData from "./base-message.mjs";
+
+export default class AttackMessageData extends BaseMessageData {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return this.mergeSchema( super.defineSchema(), {
+      attacker: new fields.DocumentUUIDField( {
+        required: false,
+        nullable: true,
+      } ),
+      targets: new fields.ArrayField(
+        new fields.DocumentUUIDField( {
+          required: false,
+          nullable: true,
+        } ),
+        {
+          required: false,
+          nullable: true,
+        }
+      ),
+      damageDealt: new fields.NumberField( {
+        required: false,
+        nullable: true,
+        min:      0,
+        initial:  0,
+      } ),
+    } );
+  }
+
+}

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -1,0 +1,5 @@
+import SystemDataModel from "../abstract.mjs";
+
+export default class BaseMessageData extends SystemDataModel {
+
+}

--- a/module/documents/_module.mjs
+++ b/module/documents/_module.mjs
@@ -1,4 +1,5 @@
 // document classes
 export {default as ActorEd} from "./actor.mjs";
+export {default as ChatMessageEd} from "./chat.mjs";
 export {default as ItemEd} from "./item.mjs";
 export {default as JournalEntryEd} from "./journal.mjs";

--- a/module/documents/chat.mjs
+++ b/module/documents/chat.mjs
@@ -1,0 +1,12 @@
+export default class ChatMessageEd extends ChatMessage {
+
+  /** @inheritdoc */
+  async getHTML() {
+    const baseHtml = await super.getHTML();
+    if ( typeof this.system.getHTML === "function" ) {
+      return this.system.getHTML( baseHtml );
+    }
+    return baseHtml;
+  }
+
+}

--- a/module/hooks/init.mjs
+++ b/module/hooks/init.mjs
@@ -25,6 +25,7 @@ export default function () {
     // record configuration values
     CONFIG.ED4E = ED4E;
     CONFIG.Actor.documentClass = documents.ActorEd;
+    CONFIG.ChatMessage.documentClass = documents.ChatMessageEd;
     CONFIG.Item.documentClass = documents.ItemEd;
     CONFIG.JournalEntry.documentClass = documents.JournalEntryEd;
 
@@ -38,6 +39,7 @@ export default function () {
 
     // Hook up system data types
     CONFIG.Actor.dataModels = data.actor.config;
+    CONFIG.ChatMessage.dataModels = data.chat.config;
     CONFIG.Item.dataModels = data.item.config;
 
     // Register sheet application classes

--- a/template.json
+++ b/template.json
@@ -13,6 +13,12 @@
       "loot"
     ]
   },
+  "ChatMessage": {
+    "types": [
+      "attack",
+      "base"
+      ]
+  },
   "Item": {
     "types": [
       "armor",


### PR DESCRIPTION
Create the foundation for ED system specific ChatMessages documents and their DataModels. This currently has no additional functionality but serves as the basis for future enhancements (e.g. Chat Workflows for attacks, etc). The AttackMessage is just an example of how it might work.