### PR TITLE
ed-roll-fix-v13-changes

### DIFF
--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -20,7 +20,7 @@ export default class BaseMessageData extends SystemDataModel {
    * Any DEFAULT_OPTIONS of super-classes further upstream of the BASE_DATA_MODEL are ignored.
    * Hook events for super-classes further upstream of the BASE_DATA_MODEL are not dispatched.
    * @type {typeof BaseMessageData}
-   * @see {foundry.applications.types.ApplicationV2#BASE_APPLICATION}
+   * @see {ApplicationV2#BASE_APPLICATION}
    */
   static BASE_DATA_MODEL = BaseMessageData;
 
@@ -46,7 +46,7 @@ export default class BaseMessageData extends SystemDataModel {
   }
 
   /**
-   * Iterate over the inheritance chain of this Application. Analogous to {@link foundry.applications.ApplicationV2#inheritanceChain}
+   * Iterate over the inheritance chain of this Application. Analogous to {@link ApplicationV2#inheritanceChain}
    * @see BaseMessageData.BASE_DATA_MODEL
    * @generator
    * @yields {typeof ApplicationV2}
@@ -61,7 +61,7 @@ export default class BaseMessageData extends SystemDataModel {
   }
 
   /**
-   * Initialize the default options for this. Analogous to {@link foundry.applications.ApplicationV2#_initializeApplicationOptions}
+   * Initialize the default options for this. Analogous to {@link ApplicationV2#_initializeApplicationOptions}
    * @param {object} options Options provided directly to the constructor
    * @param {object} [options.actions] - Action handlers defined for this Application.
    * @returns {object} Configured options for the application instance
@@ -108,7 +108,7 @@ export default class BaseMessageData extends SystemDataModel {
   }
 
   /**
-   * Centralized handling of click events which occur on or within the Application frame. Taken from {@link foundry.applications.ApplicationV2}
+   * Centralized handling of click events which occur on or within the Application frame. Taken from {@link ApplicationV2}
    * @param { PointerEvent } event - The originating click event
    * @private
    */
@@ -122,7 +122,7 @@ export default class BaseMessageData extends SystemDataModel {
   }
 
   /**
-   * Handle a click event on an element which defines a [data-action] handler. Taken from {@link foundry.applications.ApplicationV2}.
+   * Handle a click event on an element which defines a [data-action] handler. Taken from {@link ApplicationV2}.
    * @param {PointerEvent} event      The originating click event
    * @param {HTMLElement} target      The capturing HTML element which defined a [data-action]
    */

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -41,7 +41,7 @@ export default class BaseMessageData extends SystemDataModel {
    * @param {HTMLElement} baseHtml - The base HTML element which should be enhanced
    * @returns {Promise<HTMLElement>} A Promise which resolves to the rendered HTML
    */
-  async getHTML( baseHtml ) {
+  async renderHTML( baseHtml ) {
     return this._attachListeners( baseHtml );
   }
 

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -102,7 +102,7 @@ export default class BaseMessageData extends SystemDataModel {
   _attachListeners( element ) {
 
     const click = this.#onClick.bind( this );
-    element.addEventListener( "click", click );
+    element.addEventListener( "click", click, { passive: false } );
 
     return element;
   }
@@ -116,7 +116,6 @@ export default class BaseMessageData extends SystemDataModel {
     const target = event.target;
     const actionButton = target.closest( "[data-action]" );
     if ( actionButton ) {
-      event.preventDefault();
       this.#onClickAction( event, actionButton );
     }
   }
@@ -128,6 +127,10 @@ export default class BaseMessageData extends SystemDataModel {
    */
   #onClickAction ( event, target ) {
     const action = target.dataset.action;
+
+    if ( action in ui.chat.options.actions ) return;
+    event.preventDefault();
+
     let handler = this.options.actions[ action ];
 
     // No defined handler

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -52,8 +52,8 @@ export default class DamageMessageData extends BaseMessageData {
   /* -------------------------------------------- */
 
   /** @inheritdoc */
-  async getHTML( baseHtml ) {
-    const newHTML = await super.getHTML( baseHtml );
+  async renderHTML( baseHtml ) {
+    const newHTML = await super.renderHTML( baseHtml );
     const damageButtonsDiv = newHTML.querySelector( ".damage-roll-buttons" );
     damageButtonsDiv.parentNode.insertBefore( await this.getTransactionsHTML(), damageButtonsDiv.nextSibling );
     return newHTML;

--- a/module/dice/ed-roll.mjs
+++ b/module/dice/ed-roll.mjs
@@ -351,12 +351,12 @@ export default class EdRoll extends Roll {
 
   /**
    * @description                       Add a success or failure class to the dice total.
-   * @param {jQuery} jquery             The HTML element to which the class should be added.
+   * @param {HTMLElement} element       The HTML element to which the class should be added.
    * @userFunction                      UF_Rolls-addSuccessClass
    */
-  addSuccessClass( jquery ) {
+  addSuccessClass( element ) {
     if ( this.isSuccess || this.isFailure ) {
-      jquery.find( ".dice-total" ).addClass(
+      element.querySelector( ".dice-total" ).classList.add(
         this.isSuccess ? "roll-success" : "roll-failure"
       );
     }

--- a/module/documents/chat.mjs
+++ b/module/documents/chat.mjs
@@ -1,15 +1,11 @@
 export default class ChatMessageEd extends ChatMessage {
 
-  /** @inheritdoc */
-  async getHTML() {
-    const baseHtml = await super.getHTML();
+  /** @inheritDoc */
+  async renderHTML( { canDelete, canClose = false } = {} ) {
+    const baseHtml = await super.renderHTML( { canDelete, canClose } );
 
-    // the return type of getHTML is jQuery, so we need to convert it to a HTMLElement
-    // this behavior is going to change to HTMLElement in the future
-    if ( baseHtml.length !== 1 ) throw new Error( "The base HTML element must be a single element" );
-    if ( typeof this.system.getHTML === "function" ) return $( await this.system.getHTML( baseHtml[0] ) );
+    if ( typeof this.system.renderHTML === "function" ) return this.system.renderHTML( baseHtml );
 
     return baseHtml;
   }
-
 }

--- a/module/hooks/chat.mjs
+++ b/module/hooks/chat.mjs
@@ -44,7 +44,7 @@ export default function () {
     return cmdMapping[commandMatches.groups.command.substring( 1 )]( commandMatches.groups.arguments.trim() );
   } );
 
-  Hooks.on( "renderChatMessage", ( msg, html, msgData ) => {
+  Hooks.on( "renderChatMessageHTML", ( msg, html, _ ) => {
     // Add character portrait to message
     addUserPortrait( msg, html );
 
@@ -164,9 +164,9 @@ function triggerRollStep( argString ) {
 /**
  * Add the user's avatar to the chat message.
  * @param {ChatMessage} msg - The chat message object.
- * @param {jQuery} jquery - The jQuery object for the chat message.
+ * @param {HTMLElement} element - The jQuery object for the chat message.
  */
-function addUserPortrait( msg, jquery ) {
+function addUserPortrait( msg, element ) {
 
   const chatAvatarSetting = game.settings.get( "ed4e", "chatAvatar" );
   const isGM = msg.author.isGM;
@@ -180,9 +180,10 @@ function addUserPortrait( msg, jquery ) {
   avatar ??= isGM ? avatar_img : msg.author.character?.img;
 
   if ( avatar ) {
-    jquery.find( ".message-header" ).prepend(
-      `<img src="${avatar}" class="avatar">`
-    );
+    const img = document.createElement( "img" );
+    img.src = avatar;
+    img.classList.add( "avatar" );
+    element.querySelector( ".message-header" ).prepend( img );
   }
 }
 

--- a/templates/chat/tooltip.hbs
+++ b/templates/chat/tooltip.hbs
@@ -1,20 +1,22 @@
 {{#if parts.length}}
   <div class="dice-tooltip">
-    {{#each parts}}
-      <section class="tooltip-part">
-        <div class="dice">
-          <header class="part-header flexrow">
-            <span class="part-formula">{{this.formula}}</span>
-            {{#if this.flavor}}<span class="part-flavor">{{this.flavor}}</span>{{/if}}
-            <span class="part-total">{{this.total}}</span>
-          </header>
-          <ol class="dice-rolls">
-            {{#each this.rolls}}
-              <li class="roll {{this.classes}}">{{{this.result}}}</li>
-            {{/each}}
-          </ol>
-        </div>
-      </section>
-    {{/each}}
+    <div class="wrapper">
+      {{#each parts}}
+        <section class="tooltip-part">
+          <div class="dice">
+            <header class="part-header flexrow">
+              <span class="part-formula">{{this.formula}}</span>
+              {{#if this.flavor}}<span class="part-flavor">{{this.flavor}}</span>{{/if}}
+              <span class="part-total">{{this.total}}</span>
+            </header>
+            <ol class="dice-rolls">
+              {{#each this.rolls}}
+                <li class="roll {{this.classes}}">{{{this.result}}}</li>
+              {{/each}}
+            </ol>
+          </div>
+        </section>
+      {{/each}}
+    </div>
   </div>
 {{/if}}


### PR DESCRIPTION
Fix some V13 related bugs:
- hook "renderChatMessage" is renamed and uses HTMLElement instead of query
- Chat's `getHTML` is now `renderHTML` and uses HTMLElement instead of jQuery
- fix dice tooltip template to make it expandable again