### PR TITLE
Basic attack rolls from abilities

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -460,12 +460,25 @@
         "physical": "Körperlich",
         "social": "Sozial"
       },
-      "WeaponType": {
-        "blowgun": "Blasrohr",
+      "WeaponSubType" : {
+        "axe": "Axt",
         "bow": "Bogen",
+        "blade": "Klinge",
+        "bola": "Bola",
         "crossbow": "Armbrust",
+        "club": "Keule",
+        "dart": "Wurfpfeil",
+        "dagger": "Dolch",
+        "hawkHatchet": "Falkenklaue",
+        "net": "Netz",
+        "polearm": "Stangenwaffe",
+        "spear": "Speer",
+        "staff": "Stab",
+        "sword": "Schwert"
+      },
+      "WeaponType": {
         "melee": "Nahkampf",
-        "sling": "Schleuder",
+        "missile": "Projektilwaffe",
         "thrown": "Wurfwaffe",
         "unarmed": "Unbewaffnet"
       }
@@ -596,6 +609,7 @@
             "RollTypeDetails": {
               "attack":                                     "Details für Aktionstyp 'Angriff'",
               "Attack": {
+                "combatType":                               "Welchen Kampftyp muss die verwendete Waffe haben?",
                 "weaponItemStatus":                         "Wie muss die Waffe getragen werden um damit anzugreifen"
               },
               "reaction":                                   "Details für Aktionstyp 'Reaktion'",
@@ -753,7 +767,8 @@
             "weavingDifficulty":                            "Die Schwierigkeit um den Zauber erfolgreich zu wirken"
           },
           "Weapons": {
-            "weaponType":                                   "Waffentyp",
+            "weaponType":                                   "Der Kampftyp der Waffe",
+            "weaponSubType":                                "Die Art der Waffe",
             "damageAttribute":                              "Schaden Attribut",
             "damageBaseStep":                               "Grundschaden Stufe",
             "size":                                         "Größe",
@@ -791,6 +806,7 @@
               "ability":                                   "Fähigkeit",
               "attack":                                    "Angriff",
               "Attack": {
+                "combatType":                               "Kampftyp",
                 "weaponItemStatus":                         "Waffenstatus"
               },
               "damage":                                    "Schaden",
@@ -955,7 +971,8 @@
             "weavingDifficulty":                            "Webschwierigkeit"
           },
           "Weapons": {
-            "weaponType":                                   "Waffentyp",
+            "weaponType":                                   "Kampftyp",
+            "weaponSubType":                                "Waffensubtyp",
             "damageAttribute":                              "Schaden Attribut",
             "damageBaseStep":                               "Grundschaden Stufe",
             "size":                                         "Größe",

--- a/lang/de.json
+++ b/lang/de.json
@@ -551,6 +551,9 @@
       },
       "General": {
         "Hints": {
+          "Rollable": {
+            "type":                                         "Welche Aktionsart wird für diese Fähigkeit verwendet?"
+          },
           "Target": {
             "target":                                       "Welcher Widerstandstyp des Ziels wird für diese Fähigkeit verwendet?",
             "group":                                        "Welche Gruppen Parameter werden für mehrere Ziele verwendet?",
@@ -558,6 +561,9 @@
           }
         },
         "Labels": {
+          "Rollable": {
+            "type":                                         "Aktionsart"
+          },
           "Target": {
             "target":                                       "Widerstandstyp",
             "group":                                        "Gruppen Parameter",
@@ -590,7 +596,6 @@
             "talentLearnedKnacks":                          "Gelernte Kniffe",
             "talentKnacksLearned":                          "Gelernte Kniffe",
             "talentKnacks":                                 "Kniffe",
-            "type":                                         "Welche Aktionsart wird für diese Fähigkeit verwendet?",
             "DamageAbilities": {
             "damage":                                       "Ist diese Fähigkeit eine Schadensfägigkeit",
             "substitute":                                   "Ersetzt Schadesattribute",
@@ -774,7 +779,6 @@
             "talentLearnedKnacks":                          "Gelernte Kniffe",
             "talentKnacksLearned":                          "Gelernte Kniffe",
             "talentKnacks":                                 "Kniffe",
-            "type":                                         "Aktionsart",
             "DamageAbilities": {
             "damage":                                       "Schaden",
             "substitute":                                   "Ersetzt Schadensattribute",

--- a/lang/de.json
+++ b/lang/de.json
@@ -396,6 +396,7 @@
         "effect": "Effekt",
         "halfmagic": "Halb Magie",
         "initiative": "Initiative",
+        "reaction": "Reaktion",
         "recovery": "Erholung",
         "spellcasting": "Spruchzauberei",
         "threadWeaving": "Fadenweben"
@@ -591,6 +592,17 @@
               "magicType":                              "Magie Typ",
               "magic":                                  "Magie"
             },
+            "rollTypeDetails":                              "Details zur Aktionsart",
+            "RollTypeDetails": {
+              "attack":                                     "Details für Aktionstyp 'Angriff'",
+              "Attack": {
+                "weaponItemStatus":                         "Wie muss die Waffe getragen werden um damit anzugreifen"
+              },
+              "reaction":                                   "Details für Aktionstyp 'Reaktion'",
+              "Reaction": {
+                "defenseType":                             "Auf welchen Widerstand muss eine Fähigkeit zielen damit diese Reaktion ausgelöst wird?"
+              }
+            },
             "talentAvailableKnacks":                        "Verfügbare Kniffe",
             "talentKnacksAvailable":                        "Verfügbare Kniffe",
             "talentLearnedKnacks":                          "Gelernte Kniffe",
@@ -768,11 +780,29 @@
             "durability":                                   "Unempfindlichkeit",
             "devotionRequired":                             "Weihepunkt benötigt",
             "talentCategory":                               "Talent Kategorie",
-              "Magic": {
+            "Magic": {
               "threadWeaving":                          "Fadenweben",
               "spellcasting":                           "Spruchzauberei",
               "magicType":                              "Magie Typ",
               "magic":                                  "Magie"
+            },
+            "rollTypeDetails":                              "Details zur Aktionsart",
+            "RollTypeDetails": {
+              "ability":                                   "Fähigkeit",
+              "attack":                                    "Angriff",
+              "Attack": {
+                "weaponItemStatus":                         "Waffenstatus"
+              },
+              "damage":                                    "Schaden",
+              "effect":                                    "Effekt",
+              "initiative":                                "Initiative",
+              "reaction":                                  "Reaktion",
+              "Reaction": {
+                "defenseType":                              "Verteidigungstyp"
+              },
+              "recovery":                                  "Erholung",
+              "spellcasting":                              "Spruchzauberei",
+              "threadWeaving":                             "Fadenweben"
             },
             "talentAvailableKnacks":                        "Verfügbare Kniffe",
             "talentKnacksAvailable":                        "Verfügbare Kniffe",
@@ -1248,6 +1278,7 @@
       },
       "Header": {
         "activeUser": "Aktive Spieler",
+        "actionType": "Aktionstyp",
         "actorsNoUserConfigured": "Nicht konfigurierte, zugewiesene Akteure",
         "description": "Beschreibung",
         "details": "Details",
@@ -1256,6 +1287,8 @@
         "inactiveUser": "Inaktive Spieler",
         "magic": "Magie",
         "navigator": "Navigator",
+        "talentSource": "Talent Ursprung",
+        "targetingDetails":   "Ziel Details",
         "type": "Typ"
       },
       "Knack": {

--- a/lang/de.json
+++ b/lang/de.json
@@ -621,12 +621,7 @@
             "talentKnacksAvailable":                        "Verfügbare Kniffe",
             "talentLearnedKnacks":                          "Gelernte Kniffe",
             "talentKnacksLearned":                          "Gelernte Kniffe",
-            "talentKnacks":                                 "Kniffe",
-            "DamageAbilities": {
-            "damage":                                       "Ist diese Fähigkeit eine Schadensfägigkeit",
-            "substitute":                                   "Ersetzt Schadesattribute",
-            "relatedRollType":                              "gilt für Aktionstyp"
-            }
+            "talentKnacks":                                 "Kniffe"
           },
           "Action": {
             "action":                                       "Aktion",
@@ -824,12 +819,7 @@
             "talentKnacksAvailable":                        "Verfügbare Kniffe",
             "talentLearnedKnacks":                          "Gelernte Kniffe",
             "talentKnacksLearned":                          "Gelernte Kniffe",
-            "talentKnacks":                                 "Kniffe",
-            "DamageAbilities": {
-            "damage":                                       "Schaden",
-            "substitute":                                   "Ersetzt Schadensattribute",
-            "relatedRollType":                              "gilt für Aktionstyp"
-            }
+            "talentKnacks":                                 "Kniffe"
           },
           "Action": {
             "action":                                       "Aktion",

--- a/lang/de.json
+++ b/lang/de.json
@@ -609,7 +609,7 @@
             "RollTypeDetails": {
               "attack":                                     "Details für Aktionstyp 'Angriff'",
               "Attack": {
-                "combatType":                               "Welchen Kampftyp muss die verwendete Waffe haben?",
+                "weaponType":                               "Welchen Kampftyp muss die verwendete Waffe haben?",
                 "weaponItemStatus":                         "Wie muss die Waffe getragen werden um damit anzugreifen"
               },
               "reaction":                                   "Details für Aktionstyp 'Reaktion'",
@@ -806,7 +806,7 @@
               "ability":                                   "Fähigkeit",
               "attack":                                    "Angriff",
               "Attack": {
-                "combatType":                               "Kampftyp",
+                "weaponType":                               "Kampftyp",
                 "weaponItemStatus":                         "Waffenstatus"
               },
               "damage":                                    "Schaden",
@@ -1400,7 +1400,8 @@
           "noTalentCategorySelected": "Du musst eine Talentkategorie auswählen, sonst können wir nichts zuordnen und kuhle LP Sachen machen :(",
           "questorItemNotUpdated": "Questor-Item konnte nicht aktualisiert werden"
         },
-        "livingArmorOnly":                                  "Es kann nur nur lebendige Rüstung getragen werden.",
+        "livingArmorOnly":                                 "Es kann nur nur lebendige Rüstung getragen werden.",
+        "noWeaponToAttackWith":                            "Keine Waffe zum Angreifen verfügbar :(",
         "piecemealArmorSizeExceeded": "Maximale Menge an stückweiser Rüstung erreicht. Leg andere Teile ab um das neue Stück auszurüsten."
       }
     },

--- a/lang/en.json
+++ b/lang/en.json
@@ -420,12 +420,7 @@
                         "talentLearnedKnacks":                          "Learned Knacks",
                         "talentKnacksLearned":                          "Knacks learned",
                         "talentKnacks":                                 "Knacks",
-                        "type":                                         "Type",
-                        "DamageAbilities": {
-                        "damage":                                       "Damage",
-                        "substitute":                                   "Replaces damage Attribute",
-                        "relatedRollType":                              "related action type"
-                        }
+                        "type":                                         "Type"
                     },
                     "Action": {
                         "action":                                       "Action",
@@ -614,12 +609,7 @@
                         "talentLearnedKnacks":                          "Learned Knacks",
                         "talentKnacksLearned":                          "Knacks learned",
                         "talentKnacks":                                 "Knacks",
-                        "type":                                         "Type",
-                        "DamageAbilities": {
-                        "damage":                                       "Damage",
-                        "substitute":                                   "Replaces damage Attribute",
-                        "relatedRollType":                              "related action type"
-                        }
+                        "type":                                         "Type"
                     },
                     "Action": {
                         "action":                                       "Action",

--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -171,7 +171,21 @@ export default class ActorSheetEd extends HandlebarsApplicationMixin( DocumentSh
 
   static async rollable( event, target ) {
     event.preventDefault();
-    const rolltype = target.dataset.rolltype;
+    const li = target.closest( ".item-id" );
+    const ability = this.document.items.get( li.dataset.itemId );
+
+    if ( ability?.system?.roll instanceof Function ) return ability.system.roll();
+
+    const rollType = target.dataset.rolltype;
+    if ( rollType === "attribute" ) {
+      const attribute = target.dataset.attribute;
+      this.document.rollAttribute( attribute, {}, { event: event } );
+    }  else if ( rollType === "equipment" ) {
+      const li = target.closest( ".item-id" );
+      const equipment = this.document.items.get( li.dataset.itemId );
+      this.document.rollEquipment( equipment, { event: event } );
+    }
+    /*
     if ( rolltype === "attribute" ) {
       const attribute = target.dataset.attribute;
       this.document.rollAttribute( attribute, {}, { event: event } );
@@ -183,7 +197,7 @@ export default class ActorSheetEd extends HandlebarsApplicationMixin( DocumentSh
       const li = target.closest( ".item-id" );
       const equipment = this.document.items.get( li.dataset.itemId );
       this.document.rollEquipment( equipment, { event: event } );
-    }
+    } */
   }
 
   /**

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -712,6 +712,10 @@ ED4E.rollTypes = {
     label:            "ED.Config.rollTypes.initiative",
     flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/initiative-roll-flavor.hbs",
   },
+  reaction: {
+    label:            "ED.Config.rollTypes.reaction",
+    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/reaction-roll-flavor.hbs",
+  },
   recovery: {
     label:            "ED.Config.rollTypes.recovery",
     flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/recovery-roll-flavor.hbs",

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -257,26 +257,14 @@ preLocalize( "armor" );
  * @enum {string}
  */
 ED4E.weaponType = {
-  blowgun:         {
-    label:      "ED.Config.WeaponType.blowgun",
-    ranged:     true,
-  },
-  bow:            {
-    label:      "ED.Config.WeaponType.bow",
-    ranged:     true,
-  },
-  crossbow:       {
-    label:      "ED.Config.WeaponType.crossbow",
-    ranged:     true,
-  },
   melee:          {
     label:      "ED.Config.WeaponType.melee",
     ranged:     false,
   },
-  sling:         {
-    label:      "ED.Config.WeaponType.sling",
+  missile:        {
+    label:      "ED.Config.WeaponType.missile",
     ranged:     true,
-  },  
+  },
   thrown:         {
     label:      "ED.Config.WeaponType.thrown",
     ranged:     true,
@@ -287,6 +275,17 @@ ED4E.weaponType = {
   },
 };
 preLocalize( "weaponType", { key: "label" } );
+
+ED4E.weaponSubType = {
+  bow: {
+    label:      "ED.Config.WeaponSubType.bow",
+    weaponType: "missile",
+  },
+  crossbow: {
+    label:      "ED.Config.WeaponSubType.crossbow",
+    weaponType: "missile",
+  },
+};
 
 /**
  * Damage type

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -76,14 +76,26 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
       rollTypeDetails: new fields.SchemaField( {
         ability:       new fields.SchemaField( {}, {} ),
         attack:        new fields.SchemaField( {
-          weaponItemStatus: new fields.StringField( {
-            required: false,
-            nullable: true,
+          weaponItemStatus: new fields.SetField(
+            new fields.StringField( {
+              required: true,
+              blank:    false,
+              choices:  ED4E.itemStatus,
+            } ),
+            {
+              required: true,
+              initial:  [ "equipped" ],
+              label:    this.labelKey( "Ability.RollTypeDetails.Attack.weaponItemStatus" ),
+              hint:     this.hintKey( "Ability.RollTypeDetails.Attack.weaponItemStatus" )
+            }
+          ),
+          combatType: new fields.StringField( {
+            required: true,
             blank:    false,
-            initial:  null,
-            choices:  ED4E.itemStatus,
-            label:    this.labelKey( "Ability.RollTypeDetails.Attack.weaponItemStatus" ),
-            hint:     this.hintKey( "Ability.RollTypeDetails.Attack.weaponItemStatus" )
+            initial:  "melee",
+            choices:  ED4E.weaponType,
+            label:    this.labelKey( "Ability.RollTypeDetails.Attack.combatType" ),
+            hint:     this.hintKey( "Ability.RollTypeDetails.Attack.combatType" )
           } ),
         }, {
           required: false,
@@ -264,7 +276,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     console.log( "Rolling attack" );
     if ( !this.isActorEmbedded ) return;
 
-    // ed-id "second-weapon" for offhand weapons
     // don't forget to add tail attack
     const equippedWeapons = this.parentActor.equippedWeapons;
     console.log( "Equipped weapons: ", equippedWeapons );

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -129,31 +129,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
         label:    this.labelKey( "Ability.rollTypeDetails" ),
         hint:     this.hintKey( "Ability.rollTypeDetails" )
       } ),
-      damageAbilities: new fields.SchemaField( {
-        damage: new fields.BooleanField( {
-          required: false,
-          nullable: false,
-          initial:  false,
-          label:    this.labelKey( "Ability.DamageAbilities.damage" ),
-          hint:     this.hintKey( "Ability.DamageAbilities.damage" )
-        } ),
-        substitute: new fields.BooleanField( {
-          required: false,
-          nullable: false,
-          initial:  false,
-          label:    this.labelKey( "Ability.DamageAbilities.substitute" ),
-          hint:     this.hintKey( "Ability.DamageAbilities.substitute" )
-        } ),
-        relatedRollType: new fields.StringField( {
-          required: false,
-          nullable: true,
-          blank:    true,
-          initial:  "",
-          choices:  ED4E.rollTypes,
-          label:    this.labelKey( "Ability.DamageAbilities.relatedRollType" ),
-          hint:     this.hintKey( "Ability.DamageAbilities.relatedRollType" )
-        } ),
-      } ),
     } );
   }
 

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -73,6 +73,49 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
         label:    this.labelKey( "Ability.rank" ),
         hint:     this.hintKey( "Ability.rank" )
       } ),
+      rollTypeDetails: new fields.SchemaField( {
+        ability:       new fields.SchemaField( {}, {} ),
+        attack:        new fields.SchemaField( {
+          weaponItemStatus: new fields.StringField( {
+            required: false,
+            nullable: true,
+            blank:    false,
+            initial:  null,
+            choices:  ED4E.itemStatus,
+            label:    this.labelKey( "Ability.RollTypeDetails.Attack.weaponItemStatus" ),
+            hint:     this.hintKey( "Ability.RollTypeDetails.Attack.weaponItemStatus" )
+          } ),
+        }, {
+          required: false,
+          label:    this.labelKey( "Ability.RollTypeDetails.attack" ),
+          hint:     this.hintKey( "Ability.RollTypeDetails.attack" )
+        } ),
+        damage:        new fields.SchemaField( {}, {} ),
+        effect:        new fields.SchemaField( {}, {} ),
+        initiative:    new fields.SchemaField( {}, {} ),
+        reaction:      new fields.SchemaField( {
+          defenseType: new fields.StringField( {
+            required: true,
+            nullable: false,
+            blank:    false,
+            initial:  "physical",
+            choices:  ED4E.targetDifficulty,
+            label:    this.labelKey( "Ability.RollTypeDetails.Reaction.defenseType" ),
+            hint:     this.hintKey( "Ability.RollTypeDetails.Reaction.defenseType" )
+          } ),
+        }, {
+          required: false,
+          label:    this.labelKey( "Ability.RollTypeDetails.reaction" ),
+          hint:     this.hintKey( "Ability.RollTypeDetails.reaction" ),
+        } ),
+        recovery:      new fields.SchemaField( {}, {} ),
+        spellcasting:  new fields.SchemaField( {}, {} ),
+        threadWeaving: new fields.SchemaField( {}, {} ),
+      }, {
+        required: false,
+        label:    this.labelKey( "Ability.rollTypeDetails" ),
+        hint:     this.hintKey( "Ability.rollTypeDetails" )
+      } ),
       damageAbilities: new fields.SchemaField( {
         damage: new fields.BooleanField( {
           required: false,
@@ -211,6 +254,22 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     );
     if ( !createData?.system?.level ) itemData.system.level = 0;
     return ( await actor.createEmbeddedDocuments( "Item", [ itemData ] ) )?.[0];
+  }
+
+  /* -------------------------------------------- */
+  /*                    Rolling                   */
+  /* -------------------------------------------- */
+
+  async rollAttack() {
+    console.log( "Rolling attack" );
+    if ( !this.isActorEmbedded ) return;
+
+    // ed-id "second-weapon" for offhand weapons
+    // don't forget to add tail attack
+    const equippedWeapons = this.parentActor.equippedWeapons;
+    console.log( "Equipped weapons: ", equippedWeapons );
+    const attackType = !equippedWeapons ? "unarmed" : equippedWeapons[0].system.weaponType;
+    console.log( "Attack type: ", attackType );
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -73,15 +73,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
         label:    this.labelKey( "Ability.rank" ),
         hint:     this.hintKey( "Ability.rank" )
       } ),
-      rollType: new fields.StringField( {
-        required: false,
-        nullable: true,
-        blank:    true,
-        initial:  "",
-        choices:  ED4E.rollTypes,
-        label:    this.labelKey( "Ability.type" ),
-        hint:     this.hintKey( "Ability.type" )
-      } ),
       damageAbilities: new fields.SchemaField( {
         damage: new fields.BooleanField( {
           required: false,

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -1,12 +1,15 @@
 import { ItemDataModel } from "../../abstract.mjs";
 import ED4E from "../../../config.mjs";
+import RollableTemplate from "./rollable.mjs";
 
 /**
  * Data model template with information on Attack items.
  * @property {number} strain        strain
  * @property {string} action        action type
  */
-export default class ActionTemplate extends ItemDataModel {
+export default class ActionTemplate extends ItemDataModel.mixin(
+  RollableTemplate,
+) {
 
   /** @inheritDoc */
   static defineSchema() {

--- a/module/data/item/templates/rollable.mjs
+++ b/module/data/item/templates/rollable.mjs
@@ -1,6 +1,7 @@
 import SystemDataModel from "../../abstract.mjs";
 import ED4E from "../../../config.mjs";
 import EdRollOptions from "../../other/roll-options.mjs";
+import { filterObject } from "../../../utils.mjs";
 
 const { fields } = foundry.data;
 
@@ -14,7 +15,10 @@ export default class RollableTemplate extends SystemDataModel {
         nullable: true,
         blank:    true,
         initial:  "",
-        choices:  ED4E.rollTypes,
+        choices:  filterObject(
+          ED4E.rollTypes,
+          ( key, _ ) => ![ "attribute", "halfmagic" ].includes( key )
+        ),
         label:    this.labelKey( "Rollable.type" ),
         hint:     this.hintKey( "Rollable.type" )
       } ),

--- a/module/data/item/templates/rollable.mjs
+++ b/module/data/item/templates/rollable.mjs
@@ -20,4 +20,20 @@ export default class RollableTemplate extends SystemDataModel {
     } );
   }
 
+  async roll() {
+    let rollFunc;
+    switch ( this.rollType ) {
+      case "ability": rollFunc = this.rollAbility; break;
+      case "attack": rollFunc = this.rollAttack; break;
+      case "damage": rollFunc = this.rollDamage; break;
+      case "effect": rollFunc = this.rollEffect; break;
+      case "initiative": rollFunc = this.rollInitiative; break;
+      case "reaction": rollFunc = this.rollReaction; break;
+      case "recovery": rollFunc = this.rollRecovery; break;
+      case "spellcasting": rollFunc = this.rollSpellcasting; break;
+      case "threadWeaving": rollFunc = this.rollThreadWeaving; break;
+    }
+    return rollFunc();
+  }
+
 }

--- a/module/data/item/templates/rollable.mjs
+++ b/module/data/item/templates/rollable.mjs
@@ -1,5 +1,6 @@
 import SystemDataModel from "../../abstract.mjs";
 import ED4E from "../../../config.mjs";
+import EdRollOptions from "../../other/roll-options.mjs";
 
 const { fields } = foundry.data;
 
@@ -20,18 +21,27 @@ export default class RollableTemplate extends SystemDataModel {
     } );
   }
 
+  /**
+   * @type {EdRollOptions}
+   */
+  get baseRollOptions() {
+    if ( !this.isActorEmbedded ) return new EdRollOptions();
+
+    return EdRollOptions.fromActor( { devotionRequired: !!this.devotionRequired }, this.parentActor );
+  }
+
   async roll() {
     let rollFunc;
     switch ( this.rollType ) {
-      case "ability": rollFunc = this.rollAbility; break;
-      case "attack": rollFunc = this.rollAttack; break;
-      case "damage": rollFunc = this.rollDamage; break;
-      case "effect": rollFunc = this.rollEffect; break;
-      case "initiative": rollFunc = this.rollInitiative; break;
-      case "reaction": rollFunc = this.rollReaction; break;
-      case "recovery": rollFunc = this.rollRecovery; break;
-      case "spellcasting": rollFunc = this.rollSpellcasting; break;
-      case "threadWeaving": rollFunc = this.rollThreadWeaving; break;
+      case "ability": rollFunc = this.rollAbility.bind( this ); break;
+      case "attack": rollFunc = this.rollAttack.bind( this ); break;
+      case "damage": rollFunc = this.rollDamage.bind( this ); break;
+      case "effect": rollFunc = this.rollEffect.bind( this ); break;
+      case "initiative": rollFunc = this.rollInitiative.bind( this ); break;
+      case "reaction": rollFunc = this.rollReaction.bind( this ); break;
+      case "recovery": rollFunc = this.rollRecovery.bind( this ); break;
+      case "spellcasting": rollFunc = this.rollSpellcasting.bind( this ); break;
+      case "threadWeaving": rollFunc = this.rollThreadWeaving.bind( this ); break;
     }
     return rollFunc();
   }

--- a/module/data/item/templates/rollable.mjs
+++ b/module/data/item/templates/rollable.mjs
@@ -1,0 +1,23 @@
+import SystemDataModel from "../../abstract.mjs";
+import ED4E from "../../../config.mjs";
+
+const { fields } = foundry.data;
+
+export default class RollableTemplate extends SystemDataModel {
+
+  /** @inheritDoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      rollType: new fields.StringField( {
+        required: false,
+        nullable: true,
+        blank:    true,
+        initial:  "",
+        choices:  ED4E.rollTypes,
+        label:    this.labelKey( "Rollable.type" ),
+        hint:     this.hintKey( "Rollable.type" )
+      } ),
+    } );
+  }
+
+}

--- a/module/data/item/templates/targeting.mjs
+++ b/module/data/item/templates/targeting.mjs
@@ -32,10 +32,9 @@ export default class TargetTemplate extends SystemDataModel {
           hint:     this.hintKey( "Target.group" )
         } ),
         fixed: new foundry.data.fields.NumberField( {
-          required: true,
-          nullable: false,
+          required: false,
+          nullable: true,
           min:      0,
-          initial:  () => game.settings.get( "ed4e", "minimumDifficulty" ),
           integer:  true,
           label:    this.labelKey( "Target.fixed" ),
           hint:     this.hintKey( "Target.fixed" )
@@ -59,11 +58,7 @@ export default class TargetTemplate extends SystemDataModel {
     let fixedDifficultySetting = this.difficulty.fixed;
 
     if ( numTargets <= 0 || targetDifficultySetting === "none" ) {
-      if ( fixedDifficultySetting > 0 ) {
-        difficulty = fixedDifficultySetting;
-      } else {
-        difficulty = 0;
-      }
+      difficulty = ( fixedDifficultySetting > 0 ) ? fixedDifficultySetting : game.settings.get( "ed4e", "minimumDifficulty" );
     } else {
       let baseDifficulty;
       let additionalTargetDifficulty = 0;

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -35,7 +35,14 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
         label:    this.labelKey( "Weapons.weaponType" ),
         hint:     this.hintKey( "Weapons.weaponType" )
       } ),
-      damage: new fields.SchemaField( {
+      weaponSubType: new fields.StringField( {
+        required: true,
+        initial:  "bow",
+        choices:  ED4E.weaponSubType,
+        label:    this.labelKey( "Weapons.weaponSubType" ),
+        hint:     this.hintKey( "Weapons.weaponSubType" ),
+      } ),
+      damage:        new fields.SchemaField( {
         attribute: new fields.StringField( {
           required: true,
           nullable: false,
@@ -192,7 +199,8 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
    * @type {boolean}
    */
   get isTwoHandedRanged() {
-    return [ "bow", "crossbow" ].includes( this.weaponType );
+    return false;
+    // TODO: add additional datafield
   }
 
   get isRanged() {

--- a/module/data/other/roll-options.mjs
+++ b/module/data/other/roll-options.mjs
@@ -43,8 +43,11 @@ import FormulaField from "../fields/formula-field.mjs";
  * @property { RollStepData } step Ever information related to the step of the action, Mods, Boni, Mali etc.
  * @property { RollRessourceData } karma Available Karma, Karma dice and used karma.
  * @property { RollRessourceData } devotion Available Devotions, Devotion die, Devotion die used and used devotion.
+ * @property { Record<string, number> } extraDice Extra dice that are added to the roll.
+ *                                            Keys are localized labels. Values are the number of dice.
  * @property { RollTargetData } target All information of the targets array. Defenses, number, resistance.
  * @property { RollStrainData } strain How much strain this roll will cost
+ * @property { string } chatFlavor The text that is added to the ChatMessage when this call is put to chat.
  * @property { ( 'action' | 'effect' ) } testType The type of roll.
  * @property { string } rollType Type of roll, like
  *                               damageRanged (Effect), damageMelee (Effect), attackRanged, attackMelee,
@@ -281,7 +284,7 @@ export default class EdRollOptions extends foundry.abstract.DataModel {
     return new EdRollOptions( data, options );
   }
 
-  static initResourceStep( source ) {
+  static initResourceStep( _ ) {
     const parentField = this?.parent?.name;
     return ED4E.resourceDefaultStep[parentField] ?? 4;
   }

--- a/module/data/other/roll-options.mjs
+++ b/module/data/other/roll-options.mjs
@@ -4,6 +4,57 @@ import ED4E from "../../config.mjs";
 import MappingField from "../fields/mapping-field.mjs";
 import FormulaField from "../fields/formula-field.mjs";
 
+/**
+ * @typedef { object} RollStepData Data for a roll step.
+ * @property { number } base The base step that is used to determine the dice that are rolled.
+ * @property { Record<string, number> } modifiers All modifiers that are applied to the base step.
+ *                                              Keys are localized labels. Values are the modifier.
+ * @property { number } total The final step that is used to determine the dice that are rolled.
+ *                            The sum of all modifiers is added to the base value.
+ */
+
+/**
+ * @typedef { object } RollRessourceData Data for a roll resource like karma or devotion.
+ * @property { number } pointsUsed How many points of this resource should be consumed after rolling.
+ * @property { number } available How many points of this resource are available.
+ * @property { number } step The step that is used to determine the dice that are rolled for this resource.
+ * @property { string } dice The dice that are rolled for this resource.
+ */
+
+/**
+ * @typedef { object } RollTargetData Data for the target number of a roll.
+ * @property { number } base The base target number.
+ * @property { Record<string, number> } modifiers All modifiers that are applied to the base target number.
+ *                                             Keys are localized labels. Values are the modifier.
+ * @property { number } total The final target number. The sum of all modifiers is added to the base value.
+ * @property { boolean } public Whether the target number is shown in chat or hidden.
+ */
+
+/**
+ * @typedef { object } RollStrainData Data for the strain that is taken after a roll.
+ * @property { number } base The base strain that is taken.
+ * @property { Record<string, number> } modifiers All modifiers that are applied to the base strain.
+ *                                            Keys are localized labels. Values are the modifier.
+ * @property { number } total The final strain that is taken. The sum of all modifiers is added to the base value.
+ */
+
+/**
+ * EdRollOptions for creating an EdRoll instance.
+ * @property { RollStepData } step Ever information related to the step of the action, Mods, Boni, Mali etc.
+ * @property { RollRessourceData } karma Available Karma, Karma dice and used karma.
+ * @property { RollRessourceData } devotion Available Devotions, Devotion die, Devotion die used and used devotion.
+ * @property { RollTargetData } target All information of the targets array. Defenses, number, resistance.
+ * @property { RollStrainData } strain How much strain this roll will cost
+ * @property { ( 'action' | 'effect' ) } testType The type of roll.
+ * @property { string } rollType Type of roll, like
+ *                               damageRanged (Effect), damageMelee (Effect), attackRanged, attackMelee,
+ *                               ability,
+ *                               resistances (Effect), reaction, opposed
+ *                               spellCasting, threadWeaving, spellCastingEffect (Effect)
+ *                               Initiative (effect), Recovery (Effect), effects (Effect)
+ *                               poison
+ *                               etc. TODO: complete list
+ */
 export default class EdRollOptions extends foundry.abstract.DataModel {
   /** @inheritDoc */
   static defineSchema() {
@@ -275,8 +326,7 @@ export default class EdRollOptions extends foundry.abstract.DataModel {
 
   /**
    * @description Bonus resources to be added globally
-   * @type {object}
-   * @property {number} something Value of the global bonus
+   * @type { RollRessourceData }
    */
   static get #bonusResource() {
     const fields = foundry.data.fields;

--- a/module/dice/ed-roll.mjs
+++ b/module/dice/ed-roll.mjs
@@ -44,7 +44,7 @@ export default class EdRoll extends Roll {
       }]`;
     super( baseTerm, data, edRollOptions );
 
-    this.flavorTemplate = ED4E.testTypes[this.options.testType]?.flavorTemplate ?? ED4E.testTypes.arbitrary.flavorTemplate;
+    this.flavorTemplate = ED4E.rollTypes[this.options.rollType]?.flavorTemplate ?? ED4E.testTypes.arbitrary.flavorTemplate;
 
     if ( !this.options.extraDiceAdded ) this.#addExtraDice();
     if ( !this.options.configured ) this.#configureModifiers();

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -65,6 +65,16 @@ export default class ActorEd extends Actor {
   }
 
   /**
+   * Returns the equipped weapons of this actor, if any.
+   * @type {ItemEd[]}
+   */
+  get equippedWeapons() {
+    return this.itemTypes["weapon"].filter(
+      item => [ "mainHand", "offHand", "twoHands" ].includes( item.system.itemStatus )
+    );
+  }
+
+  /**
    * Returns the highest discipline of an actor
    * @type {Item|undefined}
    */ 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -285,7 +285,7 @@ export default class ActorEd extends Actor {
       this
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    return this.#processRoll( roll );
+    return this.processRoll( roll );
   }
 
   /**
@@ -327,7 +327,7 @@ export default class ActorEd extends Actor {
     );
     edRollOptions.updateSource( edRollOptionsData );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    return this.#processRoll( roll );
+    return this.processRoll( roll );
   }
 
   /**
@@ -365,7 +365,7 @@ export default class ActorEd extends Actor {
       this
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    this.#processRoll( roll );
+    this.processRoll( roll );
   }
 
   /**
@@ -463,7 +463,7 @@ export default class ActorEd extends Actor {
       this
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    this.#processRoll( roll );
+    this.processRoll( roll );
   }
 
 
@@ -570,7 +570,7 @@ export default class ActorEd extends Actor {
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
 
-    this.#processRoll( roll );
+    this.processRoll( roll );
   }
 
   async jumpUp( options = {} ) {
@@ -615,7 +615,7 @@ export default class ActorEd extends Actor {
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
 
-    this.#processRoll( roll );
+    this.processRoll( roll );
   }
 
 
@@ -643,7 +643,7 @@ export default class ActorEd extends Actor {
    * @param {EdRoll} roll The prepared Roll.
    * @returns {EdRoll}    The processed Roll.
    */
-  async #processRoll( roll ) {
+  async processRoll( roll ) {
     if ( !roll ) {
       // No roll available, do nothing.
       return;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -70,7 +70,7 @@ export default class ActorEd extends Actor {
    */
   get equippedWeapons() {
     return this.itemTypes["weapon"].filter(
-      item => [ "mainHand", "offHand", "twoHands" ].includes( item.system.itemStatus )
+      item => [ "mainHand", "offHand", "twoHands", "tail" ].includes( item.system.itemStatus )
     );
   }
 

--- a/templates/actor/actor-partials/actor-section-top.hbs
+++ b/templates/actor/actor-partials/actor-section-top.hbs
@@ -1,10 +1,6 @@
 <section class="actor-section__top">
     <div class="top">
-        {{log "actor-section-top" this}}
-        {{log "this.actor" this.actor}}
-        {{log "this.actor.type" this.actor.type}}
         {{#if (eq this.actor.type "npc")}}
-        {{log "bin drin???" this}}
             {{#if (eq this.actor.system.mobRules true)}}
             <div class="image-characteristics-mob__grid-container">
             {{else}}
@@ -88,7 +84,6 @@
             </div>
 
             <!-- GRID - Damage & Recovery -->
-            {{log "this.actor.type" this.actor.type}}
             {{#if (eq this.actor.type "character")}}
                 {{> "systems/ed4e/templates/actor/cards/damage-character-card.hbs"}}
             {{else}}

--- a/templates/item/item-partials/item-details/details/item-details-abilities.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-abilities.hbs
@@ -14,15 +14,4 @@
     {{/if}}
   {{/each}}
 
-
 </fieldset>
-
-{{!-- Damage ability yes / no --}}
-{{!--formField systemFields.damageAbilities.fields.damage name="system.damageAbilities.damage" value=item.system.damageAbilities.damage localize=true--}}
-{{!-- Damage adder yes / no --}}
-{{!--formField systemFields.damageAbilities.fields.substitute name="system.damageAbilities.substitute" value=item.system.damageAbilities.substitute localize=true--}}
-{{!--#if (eq item.system.damageAbilities.substitute true)--}}
-{{!-- Strength SUbstitute is based on the rolltype --}}
-{{!--formField systemFields.damageAbilities.fields.relatedRollType name="system.damageAbilities.relatedRollType" value=item.system.damageAbilities.relatedRollType localize=true}}
-
-{{/if--}}

--- a/templates/item/item-partials/item-details/details/item-details-abilities.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-abilities.hbs
@@ -9,7 +9,7 @@
   {{#each systemFields.rollTypeDetails.fields as |field key|}}
     {{#if (eq key ../item.system.rollType)}}
       {{#each field.fields as |subField subKey|}}
-        {{formGroup subField name=(concat "system.rollTypeDetails." key "." subKey.name) value=(lookup (lookup ../../item.system.rollTypeDetails key) subKey) localize=true}}
+        {{formGroup subField name=(concat "system.rollTypeDetails." key "." subKey) value=(lookup (lookup ../../item.system.rollTypeDetails key) subKey) localize=true}}
       {{/each}}
     {{/if}}
   {{/each}}

--- a/templates/item/item-partials/item-details/details/item-details-abilities.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-abilities.hbs
@@ -1,11 +1,28 @@
 {{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}
-{{!-- abilty action type --}}
-{{formField systemFields.rollType name="system.rollType" value=item.system.rollType localize=true}}
+
+<fieldset>
+  <legend>{{localize "ED.Item.Header.actionType"}}</legend>
+
+  {{!-- abilty action type --}}
+  {{formGroup systemFields.rollType name="system.rollType" value=item.system.rollType localize=true}}
+
+  {{#each systemFields.rollTypeDetails.fields as |field key|}}
+    {{#if (eq key ../item.system.rollType)}}
+      {{#each field.fields as |subField subKey|}}
+        {{formGroup subField name=(concat "system.rollTypeDetails." key "." subKey.name) value=(lookup (lookup ../../item.system.rollTypeDetails key) subKey) localize=true}}
+      {{/each}}
+    {{/if}}
+  {{/each}}
+
+
+</fieldset>
+
 {{!-- Damage ability yes / no --}}
-{{formField systemFields.damageAbilities.fields.damage name="system.damageAbilities.damage" value=item.system.damageAbilities.damage localize=true}}
+{{!--formField systemFields.damageAbilities.fields.damage name="system.damageAbilities.damage" value=item.system.damageAbilities.damage localize=true--}}
 {{!-- Damage adder yes / no --}}
-{{formField systemFields.damageAbilities.fields.substitute name="system.damageAbilities.substitute" value=item.system.damageAbilities.substitute localize=true}}
-{{#if (eq item.system.damageAbilities.substitute true)}}
+{{!--formField systemFields.damageAbilities.fields.substitute name="system.damageAbilities.substitute" value=item.system.damageAbilities.substitute localize=true--}}
+{{!--#if (eq item.system.damageAbilities.substitute true)--}}
 {{!-- Strength SUbstitute is based on the rolltype --}}
-{{formField systemFields.damageAbilities.fields.relatedRollType name="system.damageAbilities.relatedRollType" value=item.system.damageAbilities.relatedRollType localize=true}}
-{{/if}}
+{{!--formField systemFields.damageAbilities.fields.relatedRollType name="system.damageAbilities.relatedRollType" value=item.system.damageAbilities.relatedRollType localize=true}}
+
+{{/if--}}

--- a/templates/item/item-partials/item-details/details/item-details-talent.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-talent.hbs
@@ -1,15 +1,22 @@
-<div>
-    {{> "systems/ed4e/templates/item/item-partials/item-details/details/item-details-abilities.hbs"}}
-{{!-- class Identifier --}}
-{{formField systemFields.source.fields.class label=(localize "ED.Data.Item.Labels.Ability.Source.class") 
-hint=(localize "ED.Data.Item.Hints.Ability.Source.class") name="system.source.class" value=item.system.source.class localize=true }}
-{{!-- Added at Level --}}
-{{formField systemFields.source.fields.atLevel name="system.source.atLevel" value=item.system.source.atLevel localize=true}}
-{{! -- Magic Type -- }}
-<div>
-  <h3>{{localize "ED.Item.Header.magic"}}</h3>
-</div>
+{{> "systems/ed4e/templates/item/item-partials/item-details/details/item-details-abilities.hbs"}}
 
-{{formField systemFields.magic.fields.spellcasting name="system.magic.spellcasting" value=item.system.magic.spellcasting localize=true}}
-{{formField systemFields.magic.fields.threadWeaving name="system.magic.threadWeaving" value=item.system.magic.threadWeaving localize=true}}
-{{formField systemFields.magic.fields.magicType name="system.magic.magicType" value=item.system.magic.magicType required=false localize=true}}
+<fieldset>
+  <legend>{{localize "ED.Item.Header.talentSource"}}</legend>
+
+  {{!-- class Identifier --}}
+  {{formField systemFields.source.fields.class label=(localize "ED.Data.Item.Labels.Ability.Source.class")
+  hint=(localize "ED.Data.Item.Hints.Ability.Source.class") name="system.source.class" value=item.system.source.class localize=true }}
+
+  {{!-- Added at Level --}}
+  {{formField systemFields.source.fields.atLevel name="system.source.atLevel" value=item.system.source.atLevel localize=true}}
+</fieldset>
+
+{{! -- Magic Type -- }}
+<fieldset>
+  <legend>{{localize "ED.Item.Header.magic"}}</legend>
+
+  {{formField systemFields.magic.fields.spellcasting name="system.magic.spellcasting" value=item.system.magic.spellcasting localize=true}}
+  {{formField systemFields.magic.fields.threadWeaving name="system.magic.threadWeaving" value=item.system.magic.threadWeaving localize=true}}
+  {{formField systemFields.magic.fields.magicType name="system.magic.magicType" value=item.system.magic.magicType required=false localize=true}}
+</fieldset>
+

--- a/templates/item/item-partials/item-details/partials/targeting.hbs
+++ b/templates/item/item-partials/item-details/partials/targeting.hbs
@@ -1,7 +1,10 @@
-{{!-- Fixed Difficulty --}}
-{{formField systemFields.difficulty.fields.fixed name="system.difficulty.fixed" value=item.system.difficulty.fixed localize=true}}
-{{!-- Target Difficulty Parameter --}}
-{{formField systemFields.difficulty.fields.target name="system.difficulty.target" value=item.system.difficulty.target localize=true}}
-{{!-- Group Difficulty Parameter --}}
-{{formField systemFields.difficulty.fields.group name="system.difficulty.group" value=item.system.difficulty.group localize=true}}
-    
+<fieldset>
+  <legend>{{localize "ED.Item.Header.targetingDetails"}}</legend>
+
+  {{!-- Fixed Difficulty --}}
+  {{formField systemFields.difficulty.fields.fixed name="system.difficulty.fixed" value=item.system.difficulty.fixed localize=true}}
+  {{!-- Target Difficulty Parameter --}}
+  {{formField systemFields.difficulty.fields.target name="system.difficulty.target" value=item.system.difficulty.target localize=true}}
+  {{!-- Group Difficulty Parameter --}}
+  {{formField systemFields.difficulty.fields.group name="system.difficulty.group" value=item.system.difficulty.group localize=true}}
+</fieldset>


### PR DESCRIPTION
Make weapon attacks for happy paths (correct weapon type, equip status, etc.) from "attack" type abilities.

This covers:
- ability options:
    -Roll Type Details (Important is attack)
    -required item status (main, off, tail, unarmed)
    -required Combat type (melee, missile, thrown, unarmed)
    -reaction typ (pyhsical, mystiacl, social)
- Weapon options:
    -Combat type

clicking on an ability with the rollType "attack" set, a check will be done to see if a weapon with the same weaponType is equipped and if the required item status fits the item status of the equipment.
if this is the case, an attack roll is created. Other case are not handled here yet.