### PR TITLE
Add damage roll and options

### DIFF
--- a/module/data/chat/attack.mjs
+++ b/module/data/chat/attack.mjs
@@ -6,7 +6,7 @@ export default class AttackMessageData extends BaseMessageData {
   static DEFAULT_OPTIONS = {
     actions: {
       "apply-effect":  this._onApplyEffect,
-      "roll-damage":   this._onApplyDamage,
+      "roll-damage":   this._onRollDamage,
       "maneuver":      this._onUseManeuver,
       "reaction":      this._onUseReaction,
     },
@@ -15,14 +15,6 @@ export default class AttackMessageData extends BaseMessageData {
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
-      damageDealt: new fields.NumberField( {
-        required: false,
-        nullable: true,
-        step:     1,
-        min:      0,
-        initial:  0,
-        integer:  true,
-      } ),
       // as value/max, so it can be used as like other resources, like an HTML meter element
       successes: new fields.SchemaField( {
         // available successes
@@ -95,10 +87,12 @@ export default class AttackMessageData extends BaseMessageData {
   /*  Listeners                                   */
   /* -------------------------------------------- */
 
-  static async _onApplyDamage( event, button ) {
+  static async _onRollDamage( event, button ) {
     event.preventDefault();
     console.log( "In _onApplyDamage ChatMessage listener" );
     // update the damageDealt in the DataModel
+    const weapon = await fromUuid( this.roll.options.weaponUuid );
+    if ( weapon?.system.roll instanceof Function ) await weapon.system.rollDamage();
   }
 
   static async _onApplyEffect( event, button ) {

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -310,7 +310,7 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     const roll = await RollPrompt.waitPrompt(
       new AttackRollOptions( rollOptionsUpdate ),
       {
-        rollData: this.parentActor.system,
+        rollData: this.parentActor,
       }
     );
     return this.parentActor.processRoll( roll );

--- a/module/data/roll/ability.mjs
+++ b/module/data/roll/ability.mjs
@@ -5,11 +5,6 @@ export default class AbilityRollOptions extends EdRollOptions {
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
-      rollingActorUuid: new fields.DocumentUUIDField( {
-        required: false,
-        label:    "TODO.RollingActor",
-        hint:     "TODO.RollingActorHint",
-      } ),
       abilityUuid: new fields.DocumentUUIDField( {
         type:     "Item",
         embedded: true,

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -246,6 +246,11 @@ export default class EdRollOptions extends SparseDataModel {
         label:    "localize: roll chat flavour",
         hint:     "localize: text that is added to the chatmessage when this call is put to chat",
       } ),
+      rollingActorUuid: new fields.DocumentUUIDField( {
+        required: false,
+        label:    "TODO.RollingActor",
+        hint:     "TODO.RollingActorHint",
+      } ),
       testType: new fields.StringField( {
         required: true,
         nullable: false,
@@ -292,7 +297,7 @@ export default class EdRollOptions extends SparseDataModel {
       available:  actor.system.devotion.value,
       step:       actor.system.devotion.step,
     };
-    data.rollingActor = actor.uuid;
+    data.rollingActorUuid = actor.uuid;
 
     return new EdRollOptions( data, options );
   }

--- a/module/data/roll/damage.mjs
+++ b/module/data/roll/damage.mjs
@@ -1,0 +1,39 @@
+import EdRollOptions from "./common.mjs";
+
+export default class DamageRollOptions extends EdRollOptions {
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return this.mergeSchema( super.defineSchema(), {
+      weaponUuid:        new fields.DocumentUUIDField( {
+        type:     "Item",
+        embedded: true,
+      } ),
+      damageAbilities: new fields.SetField(
+        new fields.DocumentUUIDField( {
+          type:     "Item",
+          embedded: true,
+        } ),
+        {}
+      ),
+    } );
+  }
+
+  /** @inheritDoc */
+  async _preUpdate( changes, options, user ){
+    super._preUpdate( changes, options, user );
+    await this._addDamageAbilityModifiers( changes );
+    await this._removeDamageAbilityModifiers( changes );
+  }
+
+  async _addDamageAbilityModifiers( changes ) {
+    const addedDamageAbilities = changes.system?.damageAbilities?.difference( this.damageAbilities );
+    console.log( "Coming up: addedDamageAbilities", addedDamageAbilities );
+  }
+
+  async _removeDamageAbilityModifiers( changes ) {
+    const removedDamageAbilities = this.damageAbilities.difference( changes.system?.damageAbilities );
+    console.log( "Coming up: removedDamageAbilities", removedDamageAbilities );
+  }
+
+}

--- a/module/dice/ed-roll.mjs
+++ b/module/dice/ed-roll.mjs
@@ -326,7 +326,8 @@ export default class EdRoll extends Roll {
     let templateData = {};
 
     // Basic Data
-    templateData.roller = game.user.character?.name
+    templateData.roller = ( await fromUuid( this.options.rollingActorUuid ) )?.name
+      ?? game.user.character?.name
       ?? canvas.tokens.controlled[0]
       ?? game.user.name;
     templateData.customFlavor = this.options.chatFlavor;

--- a/templates/chat/chat-flavor/damage-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/damage-roll-flavor.hbs
@@ -7,9 +7,6 @@ Damage Flavor contains:
 - Target Modifiers 
 --}}
 <div class="custom-flavor">{{ customFlavor }}</div>
-{{#if (eq ruleOfOne true)}}
-  <div class="roll-failure">{{localize "ED.Rolls.ruleOfOne"}}</div>
-{{else}}
 <div class="flexrow message-buttons damage-roll-buttons" data-roll-total={{ result }}>
   <button type="button" class="apply-damage" title="{{ localize "ED.Chat.Button.applyDamageTitle" }}" data-action="apply-damage">
     {{ localize "ED.Chat.Button.applyDamage" }}
@@ -20,9 +17,4 @@ Damage Flavor contains:
 </div>
 <div class="modifier-lists flexrow">
   {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
-  {{#if target.public}}
-    {{> "systems/ed4e/templates/chat/dice-partials/roll-target-modifier.hbs"}}
-  {{/if}}
-  
 </div>
-{{/if}}


### PR DESCRIPTION
- add roll type "damage"
- add damage roll options
- roll damage from attack message

Currently damage rolls are only created automatically from weapon items.
Functionality for applying damage from a damage message comes in another story.