### PR TITLE
Add buttons to attack without an ability

### DIFF
--- a/module/applications/actor/base-sheet.mjs
+++ b/module/applications/actor/base-sheet.mjs
@@ -28,6 +28,7 @@ export default class ActorSheetEd extends HandlebarsApplicationMixin( DocumentSh
       submitOnChange: true,
     },
     actions:  {
+      attack:           ActorSheetEd._onAttack,
       editImage:        ActorSheetEd._onEditImage,
       editItem:         ActorSheetEd._onItemEdit,
       deleteItem:       ActorSheetEd._onItemDelete,
@@ -71,6 +72,12 @@ export default class ActorSheetEd extends HandlebarsApplicationMixin( DocumentSh
     );
 
     return context;
+  }
+
+  static async _onAttack( event, target ) {
+    event.preventDefault();
+    const attackType = target.dataset.attackType;
+    return this.document.attack( attackType );
   }
 
   static async _onEditImage( event, target ) {

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -325,11 +325,13 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
 
   _drawWeapon() {
     ui.notifications.info( "It's coming. Patience please!" );
+    this.parentActor.drawWeapon();
     return false;
   }
 
   _switchWeapon() {
     ui.notifications.info( "It's coming. Patience please!" );
+    this.parentActor.switchWeapon();
     return false;
   }
 

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -304,7 +304,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
       ...rollOptions.toObject(),
       rollingActorUuid: this.parentActor.uuid,
       target:           { tokens: game.user.targets.map( token => token.document.uuid ) },
-      abilityUuid:      this.parent.uuid,
       weaponType:       this.rollTypeDetails.attack.weaponType,
       weaponUuid:       weapon?.uuid ?? null,
       chatFlavor:       "AbilityTemplate: ATTACK ROLL",

--- a/module/data/roll/attack.mjs
+++ b/module/data/roll/attack.mjs
@@ -1,7 +1,7 @@
-import AbilityRollOptions from "./ability.mjs";
 import ED4E from "../../config.mjs";
+import EdRollOptions from "./common.mjs";
 
-export default class AttackRollOptions extends AbilityRollOptions {
+export default class AttackRollOptions extends EdRollOptions {
 
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -12,6 +12,7 @@ import { sum } from "../utils.mjs";
 import PromptFactory from "../applications/global/prompt-factory.mjs";
 import ClassTemplate from "../data/item/templates/class.mjs";
 import DamageRollOptions from "../data/roll/damage.mjs";
+import AttackRollOptions from "../data/roll/attack.mjs";
 
 const futils = foundry.utils;
 
@@ -572,6 +573,63 @@ export default class ActorEd extends Actor {
     return {
       damageTaken:       finalAmount,
       knockdownTest,
+    };
+  }
+
+  async attack( attackType ) {
+    return this[`${attackType}Attack`]();
+  }
+
+  async weaponAttack() {
+    // TODO: Implement
+  }
+
+  async unarmedAttack() {
+    const rollOptions = AttackRollOptions.fromActor(
+      {
+        ...( await this._getCommonAttackRollData() ),
+        weaponType: "unarmed",
+        weaponUuid: null,
+        chatFlavor: game.i18n.format( "TODO.ED.Chat.Flavor.unarmedAttack", {} ),
+      },
+      this,
+    );
+
+    const roll = await RollPrompt.waitPrompt(
+      rollOptions,
+      { rollData: this },
+    );
+    return this.processRoll( roll );
+  }
+
+  async tailAttack() {
+    // TODO: Implement
+  }
+
+  async _getCommonAttackRollData() {
+    const targetTokens = game.user.targets;
+    const maxDifficulty = Math.max( ...[ ...targetTokens ].map(
+      token => token.actor.system.characteristics.defenses.physical.value )
+    );
+
+    return {
+      step:       {
+        base:      this.system.attributes.dex.step,
+        modifiers: {},
+      },
+      extraDice:  {},
+      target:     {
+        base:      maxDifficulty,
+        modifiers: {},
+        public:    false,
+        tokens:    targetTokens.map( token => token.document.uuid ),
+      },
+      strain:     {
+        base:      0,
+        modifiers: {},
+      },
+      testType:   "action",
+      rollType:   "attack",
     };
   }
 

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -581,7 +581,28 @@ export default class ActorEd extends Actor {
   }
 
   async weaponAttack() {
-    // TODO: Implement
+    let weapon = this.itemTypes.weapon.find( item => [ "mainHand", "offHand", "twoHands" ].includes( item.system.itemStatus ) );
+    if ( !weapon ) weapon = this.drawWeapon();
+    if ( !weapon ) {
+      ui.notifications.warn( "TODO.ED.Localize: No weapon available." );
+      return;
+    }
+
+    const rollOptions = AttackRollOptions.fromActor(
+      {
+        ...( await this._getCommonAttackRollData() ),
+        weaponType: weapon.system.weaponType,
+        weaponUuid: weapon.uuid,
+        chatFlavor: game.i18n.format( "TODO.ED.Chat.Flavor.weaponAttack", {} ),
+      },
+      this,
+    );
+
+    const roll = await RollPrompt.waitPrompt(
+      rollOptions,
+      { rollData: this },
+    );
+    return this.processRoll( roll );
   }
 
   async unarmedAttack() {
@@ -624,6 +645,16 @@ export default class ActorEd extends Actor {
     // TODO: apply the "-2 to all action tests this round" active effect
 
     return processedRoll;
+  }
+
+  drawWeapon() {
+    ui.notifications.info( "Function 'drawWeapon': it's coming. Bear with us please!" );
+    return undefined;
+  }
+
+  switchWeapon() {
+    ui.notifications.info( "Function 'switchWeapon': it's coming. Bear with us please!" );
+    return undefined;
   }
 
   async _getCommonAttackRollData() {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -603,7 +603,27 @@ export default class ActorEd extends Actor {
   }
 
   async tailAttack() {
-    // TODO: Implement
+    const weapon = this.itemTypes.weapon.find( item => item.system.itemStatus === "tail" );
+
+    const rollOptions = AttackRollOptions.fromActor(
+      {
+        ...( await this._getCommonAttackRollData() ),
+        weaponType: weapon ? "melee" : "unarmed",
+        weaponUuid: weapon?.uuid ?? null,
+        chatFlavor: game.i18n.format( "TODO.ED.Chat.Flavor.tailAttack", {} ),
+      },
+      this,
+    );
+
+    const roll = await RollPrompt.waitPrompt(
+      rollOptions,
+      { rollData: this },
+    );
+    const processedRoll = this.processRoll( roll );
+
+    // TODO: apply the "-2 to all action tests this round" active effect
+
+    return processedRoll;
   }
 
   async _getCommonAttackRollData() {

--- a/templates/actor/actor-tabs/general.hbs
+++ b/templates/actor/actor-tabs/general.hbs
@@ -213,20 +213,20 @@
 
         {{#if this.actor.namegiver.system.tailAttack}}
           <div class="partial__three">
-            <button class="attack-substitude__weapon-attack" data-item-id="weapon-attack">Weapon Attack</button>
+            <button class="attack-substitute__weapon-attack" data-action="attack" data-attack-type="weapon">{{localize "TODO.Weapon Attack"}}</button>
           </div>
           <div class="partial__three">
-            <button class="attack-substitude__unarmed-attack" data-item-id="unarmed-attack">Unarmed Attack</button>
+            <button class="attack-substitute__unarmed-attack" data-action="attack" data-attack-type="unarmed">{{localize "TODO.Unarmed Attack"}}</button>
           </div>
           <div class="partial__three">
-            <button class="attack-substitude__tail-attack" data-item-id="tail-attack">Tail Attack</button>
+            <button class="attack-substitute__tail-attack" data-action="attack" data-attack-type="tail">{{localize "TODO.Tail Attack"}}</button>
           </div>
         {{else}}
           <div class="partial__two">
-            <button class="attack-substitude__weapon-attack" data-item-id="weapon-attack">Weapon Attack</button>
+            <button class="attack-substitute__weapon-attack" data-action="attack" data-attack-type="weapon">{{localize "TODO.Weapon Attack"}}</button>
           </div>
           <div class="partial__two">
-            <button class="attack-substitude__unarmed-attack" data-item-id="unarmed-attack">Unarmed Attack</button>
+            <button class="attack-substitute__unarmed-attack" data-action="attack" data-attack-type="unarmed">{{localize "TODO.Unarmed Attack"}}</button>
           </div>
         {{/if}}
       </div>

--- a/templates/actor/actor-tabs/general.hbs
+++ b/templates/actor/actor-tabs/general.hbs
@@ -203,22 +203,58 @@
             <div class="conditions__grid--item">{{localize "ED.Actor.Conditions.overwhelmed"}}</div>
         </div>
     </div>
-    <div class="partial__two undefined">
-        <h3>{{localize "ED.Actor.Header.specialAbility"}}</h3>
-        <div>
-            wie soll diese ansicht aussehen, wie Rollable items oder nicht?
-            {{#each this.actor.itemTypes.specialAbility}}
-            <div class="item-id one-line__vertical-align" data-item-id="{{_id}}">
-                <div class="partial__two one-line__vertical-align">
-                    <img src="{{img}}" data-edit="img" title="{{name}}" height="25" width="25" />
-                    {{name}}
-                </div>
-                <div class="partial__two one-line__vertical-align">
-                    {{> "systems/ed4e/templates/global/card-options-chat.hbs"}}
-                </div>
-            </div>
-            {{/each}}
-        </div>
+
+  <!-- Attacks -->
+  <div class="partial__two">
+    <div>
+      <h3>{{localize "ED.Actor.Header.defaultAttacks"}}</h3>
+      <div>
+
+
+        {{#if this.actor.namegiver.system.tailAttack}}
+          <div class="partial__three">
+            <button class="attack-substitude__weapon-attack" data-item-id="weapon-attack">Weapon Attack</button>
+          </div>
+          <div class="partial__three">
+            <button class="attack-substitude__unarmed-attack" data-item-id="unarmed-attack">Unarmed Attack</button>
+          </div>
+          <div class="partial__three">
+            <button class="attack-substitude__tail-attack" data-item-id="tail-attack">Tail Attack</button>
+          </div>
+        {{else}}
+          <div class="partial__two">
+            <button class="attack-substitude__weapon-attack" data-item-id="weapon-attack">Weapon Attack</button>
+          </div>
+          <div class="partial__two">
+            <button class="attack-substitude__unarmed-attack" data-item-id="unarmed-attack">Unarmed Attack</button>
+          </div>
+        {{/if}}
+      </div>
     </div>
+    {{!-- tobe removed --}}
+    <br>
+    <br>
+
+
+
+    <div>
+      <h3 class="undefined">{{localize "ED.Actor.Header.specialAbility"}}</h3>
+      <div class="undefined">
+        wie soll diese ansicht aussehen, wie Rollable items oder nicht?
+        {{#each actor.itemTypes.specialAbility}}
+          <div class="item-id one-line__vertical-align" data-item-id="{{_id}}">
+            <div class="partial__two one-line__vertical-align">
+              <img src="{{img}}" data-edit="img" title="{{name}}" height="25" width="25" />
+              {{name}}
+            </div>
+            <div class="partial__two one-line__vertical-align">
+              {{> "systems/ed4e/templates/global/card-options-chat.hbs"}}
+            </div>
+          </div>
+        {{/each}}
+      </div>
+    </div>
+  </div>
+
 </div>
 </section>

--- a/templates/chat/chat-flavor/attack-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/attack-roll-flavor.hbs
@@ -31,7 +31,7 @@
                 <ul class="unlist">
                   {{#each maneuvers as |maneuver|}}
                     <li>
-                      <button class="reaction-button" data-action="maneuver" data-ability-uuid="{{maneuver.uuid}}">
+                      <button class="maneuver-button" data-action="maneuver" data-ability-uuid="{{maneuver.uuid}}">
                         {{maneuver.name}}
                       </button>
                     </li>


### PR DESCRIPTION
MVP approach for attacking without an ability:

- add 3 buttons to attack from the general tab in the character sheet: weapon, unarmed, tail
- all attack types use DEX attribute as base roll step
- for now: difficulty is always the max physical defense of all selected targets
- add functions in the actor document
- "weapon attack": take the first currently equipped weapon or draw one if none equipped and attack with it, damage as usual
- "unarmed attack": make unarmed attack, damage as usual
- "tail attack": if no weapon attached (`itemStatus === "tail"`) make an unarmed attack, otherwise an attack of type "melee". even though the attack test is unarmed, it still uses a weapon and must be handled accordingly,
- -2 penalty of tail attack follows when active effects are available

