### PR TITLE
Create attack ChatMessage document and data model

### DIFF
--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -215,7 +215,7 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
    * @protected
    */
   async _preCreate( data, options, user ) {
-    const actor = this.parent.actor;
+    const actor = this.parent?.actor;
     if ( ( actor?.type !== "character" ) || !this.metadata?.singleton ) return;
     if ( actor.itemTypes[data.type]?.length ) {
       ui.notifications.error( game.i18n.format( "ED.Notifications.ActorWarningSingleton", {

--- a/module/data/chat/_module.mjs
+++ b/module/data/chat/_module.mjs
@@ -7,6 +7,6 @@ export {
 };
 
 export const config = {
-  base:   BaseMessageData,
+  common:   BaseMessageData,
   attack: AttackMessageData,
 };

--- a/module/data/chat/attack.mjs
+++ b/module/data/chat/attack.mjs
@@ -2,6 +2,13 @@ import BaseMessageData from "./base-message.mjs";
 
 export default class AttackMessageData extends BaseMessageData {
 
+
+  static DEFAULT_OPTIONS = {
+    actions: {
+      "roll-damage": this._onApplyDamage.bind( this ),
+    },
+  };
+
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
@@ -26,6 +33,11 @@ export default class AttackMessageData extends BaseMessageData {
         initial:  0,
       } ),
     } );
+  }
+
+  static async _onApplyDamage( event, button ) {
+    event.preventDefault();
+    console.log( "In _onApplyDamage ChatMessage listener" );
   }
 
 }

--- a/module/data/chat/attack.mjs
+++ b/module/data/chat/attack.mjs
@@ -5,7 +5,10 @@ export default class AttackMessageData extends BaseMessageData {
 
   static DEFAULT_OPTIONS = {
     actions: {
-      "roll-damage": this._onApplyDamage.bind( this ),
+      "apply-effect":  this._onApplyEffect,
+      "roll-damage":   this._onApplyDamage,
+      "maneuver":      this._onUseManeuver,
+      "reaction":      this._onUseReaction,
     },
   };
 
@@ -38,6 +41,27 @@ export default class AttackMessageData extends BaseMessageData {
   static async _onApplyDamage( event, button ) {
     event.preventDefault();
     console.log( "In _onApplyDamage ChatMessage listener" );
+  }
+
+  static async _onApplyEffect( event, button ) {
+    event.preventDefault();
+    console.log( "In _onApplyEffect ChatMessage listener" );
+  }
+
+  static async _onUseManeuver( event, button ) {
+    event.preventDefault();
+    ui.notifications.info( "Maneuvers are not done yet. We're working on it :)" );
+    /* console.log( "In _onUseManeuver ChatMessage listener" );
+    const ability = await fromUuid( button.dataset.abilityUuid );
+    console.log( "Ability: ", ability ); */
+  }
+
+  static async _onUseReaction( event, button ) {
+    event.preventDefault();
+    ui.notifications.info( "Reactions are not done yet. We're working on it :)" );
+    /* console.log( "In _onUseReaction ChatMessage listener" );
+    const ability = await fromUuid( button.dataset.abilityUuid );
+    console.log( "Ability: ", ability ); */
   }
 
 }

--- a/module/data/chat/attack.mjs
+++ b/module/data/chat/attack.mjs
@@ -15,32 +15,90 @@ export default class AttackMessageData extends BaseMessageData {
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
-      attacker: new fields.DocumentUUIDField( {
-        required: false,
-        nullable: true,
-      } ),
-      targets: new fields.ArrayField(
-        new fields.DocumentUUIDField( {
-          required: false,
-          nullable: true,
-        } ),
-        {
-          required: false,
-          nullable: true,
-        }
-      ),
       damageDealt: new fields.NumberField( {
         required: false,
         nullable: true,
+        step:     1,
         min:      0,
         initial:  0,
+        integer:  true,
       } ),
+      // as value/max, so it can be used as like other resources, like an HTML meter element
+      successes: new fields.SchemaField( {
+        // available successes
+        value: new fields.NumberField( {
+          step:     1,
+          initial:  0,
+          integer:  true,
+        } ),
+        // num successes on the original roll
+        max: new fields.NumberField( {
+          step:     1,
+          initial:  0,
+          integer:  true,
+        } )
+      } ),
+      successful: new fields.BooleanField( {} ),
     } );
   }
+
+  /* -------------------------------------------- */
+  /*  Properties                                  */
+  /* -------------------------------------------- */
+
+  /**
+   * The Actor that is attacking.
+   * @type {Document | object | null}
+   */
+  get attacker() {
+    return fromUuidSync( this.roll.options.rollingActorUuid );
+  }
+
+  /**
+   * The attack roll of this message.
+   * @type {EdRoll}
+   */
+  get roll() {
+    return this.parent?.rolls[0];
+  }
+
+  /**
+   * The targets of the attack.
+   * @type {Set[ActorEd]}
+   */
+  get targets() {
+    return this.roll.options.target.tokens.map( token => fromUuidSync( token ) );
+  }
+
+  /* -------------------------------------------- */
+  /*  Data Preparation                            */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  async _preCreate( data, options, user ) {
+    if ( ( await super._preCreate( data, options, user ) ) === false ) return false;
+
+    const roll = this.parent?.rolls[0];
+    const updates = {};
+
+    updates.successful = roll.isSuccess;
+    updates.successes = {
+      value: roll.numSuccesses,
+      max:   roll.numSuccesses,
+    };
+
+    this.updateSource( updates );
+  }
+
+
+  /* -------------------------------------------- */
+  /*  Listeners                                   */
+  /* -------------------------------------------- */
 
   static async _onApplyDamage( event, button ) {
     event.preventDefault();
     console.log( "In _onApplyDamage ChatMessage listener" );
+    // update the damageDealt in the DataModel
   }
 
   static async _onApplyEffect( event, button ) {
@@ -51,6 +109,7 @@ export default class AttackMessageData extends BaseMessageData {
   static async _onUseManeuver( event, button ) {
     event.preventDefault();
     ui.notifications.info( "Maneuvers are not done yet. We're working on it :)" );
+    // update the number of successes in the DataModel
     /* console.log( "In _onUseManeuver ChatMessage listener" );
     const ability = await fromUuid( button.dataset.abilityUuid );
     console.log( "Ability: ", ability ); */
@@ -59,6 +118,7 @@ export default class AttackMessageData extends BaseMessageData {
   static async _onUseReaction( event, button ) {
     event.preventDefault();
     ui.notifications.info( "Reactions are not done yet. We're working on it :)" );
+    // potentially update the success of the roll in the DataModel, e.g. with avoid blow
     /* console.log( "In _onUseReaction ChatMessage listener" );
     const ability = await fromUuid( button.dataset.abilityUuid );
     console.log( "Ability: ", ability ); */

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -103,7 +103,7 @@ export default class BaseMessageData extends SystemDataModel {
     const actionButton = target.closest( "[data-action]" );
     if ( actionButton ) {
       event.preventDefault();
-      return this.#onClickAction( event, actionButton );
+      this.#onClickAction( event, actionButton );
     }
   }
 

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -99,10 +99,12 @@ export default class BaseMessageData extends SystemDataModel {
    * @private
    */
   #onClick( event ) {
-    event.preventDefault();
     const target = event.target;
     const actionButton = target.closest( "[data-action]" );
-    if ( actionButton ) return this.#onClickAction( event, actionButton );
+    if ( actionButton ) {
+      event.preventDefault();
+      return this.#onClickAction( event, actionButton );
+    }
   }
 
   /**

--- a/module/data/item/knack-ability.mjs
+++ b/module/data/item/knack-ability.mjs
@@ -37,7 +37,7 @@ export default class KnackAbilityData extends AbilityTemplate.mixin(
 
   /** @inheritdoc */
   async _onCreate( data, options, user ) {
-    if ( !await super._preCreate( data, options, user ) ) return false;
+    if ( ( await super._preCreate( data, options, user ) ) === false ) return false;
 
     // assign the source talent
   }

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -285,7 +285,7 @@ export default class TalentData extends AbilityTemplate.mixin(
 
   /** @inheritdoc */
   async _onCreate( data, options, user ) {
-    if ( !await super._preCreate( data, options, user ) ) return false;
+    if ( ( await super._preCreate( data, options, user ) ) === false ) return false;
 
     // assign the source talent
   }

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -299,12 +299,12 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     const rollOptions = this.baseRollOptions;
     const rollOptionsUpdate = {
       ...rollOptions.toObject(),
-      rollingActor:  this.parentActor.uuid,
-      target:        { tokens: game.user.targets.map( token => token.document.uuid ) },
-      attackAbility: this.parent.uuid,
-      weapon:        weapon.uuid,
-      chatFlavor:    "AbilityTemplate: ATTACK ROLL",
-      rollType:      "attack", // for now just basic attack, later maybe `attack${ this.rollTypeDetails.attack.weaponType }`,
+      rollingActorUuid: this.parentActor.uuid,
+      target:           { tokens: game.user.targets.map( token => token.document.uuid ) },
+      abilityUuid:      this.parent.uuid,
+      weaponUuid:       weapon.uuid,
+      chatFlavor:       "AbilityTemplate: ATTACK ROLL",
+      rollType:         "attack", // for now just basic attack, later maybe `attack${ this.rollTypeDetails.attack.weaponType }`,
     };
 
     const roll = await RollPrompt.waitPrompt(

--- a/module/data/roll/attack.mjs
+++ b/module/data/roll/attack.mjs
@@ -5,7 +5,7 @@ export default class AttackRollOptions extends AbilityRollOptions {
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
-      weapon:        new fields.DocumentUUIDField( {
+      weaponUuid:        new fields.DocumentUUIDField( {
         type:     "Item",
         embedded: true,
       } ),

--- a/module/dice/ed-roll.mjs
+++ b/module/dice/ed-roll.mjs
@@ -449,7 +449,7 @@ export default class EdRoll extends Roll {
     if ( !this._evaluated ) await this.evaluate();
 
     messageData.flavor = await this.getChatFlavor();
-    if ( this.options.rollType in CONFIG.ChatMessage.typeLabels ) messageData.type = this.options.rollType;
+    messageData.type = ( this.options.rollType in CONFIG.ChatMessage.typeLabels ) ? this.options.rollType : "common";
 
     return super.toMessage( messageData, options );
   }

--- a/module/dice/ed-roll.mjs
+++ b/module/dice/ed-roll.mjs
@@ -449,6 +449,7 @@ export default class EdRoll extends Roll {
     if ( !this._evaluated ) await this.evaluate();
 
     messageData.flavor = await this.getChatFlavor();
+    if ( this.options.rollType in CONFIG.ChatMessage.typeLabels ) messageData.type = this.options.rollType;
 
     return super.toMessage( messageData, options );
   }

--- a/module/documents/chat.mjs
+++ b/module/documents/chat.mjs
@@ -3,9 +3,12 @@ export default class ChatMessageEd extends ChatMessage {
   /** @inheritdoc */
   async getHTML() {
     const baseHtml = await super.getHTML();
-    if ( typeof this.system.getHTML === "function" ) {
-      return this.system.getHTML( baseHtml );
-    }
+
+    // the return type of getHTML is jQuery, so we need to convert it to a HTMLElement
+    // this behavior is going to change to HTMLElement in the future
+    if ( baseHtml.length !== 1 ) throw new Error( "The base HTML element must be a single element" );
+    if ( typeof this.system.getHTML === "function" ) return $( await this.system.getHTML( baseHtml[0] ) );
+
     return baseHtml;
   }
 

--- a/template.json
+++ b/template.json
@@ -16,7 +16,7 @@
   "ChatMessage": {
     "types": [
       "attack",
-      "base"
+      "common"
       ]
   },
   "Item": {


### PR DESCRIPTION
- Add functionality for automatically attaching click listeners to ChatMessage HTMLs.
- Add Attack ChatMessage data model
- Add empty click handlers for attack message buttons

Functionality for chat message buttons follows in another story.