### PR TITLE
Add functionality to damage message buttons

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -240,7 +240,8 @@
         "rollEquipmentMultipleTargets": "{sourceActor} benutzt {equipment} mit Stufe {arbitraryStep} gegen mehrere Ziele",
         "rollEquipmentSingleTarget": "{sourceActor} benutzt {equipment} mit Stufe {arbitraryStep} gegen {singleTarget}",
         "rollEquipmentWithoutTarget": "{sourceActor} benutzt {equipment} mit Stufe {arbitraryStep}",
-        "rollRecovery": "{sourceActor} erholt sich mit Stufe {step}"
+        "rollRecovery": "{sourceActor} erholt sich mit Stufe {step}",
+        "actorTookDamage": "{dealtTo} hat Schaden genommen"
       },
       "Header": {
         "attackManeuvers": "Manöver",

--- a/lang/de.json
+++ b/lang/de.json
@@ -241,7 +241,8 @@
         "rollEquipmentSingleTarget": "{sourceActor} benutzt {equipment} mit Stufe {arbitraryStep} gegen {singleTarget}",
         "rollEquipmentWithoutTarget": "{sourceActor} benutzt {equipment} mit Stufe {arbitraryStep}",
         "rollRecovery": "{sourceActor} erholt sich mit Stufe {step}",
-        "actorTookDamage": "{dealtTo} hat Schaden genommen"
+        "actorTookDamage": "{dealtTo} hat Schaden genommen",
+        "undoDamage": "Schaden zurücknehmen"
       },
       "Header": {
         "attackManeuvers": "Manöver",

--- a/lang/de.json
+++ b/lang/de.json
@@ -803,7 +803,9 @@
             "rangeLongMin":                                 "Reichweite Lang Minimum",
             "rangeLongMax":                                 "Reichweite Lang Maximum",
             "ammunitionType":                               "Welcher Munitionstyp wird für diese Waffe benötigt?",
-            "forgeBonus":                                   "Schmiedebonus"
+            "forgeBonus":                                   "Schmiedebonus",
+            "armorType":                                    "Der Typ von Rüstungs den diese Waffe angreift",
+            "damageType":                                   "Die Art von Schaden die diese Waffe verursacht"
           }
         },
         "Labels": {
@@ -1027,7 +1029,9 @@
             "rangeLongMin":                                 "Reichweite Lang Minimum",
             "rangeLongMax":                                 "Reichweite Lang Maximum",
             "ammunitionType":                               "Munitionstyp",
-            "forgeBonus":                                   "Schmiedebonus"
+            "forgeBonus":                                   "Schmiedebonus",
+            "armorType":                                    "Rüstungstyp",
+            "damageType":                                   "Schadensart"
           }
         }
       },

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -298,6 +298,24 @@ ED4E.damageType = {
 preLocalize( "damageType" );
 
 /**
+ * Damage resistances
+ * @enum {string}
+ */
+ED4E.resistances = {
+  fire:       "ED.Config.Resistances.fire",
+};
+preLocalize( "resistances" );
+
+/**
+ * Damage vulnerabilities
+ * @enum {string}
+ */
+ED4E.vulnerabilities = {
+  fire:       "ED.Config.Vulnerabilities.fire",
+};
+preLocalize( "vulnerabilities" );
+
+/**
  * The possible states for a physical item that describe in which way they connect to an actor.
  * @enum {string}
  */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1089,6 +1089,7 @@ ED4E.icons = {
   previousCharGen:  "fa-thin fa-arrow-left",
   nextCharGen:      "fa-thin fa-arrow-right",
   resetPoints:      "fa-arrows-rotate",
+  undo:             "fa-arrow-rotate-left",
 };
 
 

--- a/module/data/chat/_module.mjs
+++ b/module/data/chat/_module.mjs
@@ -1,12 +1,15 @@
 import AttackMessageData from "./attack.mjs";
 import BaseMessageData from "./base-message.mjs";
+import DamageMessageData from "./damage.mjs";
 
 export {
   AttackMessageData,
   BaseMessageData,
+  DamageMessageData,
 };
 
 export const config = {
-  common:   BaseMessageData,
   attack: AttackMessageData,
+  common:   BaseMessageData,
+  damage: DamageMessageData,
 };

--- a/module/data/chat/attack.mjs
+++ b/module/data/chat/attack.mjs
@@ -47,14 +47,6 @@ export default class AttackMessageData extends BaseMessageData {
   }
 
   /**
-   * The attack roll of this message.
-   * @type {EdRoll}
-   */
-  get roll() {
-    return this.parent?.rolls[0];
-  }
-
-  /**
    * The targets of the attack.
    * @type {Set[ActorEd]}
    */

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -29,6 +29,14 @@ export default class BaseMessageData extends SystemDataModel {
   };
 
   /**
+   * The roll that generated this message. If multiple, only returns the first.
+   * @type {EdRoll|undefined}
+   */
+  get roll() {
+    return this.parent?.rolls[0];
+  }
+
+  /**
    * Render the HTML for the ChatMessage which should be added to the log. Analogous to {@link ChatMessage#getHTML}
    * @param {HTMLElement} baseHtml - The base HTML element which should be enhanced
    * @returns {Promise<HTMLElement>} A Promise which resolves to the rendered HTML

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -9,6 +9,12 @@ export default class BaseMessageData extends SystemDataModel {
     this.options = Object.freeze( this._initializeOptions( {} ) );
   }
 
+  /** @inheritDoc */
+  static labelKey = SystemDataModel.getLocalizeKey.bind( this, "Chat", false );
+
+  /** @inheritDoc */
+  static hintKey = SystemDataModel.getLocalizeKey.bind( this, "Chat", true );
+
   /**
    * Designates which upstream class in this class' inheritance chain is the base data model.
    * Any DEFAULT_OPTIONS of super-classes further upstream of the BASE_DATA_MODEL are ignored.

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -44,6 +44,43 @@ export default class DamageMessageData extends BaseMessageData {
   }
 
   /* -------------------------------------------- */
+  /*  Rendering                                  */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  async getHTML( baseHtml ) {
+    const newHTML = await super.getHTML( baseHtml );
+    const damageButtonsDiv = newHTML.querySelector( ".damage-roll-buttons" );
+    damageButtonsDiv.parentNode.insertBefore( await this.getTransactionsHTML(), damageButtonsDiv.nextSibling );
+    return newHTML;
+  }
+
+  async getTransactionsHTML() {
+    const div = document.createElement( "div" );
+    div.classList.add( "damage-transactions" );
+    for ( let transaction of this.transactions ) {
+      const dealtTo = await fromUuid( transaction.dealtTo );
+      const dealtToName = dealtTo ? dealtTo.name : game.i18n.localize( "TODO.Unknown Actor" );
+      const message = game.i18n.format( "ED.Chat.Flavor.actorTookDamage", { dealtTo: dealtToName } );
+
+      const transactionDiv = document.createElement( "div" );
+      transactionDiv.classList.add( "damage-transaction" );
+      transactionDiv.dataset.damageDealt = transaction.damage;
+      transactionDiv.textContent = message;
+
+      const undoButton = document.createElement( "i" );
+      undoButton.classList.add( "fa-light", "fa-undo" );
+      undoButton.dataset.action = "undo-damage";
+
+      transactionDiv.appendChild( undoButton );
+
+      div.appendChild( transactionDiv );
+    }
+
+    return div;
+  }
+
+  /* -------------------------------------------- */
   /*  Listeners                                   */
   /* -------------------------------------------- */
 

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -1,0 +1,53 @@
+import BaseMessageData from "./base-message.mjs";
+
+export default class DamageMessageData extends BaseMessageData {
+
+  static DEFAULT_OPTIONS = {
+    actions: {
+      "apply-damage":  this._onApplyDamage,
+      "take-damage":   this._onTakeDamage,
+    },
+  };
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return this.mergeSchema( super.defineSchema(), {
+      transactions: new fields.ArrayField(
+        new fields.SchemaField(
+          {
+            damage: new fields.NumberField( {
+              required: false,
+              nullable: true,
+              step:     1,
+              min:      0,
+              initial:  0,
+              integer:  true,
+              label:    this.labelKey( "Damage.Transactions.transaction.damage" ),
+              hint:     this.hintKey( "Damage.Transactions.transaction.damage" ),
+            } ),
+            dealtBy: new fields.DocumentUUIDField( {
+              type:  "Actor",
+              label: this.labelKey( "Damage.Transactions.transaction.dealtBy" ),
+              hint:  this.hintKey( "Damage.Transactions.transaction.dealtBy" ),
+            } ),
+          }, {
+            label: this.labelKey( "Damage.Transactions.transaction" ),
+            hint:  this.hintKey( "Damage.Transactions.transaction" ),
+          } ),
+        {
+          initial: [],
+          label:   this.labelKey( "Damage.transactions" ),
+          hint:    this.hintKey( "Damage.transactions" ),
+        }
+      ),
+    } );
+  }
+
+  /* -------------------------------------------- */
+  /*  Listeners                                   */
+  /* -------------------------------------------- */
+
+  static async _onApplyDamage( event, button ) {}
+
+  static async _onTakeDamage( event, button ) {}
+}

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -66,6 +66,7 @@ export default class DamageMessageData extends BaseMessageData {
       this.roll.options.damageType,
       this.roll.options.armorType,
       this.roll.options.ignoreArmor,
+      this.roll,
     );
 
     const transaction = {

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -91,12 +91,12 @@ export default class DamageMessageData extends BaseMessageData {
   /*  Listeners                                   */
   /* -------------------------------------------- */
 
-  static async _onApplyDamage( event, button ) {
+  static async _onApplyDamage( event, _ ) {
     event.preventDefault();
     console.log( "Coming up: Apply Damage" );
   }
 
-  static async _onTakeDamage( event, button ) {
+  static async _onTakeDamage( event, _ ) {
     event.preventDefault();
     const targetActor = game.user.character;
     if ( !targetActor ) {

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -25,10 +25,10 @@ export default class DamageMessageData extends BaseMessageData {
               label:    this.labelKey( "Damage.Transactions.transaction.damage" ),
               hint:     this.hintKey( "Damage.Transactions.transaction.damage" ),
             } ),
-            dealtBy: new fields.DocumentUUIDField( {
+            dealtTo: new fields.DocumentUUIDField( {
               type:  "Actor",
-              label: this.labelKey( "Damage.Transactions.transaction.dealtBy" ),
-              hint:  this.hintKey( "Damage.Transactions.transaction.dealtBy" ),
+              label: this.labelKey( "Damage.Transactions.transaction.dealtTo" ),
+              hint:  this.hintKey( "Damage.Transactions.transaction.dealtTo" ),
             } ),
           }, {
             label: this.labelKey( "Damage.Transactions.transaction" ),
@@ -47,7 +47,37 @@ export default class DamageMessageData extends BaseMessageData {
   /*  Listeners                                   */
   /* -------------------------------------------- */
 
-  static async _onApplyDamage( event, button ) {}
+  static async _onApplyDamage( event, button ) {
+    event.preventDefault();
+    console.log( "Coming up: Apply Damage" );
+  }
 
-  static async _onTakeDamage( event, button ) {}
+  static async _onTakeDamage( event, button ) {
+    event.preventDefault();
+    const targetActor = game.user.character;
+    if ( !targetActor ) {
+      ui.notifications.warn( "TODO: You must have an assigned character to take damage. Otherwise target tokens and use the 'applyDamage' button instead." );
+      return;
+    }
+
+    const { damageTaken } = targetActor.takeDamage(
+      this.roll.total,
+      false,
+      this.roll.options.damageType,
+      this.roll.options.armorType,
+      this.roll.options.ignoreArmor,
+    );
+
+    const transaction = {
+      damage:  damageTaken,
+      dealtTo: targetActor.uuid,
+    };
+
+    await this.parent.update( {
+      system: {
+        transactions: [ ...this.transactions, transaction ],
+      },
+    } );
+  }
+
 }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -64,6 +64,12 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
           label:    this.labelKey( "Weapons.damageBaseStep" ),
           hint:     this.hintKey( "Weapons.damageBaseStep" )
         } ),
+        type: new fields.StringField( {
+          initial:  "standard",
+          choices:  ED4E.damageType,
+          label:    this.labelKey( "Weapons.damageType" ),
+          hint:     this.hintKey( "Weapons.damageType" )
+        } ),
       } ),
       size: new fields.NumberField( {
         required: true,
@@ -152,6 +158,12 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
         label:    this.labelKey( "Weapons.forgeBonus" ),
         hint:     this.hintKey( "Weapons.forgeBonus" )
       } ),
+      armorType: new fields.StringField( {
+        initial:  "physical",
+        choices:  ED4E.armor,
+        label:    this.labelKey( "Weapons.armorType" ),
+        hint:     this.hintKey( "Weapons.armorType" )
+      } ),
     } );
   }
 
@@ -190,6 +202,8 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
       rollType:        "damage",
       weaponUuid:       this.parent?.uuid,
       damageAbilities:  new Set( [] ),
+      armorType:       this.armorType,
+      damageType:      this.damage.type,
     };
 
     return new DamageRollOptions( damageRollOptions );

--- a/module/data/roll/damage.mjs
+++ b/module/data/roll/damage.mjs
@@ -1,4 +1,5 @@
 import EdRollOptions from "./common.mjs";
+import ED4E from "../../config.mjs";
 
 export default class DamageRollOptions extends EdRollOptions {
 
@@ -15,6 +16,32 @@ export default class DamageRollOptions extends EdRollOptions {
           embedded: true,
         } ),
         {}
+      ),
+      armorType:         new fields.StringField( {
+        initial:  "physical",
+        choices:  ED4E.armor,
+      } ),
+      damageType: new fields.StringField( {
+        initial:  "standard",
+        choices:  ED4E.damageType,
+      } ),
+      ignoreArmor: new fields.BooleanField( {
+        initial:  false,
+      } ),
+      element: new fields.SchemaField(
+        {
+          type: new fields.StringField( {
+            required: false,
+            choices:  ED4E.elements,
+          } ),
+          subtype: new fields.StringField( {
+            required: false,
+            choices:  ED4E.elementSubtypes,
+          } ),
+        },
+        {
+          required: false,
+        }
       ),
     } );
   }

--- a/module/data/roll/damage.mjs
+++ b/module/data/roll/damage.mjs
@@ -53,6 +53,15 @@ export default class DamageRollOptions extends EdRollOptions {
     await this._removeDamageAbilityModifiers( changes );
   }
 
+  /** @inheritDoc */
+  async getFlavorTemplateData( context ) {
+    const newContext = await super.getFlavorTemplateData( context );
+
+    newContext.hasAssignedCharacter = !!game.user.character;
+
+    return newContext;
+  }
+
   async _addDamageAbilityModifiers( changes ) {
     const addedDamageAbilities = changes.system?.damageAbilities?.difference( this.damageAbilities );
     console.log( "Coming up: addedDamageAbilities", addedDamageAbilities );

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -489,6 +489,10 @@ export default class ActorEd extends Actor {
    * @param {("physical"|"mystical")} [armorType]               The type of armor that protects from this damage, one of either
    *                                                            'physical', 'mystical', or 'none'.
    * @param {boolean} [ignoreArmor]                             Whether armor should be ignored when applying this damage.
+   * @returns {{damageTaken: number, knockdownTest: boolean}}
+   *                                                            An object containing:
+   *                                                            - `damageTaken`: the actual amount of damage this actor has taken after armor
+   *                                                            - `knockdownTest`: whether a knockdown test should be made.
    */
   // eslint-disable-next-line max-params
   takeDamage( amount, isStrain, damageType = "standard", armorType, ignoreArmor ) {
@@ -520,9 +524,13 @@ export default class ActorEd extends Actor {
       ChatMessage.create( messageData );
     }
 
-    if ( !this.system.condition.knockedDown && finalAmount >= health.woundThreshold + 5 ) {
-      this.knockdownTest( finalAmount );
-    }
+    const knockdownTest = !this.system.condition.knockedDown && finalAmount >= health.woundThreshold + 5;
+    if ( knockdownTest ) this.knockdownTest( finalAmount );
+
+    return {
+      damageTaken:       finalAmount,
+      knockdownTest,
+    };
   }
 
   async knockdownTest( damageTaken, options = {} ) {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -489,8 +489,7 @@ export default class ActorEd extends Actor {
    * @param {("physical"|"mystical")} [armorType]               The type of armor that protects from this damage, one of either
    *                                                            'physical', 'mystical', or 'none'.
    * @param {boolean} [ignoreArmor]                             Whether armor should be ignored when applying this damage.
-   * @param {EdRoll|undefined} [damageRoll]                               The roll that caused this damage or undefined if not caused by one.
-   * @param damageRoll
+   * @param {EdRoll|undefined} [damageRoll]                     The roll that caused this damage or undefined if not caused by one.
    * @returns {{damageTaken: number, knockdownTest: boolean}}
    *                                                            An object containing:
    *                                                            - `damageTaken`: the actual amount of damage this actor has taken after armor

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -489,13 +489,15 @@ export default class ActorEd extends Actor {
    * @param {("physical"|"mystical")} [armorType]               The type of armor that protects from this damage, one of either
    *                                                            'physical', 'mystical', or 'none'.
    * @param {boolean} [ignoreArmor]                             Whether armor should be ignored when applying this damage.
+   * @param {EdRoll|undefined} [damageRoll]                               The roll that caused this damage or undefined if not caused by one.
+   * @param damageRoll
    * @returns {{damageTaken: number, knockdownTest: boolean}}
    *                                                            An object containing:
    *                                                            - `damageTaken`: the actual amount of damage this actor has taken after armor
    *                                                            - `knockdownTest`: whether a knockdown test should be made.
    */
   // eslint-disable-next-line max-params
-  takeDamage( amount, isStrain, damageType = "standard", armorType, ignoreArmor ) {
+  takeDamage( amount, isStrain, damageType = "standard", armorType, ignoreArmor, damageRoll ) {
     const { armor, health } = this.system.characteristics;
     const finalAmount = amount - ( ignoreArmor || !armorType ? 0 : armor[armorType].value );
     const newDamage = health.damage[damageType] + finalAmount;
@@ -520,7 +522,7 @@ export default class ActorEd extends Actor {
       speaker: ChatMessage.getSpeaker( { actor: this.actor } ),
       content: "THIS WILL BE FIXED LATER see #756"
     };
-    if ( isStrain === false ) {
+    if ( !damageRoll && isStrain === false ) {
       ChatMessage.create( messageData );
     }
 

--- a/template.json
+++ b/template.json
@@ -16,7 +16,8 @@
   "ChatMessage": {
     "types": [
       "attack",
-      "common"
+      "common",
+      "damage"
       ]
   },
   "Item": {

--- a/templates/chat/chat-flavor/damage-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/damage-roll-flavor.hbs
@@ -11,9 +11,11 @@ Damage Flavor contains:
   <button type="button" class="apply-damage" title="{{ localize "ED.Chat.Button.applyDamageTitle" }}" data-action="apply-damage">
     {{ localize "ED.Chat.Button.applyDamage" }}
   </button>
-  <button type="button" class="take-damage" title="{{ localize "ED.Chat.Button.takeDamageTitle" }}" data-action="take-damage">
-    {{ localize "ED.Chat.Button.takeDamage" }}
-  </button>
+  {{#if hasAssignedCharacter}}
+    <button type="button" class="take-damage" title="{{ localize "ED.Chat.Button.takeDamageTitle" }}" data-action="take-damage">
+      {{ localize "ED.Chat.Button.takeDamage" }}
+    </button>
+  {{/if}}
 </div>
 <div class="modifier-lists flexrow">
   {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}

--- a/templates/item/item-partials/item-details/details/item-details-weapon.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-weapon.hbs
@@ -1,6 +1,11 @@
 <div>
-    {{!-- usable Item ?--}}
-    {{> "systems/ed4e/templates/item/item-partials/item-details/partials/usable-items.hbs"}}
-    {{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}
-    {{> "systems/ed4e/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs"}}
+  {{!-- usable Item ?--}}
+  <fieldset>
+    <legend>{{localize "TODO.Weapon Specific Details"}}</legend>
+    {{formField systemFields.armorType name="system.armorType" value=item.system.armorType localize=true}}
+    {{formField systemFields.damage.fields.type name="system.damage.type" value=item.system.damage.type localize=true}}
+  </fieldset>
+  {{> "systems/ed4e/templates/item/item-partials/item-details/partials/usable-items.hbs"}}
+  {{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}
+  {{> "systems/ed4e/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs"}}
 </div>


### PR DESCRIPTION
- "apply damage" applies damage to all currently targeted tokens' actors
- "take damage" is only visible if the user has an assigned character, to which the damage will be applied
- each application of damage creates a transaction of the damage in the message itself
- each transaction can be undone, this deductes the damage dealt from the recorded actors current damage