### PR TITLE
Draw and switch weapon on attack

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -795,6 +795,7 @@
           "Weapons": {
             "weaponType":                                   "Der Kampftyp der Waffe",
             "weaponSubType":                                "Die Art der Waffe",
+            "wieldingType":                                 "Die Art wie die Waffe gehalten werden muss um sie zu benutzen",
             "damageAttribute":                              "Schaden Attribut",
             "damageBaseStep":                               "Grundschaden Stufe",
             "size":                                         "Größe",
@@ -1021,6 +1022,7 @@
           "Weapons": {
             "weaponType":                                   "Kampftyp",
             "weaponSubType":                                "Waffensubtyp",
+            "wieldingType":                                 "Waffenführung",
             "damageAttribute":                              "Schaden Attribut",
             "damageBaseStep":                               "Grundschaden Stufe",
             "size":                                         "Größe",
@@ -1293,6 +1295,7 @@
       "Title": {
         "classAdvancement":                                   "Rang- und Kreisaufstieg",
         "characterGeneration":                                "Charaktererschaffung",
+        "drawWeapon":                                         "Waffe ziehen",
         "learnAbility":                                       "Erlernen von {abilityName}",
         "learnSpell":                                         "Zauber lernen",
         "recovery":                                           "Erholungsprobe",

--- a/lang/de.json
+++ b/lang/de.json
@@ -1459,7 +1459,8 @@
       "Error": {},
       "Info": {
         "noMoreItemsOfThisType": "Diese Item kann kein weiteres Mal hinzugefügt werden.",
-        "notAddedforTheActor": "Diese Item ist nicht für diesen Actortyp gedacht."
+        "notAddedforTheActor": "Diese Item ist nicht für diesen Actortyp gedacht.",
+        "switchWeapon": "Waffe wird gewechselt. Andere Waffe(n) abgelegt."
       },
       "Warn": {
         "Legend": {

--- a/module/applications/global/prompt-factory.mjs
+++ b/module/applications/global/prompt-factory.mjs
@@ -146,11 +146,12 @@ export default class PromptFactory {
 class ActorPromptFactory extends PromptFactory {
 
   _promptTypeMapping = {
-    recovery:         this._recoveryPrompt.bind( this ),
-    takeDamage:       this._takeDamagePrompt.bind( this ),
+    chooseDiscipline: this._chooseDisciplinePrompt.bind( this ),
+    drawWeapon:       this._drawWeaponPrompt.bind( this ),
     jumpUp:           this._jumpUpPrompt.bind( this ),
     knockDown:        this._knockDownPrompt.bind( this ),
-    chooseDiscipline: this._chooseDisciplinePrompt.bind( this ),
+    recovery:         this._recoveryPrompt.bind( this ),
+    takeDamage:       this._takeDamagePrompt.bind( this ),
   };
 
   async _recoveryPrompt() {
@@ -327,6 +328,23 @@ class ActorPromptFactory extends PromptFactory {
       classes:     [ "earthdawn4e", "choose-discipline-prompt", "choose-discipline", "flexcol" ],
       window:      {
         title:       "ED.Dialogs.Title.chooseDiscipline",
+        minimizable: false
+      },
+      modal:   false,
+      buttons: buttons
+    } );
+  }
+
+  async _drawWeaponPrompt() {
+    const buttons = await this._getItemButtons( this.document.itemTypes.weapon, "weapon" );
+
+    return DialogClass.wait( {
+      rejectClose: false,
+      id:          "draw-weapon-prompt",
+      uniqueId:    String( ++globalThis._appId ),
+      classes:     [ "earthdawn4e", "draw-weapon-prompt", "draw-weapon", "flexcol" ],
+      window:      {
+        title:       "ED.Dialogs.Title.drawWeapon",
         minimizable: false
       },
       modal:   false,

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -288,6 +288,18 @@ ED4E.weaponSubType = {
 };
 
 /**
+ * The way a weapon has to be equipped to wield it.
+ * @enum {string}
+ */
+ED4E.weaponWieldingType = {
+  mainHand:   "ED.Config.ItemStatus.mainHand",
+  offHand:    "ED.Config.ItemStatus.offHand",
+  twoHands:   "ED.Config.ItemStatus.twoHands",
+  tail:       "ED.Config.ItemStatus.tail",
+};
+preLocalize( "weaponWieldingType" );
+
+/**
  * Damage type
  * @enum {string}
  */

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -292,9 +292,9 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     let weapon = null;
     if ( whatToDo !== "_unarmed" ) {
       weapon = whatToDo.uuid ? whatToDo : null;
-      weapon ??= this[whatToDo]();
+      weapon ??= await this[whatToDo]();
       if ( !weapon ) {
-        ui.notifications.warn( "ED.Notifications.Warn.noWeaponToAttackWith" );
+        ui.notifications.warn( game.i18n.localize( "ED.Notifications.Warn.noWeaponToAttackWith" ) );
         return;
       }
     }
@@ -319,20 +319,17 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     return this.parentActor.processRoll( roll );
   }
 
-  _attack() {
+  async _attack() {
     return true;
   }
 
-  _drawWeapon() {
-    ui.notifications.info( "It's coming. Patience please!" );
-    this.parentActor.drawWeapon();
-    return false;
+  async _drawWeapon() {
+    return this.parentActor.drawWeapon();
   }
 
-  _switchWeapon() {
+  async _switchWeapon() {
     ui.notifications.info( "It's coming. Patience please!" );
-    this.parentActor.switchWeapon();
-    return false;
+    return this.parentActor.switchWeapon();
   }
 
   /**
@@ -351,10 +348,14 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     const weaponByStatus = equippedWeapons.find( weapon => requiredWeaponStatus.has( weapon.system.itemStatus ) );
     const weaponByType = equippedWeapons.find( weapon => weapon.system.weaponType === requiredWeaponType );
 
-    if ( weaponByStatus?.uuid === weaponByType?.uuid ) return weaponByStatus;
-    if ( !weaponByType ) return "_switchWeapon";
-    if ( !weaponByStatus ) return "_drawWeapon";
-    return "";
+    if (
+      // we need to check for the weapon  itself before comparing the uuids
+      // otherwise if both are null, the comparison will return true
+      weaponByStatus && weaponByType
+      && ( weaponByStatus.uuid === weaponByType.uuid )
+    ) return weaponByStatus;
+    if ( weaponByStatus && !weaponByType ) return "_switchWeapon";
+    return "_drawWeapon";
   }
 
 

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -328,7 +328,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
   }
 
   async _switchWeapon() {
-    ui.notifications.info( "It's coming. Patience please!" );
     return this.parentActor.switchWeapon();
   }
 
@@ -354,7 +353,7 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
       weaponByStatus && weaponByType
       && ( weaponByStatus.uuid === weaponByType.uuid )
     ) return weaponByStatus;
-    if ( weaponByStatus && !weaponByType ) return "_switchWeapon";
+    if ( !weaponByStatus && weaponByType ) return "_switchWeapon";
     return "_drawWeapon";
   }
 

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -46,6 +46,13 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
         label:    this.labelKey( "Weapons.weaponSubType" ),
         hint:     this.hintKey( "Weapons.weaponSubType" ),
       } ),
+      wieldingType: new fields.StringField( {
+        required: true,
+        initial:  "mainHand",
+        choices:  ED4E.weaponWieldingType,
+        label:    this.labelKey( "Weapons.wieldingType" ),
+        hint:     this.hintKey( "Weapons.wieldingType" ),
+      } ),
       damage:        new fields.SchemaField( {
         attribute: new fields.StringField( {
           required: true,

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -497,6 +497,7 @@ export default class ActorEd extends Actor {
           damageAbilities:  new Set( [] ),
           armorType:        "physical",
           damageType:       "standard",
+          ...rollOptionsData,
         },
         this,
       ),

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -658,9 +658,11 @@ export default class ActorEd extends Actor {
     return weapon;
   }
 
-  async switchWeapon() {
-    ui.notifications.info( "Function 'switchWeapon': it's coming. Bear with us please!" );
-    return undefined;
+  async switchWeapon( equippedWeapon ) {
+    ui.notifications.info( game.i18n.localize( "ED.Notifications.Info.switchWeapon" ) );
+    if ( equippedWeapon ) await this._updateItemStates( equippedWeapon, "carried" );
+    else this.itemTypes.weapon.forEach( weapon => this._updateItemStates( weapon, "carried" ) );
+    return this.drawWeapon();
   }
 
   async _getCommonAttackRollData() {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -647,12 +647,17 @@ export default class ActorEd extends Actor {
     return processedRoll;
   }
 
-  drawWeapon() {
-    ui.notifications.info( "Function 'drawWeapon': it's coming. Bear with us please!" );
-    return undefined;
+  /**
+   *
+   * @returns {ItemEd|undefined} The weapon that was drawn or undefined if no weapon was drawn.
+   */
+  async drawWeapon() {
+    const weapon = await fromUuid( await this._promptFactory.getPrompt( "drawWeapon" ) );
+    if ( weapon ) await weapon.update( { "system.itemStatus": weapon.system.wieldingType } );
+    return weapon;
   }
 
-  switchWeapon() {
+  async switchWeapon() {
     ui.notifications.info( "Function 'switchWeapon': it's coming. Bear with us please!" );
     return undefined;
   }

--- a/templates/item/item-partials/item-details/details/item-details-weapon.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-weapon.hbs
@@ -4,6 +4,7 @@
     <legend>{{localize "TODO.Weapon Specific Details"}}</legend>
     {{formField systemFields.armorType name="system.armorType" value=item.system.armorType localize=true}}
     {{formField systemFields.damage.fields.type name="system.damage.type" value=item.system.damage.type localize=true}}
+    {{formField systemFields.wieldingType name="system.wieldingType" value=item.system.wieldingType localize=true}}
   </fieldset>
   {{> "systems/ed4e/templates/item/item-partials/item-details/partials/usable-items.hbs"}}
   {{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}


### PR DESCRIPTION
- add new data field for weapons indicating the type of item status that's the default for wielding it

 _add function for drawing a weapon_
- list all weapons available
- select by click
- set itemstatus to wieldingtype of weapon

_add function for switching a weapon_
- if equipped weapon provided: set itemStatus to "carried"
- if not provided: set all weapons' itemStatus to "carried"
- then draw weapon as above

_attacking checks for correct weapon_
- if correct weapon type but wrong status -> switch weapon
- if no weapon equipped at all -> draw weapon