### PR TITLE
tab-handling-app-v2

### DIFF
--- a/earthdawn4e.css
+++ b/earthdawn4e.css
@@ -128,6 +128,9 @@ input.input__number-input {
   background-color: red;
   color: black;
 }
+.scrollable {
+  overflow: auto;
+}
 .itemControlGroup,
 .icon__position--right {
   float: right;

--- a/lang/de.json
+++ b/lang/de.json
@@ -1529,12 +1529,6 @@
         "walk": "Zu Fuß",
         "willpowerValue": "Willenskraft Wert"
       },
-      "Navigator": {
-        "advancement": "Fortschritt",
-        "details": "Details",
-        "effects": "Effekte",
-        "general": "Allgemein"
-      },
       "Placeholder": {
         "lpDescription":                                  "Trage hier eine Beschreibung ein"
       },
@@ -1545,7 +1539,15 @@
         "weaveThreadCheck":                               "Fadenweben ",
         "researchCheck":                                  "Forschen "
       },
-     
+      "Tabs": {
+        "advancement": "Fortschritt",
+        "details": "Details",
+        "effects": "Effekte",
+        "general": "Allgemein",
+        "level": "Kreis {circle}",
+        "talentOptions": "Optionale Talente",
+        "thread": "Fäden"
+      },
       "Talent": {
         "action":                                         "Aktion",
         "attribute": "Attribut",

--- a/lang/de.json
+++ b/lang/de.json
@@ -178,21 +178,6 @@
         },
         "attributeImprovement": "Attribut Erhöhung"
       },
-      "Navigator": {
-        "classes":                                          "Berufung",
-        "configuration":                                    "Konfiguration",
-        "devotions":                                        "Weihekräfte",
-        "equipment":                                        "Ausrüstung",
-        "general":                                          "Allgemein",
-        "information":                                      "Informationen",
-        "legend":                                           "Legende",
-        "power":                                            "Kräfte",
-        "reputation":                                       "Ruf",
-        "skills":                                           "Fertigkeiten",
-        "specials":                                         "Besonders",
-        "spells":                                           "Zauber",
-        "talents":                                          "Talente"
-      },
       "Spellcasting": {
         "elementalist": "Elementarist",
         "illusionist": "Illusionist",
@@ -200,6 +185,27 @@
         "nethermancer": "Geisterbeschwörer",
         "shaman": "Schamane",
         "wizard": "Magier"
+      },
+      "Tabs": {
+        "classes":                                          "Berufung",
+        "configuration":                                    "Konfiguration",
+        "description":                                      "Beschreibung",
+        "devotions":                                        "Weihekräfte",
+        "equipment":                                        "Ausrüstung",
+        "general":                                          "Allgemein",
+        "information":                                      "Informationen",
+        "legend":                                           "Legende",
+        "notes":                                            "Notizen",
+        "powers":                                            "Kräfte",
+        "reputation":                                       "Ruf",
+        "skills":                                           "Fertigkeiten",
+        "specials":                                         "Spezial",
+        "spells":                                           "Zauber",
+        "talents":                                          "Talente",
+        "Spells": {
+          "all":                                            "Alle",
+          "matrix":                                         "Matrix"
+        }
       },
       "Tooltips": {
         "carried": "Getragen",

--- a/less/global/global.less
+++ b/less/global/global.less
@@ -139,3 +139,10 @@ input.input__number-input {
     background-color: red;
     color: black;
 }
+
+//###########################################################
+//                       scrolling
+//###########################################################
+.scrollable {
+  overflow: auto;
+}

--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -6,11 +6,10 @@ import ActorSheetEdNamegiver from "./namegiver-sheet.mjs";
  */
 export default class ActorSheetEdCharacter extends ActorSheetEdNamegiver {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "general-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "legend", },
+    ] );
   }
 
   // region DEFAULT_OPTIONS
@@ -39,72 +38,59 @@ export default class ActorSheetEdCharacter extends ActorSheetEdNamegiver {
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
-      // id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "general-tab": {
+    general: {
       template:   "systems/ed4e/templates/actor/actor-tabs/general.hbs",
-      // id:         "general-tab",
       classes:    [ "tab", "general" ],
     },
-    "talents-tab": {
+    talents: {
       template: "systems/ed4e/templates/actor/actor-tabs/talents.hbs",
-      // id:       "talents-tab",
       classes:  [ "tab", "talents" ]
     },
-    "skills-tab": {
+    skills: {
       template: "systems/ed4e/templates/actor/actor-tabs/skills.hbs",
-      // id:       "skills-tab",
       classes:  [ "tab", "skills" ]
     },
-    "devotions-tab": {
+    devotions: {
       template: "systems/ed4e/templates/actor/actor-tabs/devotions.hbs",
-      // id:       "devotions-tab",
       classes:  [ "tab", "devotions" ]
     },
-    "spells-tab": {
+    spells: {
       template: "systems/ed4e/templates/actor/actor-tabs/spells.hbs",
-      // id:       "spells-tab",
       classes:  [ "tab", "spells" ]
     },
-    "equipment-tab": {
+    equipment: {
       template: "systems/ed4e/templates/actor/actor-tabs/equipment.hbs",
-      // id:       "equipment-tab",
       classes:  [ "tab", "equipment" ]
     },
-    "notes-tab": {
+    notes: {
       template: "systems/ed4e/templates/actor/actor-tabs/notes.hbs",
       // id:       "notes-tab",
       classes:  [ "tab", "notes" ]
     },
-    "reputation-tab": {
+    reputation: {
       template: "systems/ed4e/templates/actor/actor-tabs/reputation.hbs",
-      // id:       "reputation-tab",
       classes:  [ "tab", "reputation" ]
     },
-    "specials-tab": {
+    specials: {
       template: "systems/ed4e/templates/actor/actor-tabs/specials.hbs",
-      // id:       "specials-tab",
       classes:  [ "tab", "specials" ]
     },
-    "legend-tab": {
+    legend: {
       template: "systems/ed4e/templates/actor/actor-tabs/legend.hbs",
-      // id:       "legend-tab",
       classes:  [ "tab", "legend" ]
     },
-    "classes-tab": {
+    classes: {
       template: "systems/ed4e/templates/actor/actor-tabs/classes.hbs",
-      // id:       "classes-tab",
       classes:  [ "tab", "classes" ]
     },
     footer: {
@@ -114,32 +100,10 @@ export default class ActorSheetEdCharacter extends ActorSheetEdNamegiver {
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "general-tab":    { id: "general-tab", group: "sheet", icon: "fa-solid fa-user", label: "general" },
-      "talents-tab":    { id: "talents-tab", group: "sheet", icon: "fa-solid fa-user", label: "talents" },
-      "skills-tab":     { id: "skills-tab", group: "sheet", icon: "fa-solid fa-user", label: "skills" },
-      "devotions-tab":  { id: "devotions-tab", group: "sheet", icon: "fa-solid fa-user", label: "devotions" },
-      "spells-tab":     { id: "spells-tab", group: "sheet", icon: "fa-solid fa-user", label: "spells" },
-      "equipment-tab":  { id: "equipment-tab", group: "sheet", icon: "fa-solid fa-user", label: "equipment" },
-      "notes-tab":      { id: "notes-tab", group: "sheet", icon: "fa-solid fa-user", label: "notes" },
-      "reputation-tab": { id: "reputation-tab", group: "sheet", icon: "fa-solid fa-user", label: "reputation" },
-      "specials-tab":   { id: "specials-tab", group: "sheet", icon: "fa-solid fa-user", label: "specials" },
-      "legend-tab":     { id: "legend-tab", group: "sheet", icon: "fa-solid fa-user", label: "legend" },
-      "classes-tab":    { id: "classes-tab", group: "sheet", icon: "fa-solid fa-user", label: "classes" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
   // region _prepareContext
   async _prepareContext() {
     const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-      
+
     context.buttons = [
       {
         type:     "button",
@@ -196,30 +160,29 @@ export default class ActorSheetEdCharacter extends ActorSheetEdNamegiver {
       case "characteristics":
       case "tabs": 
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "talents-tab":
+      case "talents":
         break;
-      case "skills-tab":
+      case "skills":
         break;
-      case "devotions-tab":
+      case "devotions":
         break;
-      case "spells-tab":
+      case "spells":
         break;
-      case "equipment-tab":
+      case "equipment":
         break;  
-      case "notes-tab":
+      case "notes":
         break;
-      case "reputation-tab":
+      case "reputation":
         break;
-      case "specials-tab":
+      case "specials":
         break;
-      case "legend-tab":
+      case "legend":
         break;
-      case "classes-tab":
+      case "classes":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 

--- a/module/applications/actor/common-sheet.mjs
+++ b/module/applications/actor/common-sheet.mjs
@@ -5,14 +5,9 @@ const { ActorSheetV2 } = foundry.applications.sheets;
 
 /**
  * Extend the basic ActorSheet with modifications
- * @augments {ActorSheetV2}
  */
 
 export default class ActorSheetEd extends HandlebarsApplicationMixin( ActorSheetV2 ) {
-
-  constructor( options = {} ) {
-    super( options );
-  }
 
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
@@ -40,22 +35,55 @@ export default class ActorSheetEd extends HandlebarsApplicationMixin( ActorSheet
     },
   };
 
+  /** @inheritdoc */
+  static TABS = {
+    sheet: {
+      tabs:        [],
+      initial:     "general",
+      labelPrefix: "ED.Actor.Tabs",
+    },
+  };
+
+  static TAB_ORDER_SHEET = [
+    "general",
+    "talents",
+    "powers",
+    "skills",
+    "devotions",
+    "spells",
+    "equipment",
+    "description",
+    "notes",
+    "reputation",
+    "specials",
+    "legend",
+    "configuration",
+    "classes",
+  ];
+
+  static addSheetTabs( tabs ) {
+    this.TABS = foundry.utils.deepClone( this.TABS );
+    this.TABS.sheet.tabs.push( ...tabs );
+    this.TABS.sheet.tabs.sort(
+      ( a, b ) => this.TAB_ORDER_SHEET.indexOf( a.id ) - this.TAB_ORDER_SHEET.indexOf( b.id )
+    );
+  }
+
   /* -------------------------------------------- */
   /*  Rendering                                   */
   /* -------------------------------------------- */
 
-  async _prepareContext() {
+  async _prepareContext( options ) {
     // TODO: überprüfen was davon benötigt wird
-    const context = {
+    const context = await super._prepareContext( options );
+    foundry.utils.mergeObject( context, {
       actor:                  this.document,
       system:                 this.document.system,
       items:                  this.document.items,
       options:                this.options,
       systemFields:           this.document.system.schema.fields,
-      // enrichment:             await this.document._enableHTMLEnrichment(),
-      // enrichmentEmbededItems: await this.document._enableHTMLEnrichmentEmbeddedItems(),
       config:                 ED4E,
-    };
+    } );
 
     context.enrichedDescription = await TextEditor.enrichHTML(
       this.document.system.description.value,

--- a/module/applications/actor/common-sheet.mjs
+++ b/module/applications/actor/common-sheet.mjs
@@ -14,9 +14,7 @@ export default class ActorSheetEd extends HandlebarsApplicationMixin( ActorSheet
     super( options );
   }
 
-  /** 
-   * @override 
-   */
+  /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     classes:  [ "earthdawn4e", "sheet", "actor" ],
     window:   {

--- a/module/applications/actor/creature-sheet.mjs
+++ b/module/applications/actor/creature-sheet.mjs
@@ -2,21 +2,19 @@ import ActorSheetEdSentient from "./sentient-sheet.mjs";
 
 /**
  * Extend the basic ActorSheet with modifications
- * @augments {ActorSheet}
  */
 export default class ActorSheetEdCreature extends ActorSheetEdSentient {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "general-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "powers", },
+      { id: "reputation", },
+      { id: "configuration", },
+    ] );
   }
 
   // region DEFAULT_OPTIONS
-  /** 
-   * @override 
-   */
+  /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
     uniqueId: String( ++globalThis._appId ),
@@ -32,94 +30,61 @@ export default class ActorSheetEdCreature extends ActorSheetEdSentient {
   };
 
   // region PARTS
+  /** @inheritDoc */
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
-      // id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "general-tab": {
+    general: {
       template:   "systems/ed4e/templates/actor/actor-tabs/general.hbs",
-      // id:         "general-tab",
       classes:    [ "tab", "general" ],
     },
-    "powers-tab": {
+    powers: {
       template: "systems/ed4e/templates/actor/actor-tabs/powers.hbs",
-      // id:       "powers-tab",
       classes:  [ "tab", "powers" ]
     },
-    "spells-tab": {
+    spells: {
       template: "systems/ed4e/templates/actor/actor-tabs/spells.hbs",
-      // id:       "spells-tab",
       classes:  [ "tab", "spells" ]
     },
-    "equipment-tab": {
+    equipment: {
       template: "systems/ed4e/templates/actor/actor-tabs/equipment.hbs",
-      // id:       "equipment-tab",
       classes:  [ "tab", "equipment" ]
     },
-    "notes-tab": {
+    notes: {
       template: "systems/ed4e/templates/actor/actor-tabs/notes.hbs",
-      // id:       "notes-tab",
       classes:  [ "tab", "notes" ]
     },
-    "reputation-tab": {
+    reputation: {
       template: "systems/ed4e/templates/actor/actor-tabs/reputation.hbs",
-      // id:       "reputation-tab",
       classes:  [ "tab", "reputation" ]
     },
-    "specials-tab": {
+    specials: {
       template: "systems/ed4e/templates/actor/actor-tabs/specials.hbs",
-      // id:       "specials-tab",
       classes:  [ "tab", "specials" ]
     },
-    "configuration-tab": {
+    configuration: {
       template: "systems/ed4e/templates/actor/actor-tabs/configuration.hbs",
-      // id:       "configuration-tab",
       classes:  [ "tab", "configuration" ]
     },
     footer: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-buttons.hbs",
-      // id:       "base-tab",
       classes:  [ "sheet-footer" ]
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "general-tab":       { id: "general-tab", group: "sheet", icon: "fa-solid fa-user", label: "general" },
-      "powers-tab":        { id: "powers-tab", group: "sheet", icon: "fa-solid fa-user", label: "powers" },
-      "spells-tab":        { id: "spells-tab", group: "sheet", icon: "fa-solid fa-user", label: "spells" },
-      "equipment-tab":     { id: "equipment-tab", group: "sheet", icon: "fa-solid fa-user", label: "equipment" },
-      "notes-tab":         { id: "notes-tab", group: "sheet", icon: "fa-solid fa-user", label: "notes" },
-      "reputation-tab":    { id: "reputation-tab", group: "sheet", icon: "fa-solid fa-user", label: "reputation" },
-      "specials-tab":      { id: "specials-tab", group: "sheet", icon: "fa-solid fa-user", label: "specials" },
-      "configuration-tab":     { id: "configuration-tab", group: "sheet", icon: "fa-solid fa-user", label: "configuration" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -130,24 +95,23 @@ export default class ActorSheetEdCreature extends ActorSheetEdSentient {
       case "characteristics":
       case "tabs": 
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "powers-tab":
+      case "powers":
         break;
-      case "spells-tab":
+      case "spells":
         break;
-      case "equipment-tab":
+      case "equipment":
         break;  
-      case "notes-tab":
+      case "notes":
         break;
-      case "reputation-tab":
+      case "reputation":
         break;
-      case "specials-tab":
+      case "specials":
         break;
-      case "configuration-tab":
+      case "configuration":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/dragon-sheet.mjs
+++ b/module/applications/actor/dragon-sheet.mjs
@@ -2,21 +2,24 @@ import ActorSheetEdSentient from "./sentient-sheet.mjs";
 
 /**
  * Extend the basic ActorSheet with modifications
- * @augments {ActorSheet}
  */
 export default class ActorSheetEdDragon extends ActorSheetEdSentient {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "general-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "talents", },
+      { id: "powers", },
+      { id: "skills", },
+      { id: "devotions", },
+      { id: "reputation", },
+      { id: "specials", },
+      { id: "classes", },
+      { id: "configuration", },
+    ] );
   }
 
   // region DEFAULT_OPTIONS
-  /** 
-   * @override 
-   */
+  /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
     uniqueId: String( ++globalThis._appId ),
@@ -32,118 +35,77 @@ export default class ActorSheetEdDragon extends ActorSheetEdSentient {
   };
 
   // region PARTS
+  /** @inheritDoc */
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
-      // id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "general-tab": {
+    general: {
       template:   "systems/ed4e/templates/actor/actor-tabs/general.hbs",
-      // id:         "general-tab",
       classes:    [ "tab", "general" ],
     },
-    "talents-tab": {
+    talents: {
       template: "systems/ed4e/templates/actor/actor-tabs/talents.hbs",
-      // id:       "talents-tab",
       classes:  [ "tab", "talents" ]
     },
-    "powers-tab": {
+    powers: {
       template: "systems/ed4e/templates/actor/actor-tabs/powers.hbs",
-      // id:       "powers-tab",
       classes:  [ "tab", "powers" ]
     },
-    "skills-tab": {
+    skills: {
       template: "systems/ed4e/templates/actor/actor-tabs/skills.hbs",
-      // id:       "skills-tab",
       classes:  [ "tab", "skills" ]
     },
-    "devotions-tab": {
+    devotions: {
       template: "systems/ed4e/templates/actor/actor-tabs/devotions.hbs",
-      // id:       "devotions-tab",
       classes:  [ "tab", "devotions" ]
     },
-    "spells-tab": {
+    spells: {
       template: "systems/ed4e/templates/actor/actor-tabs/spells.hbs",
-      // id:       "spells-tab",
       classes:  [ "tab", "spells" ]
     },
-    "equipment-tab": {
+    equipment: {
       template: "systems/ed4e/templates/actor/actor-tabs/equipment.hbs",
-      // id:       "equipment-tab",
       classes:  [ "tab", "equipment" ]
     },
-    "notes-tab": {
+    notes: {
       template: "systems/ed4e/templates/actor/actor-tabs/notes.hbs",
-      // id:       "notes-tab",
       classes:  [ "tab", "notes" ]
     },
-    "reputation-tab": {
+    reputation: {
       template: "systems/ed4e/templates/actor/actor-tabs/reputation.hbs",
-      // id:       "reputation-tab",
       classes:  [ "tab", "reputation" ]
     },
-    "specials-tab": {
+    specials: {
       template: "systems/ed4e/templates/actor/actor-tabs/specials.hbs",
-      // id:       "specials-tab",
       classes:  [ "tab", "specials" ]
     },
-    "classes-tab": {
+    classes: {
       template: "systems/ed4e/templates/actor/actor-tabs/classes.hbs",
-      // id:       "classes-tab",
       classes:  [ "tab", "classes" ]
     },
-    "configuration-tab": {
+    configuration: {
       template: "systems/ed4e/templates/actor/actor-tabs/configuration.hbs",
-      // id:       "configuration-tab",
       classes:  [ "tab", "configuration" ]
     },
     footer: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-buttons.hbs",
-      // id:       "base-tab",
       classes:  [ "sheet-footer" ]
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "general-tab":       { id: "general-tab", group: "sheet", icon: "fa-solid fa-user", label: "general" },
-      "talents-tab":       { id: "talents-tab", group: "sheet", icon: "fa-solid fa-user", label: "talents" },
-      "powers-tab":        { id: "powers-tab", group: "sheet", icon: "fa-solid fa-user", label: "powers" },
-      "skills-tab":        { id: "skills-tab", group: "sheet", icon: "fa-solid fa-user", label: "skills" },
-      "devotions-tab":     { id: "devotions-tab", group: "sheet", icon: "fa-solid fa-user", label: "devotions" },
-      "spells-tab":        { id: "spells-tab", group: "sheet", icon: "fa-solid fa-user", label: "spells" },
-      "equipment-tab":     { id: "equipment-tab", group: "sheet", icon: "fa-solid fa-user", label: "equipment" },
-      "notes-tab":         { id: "notes-tab", group: "sheet", icon: "fa-solid fa-user", label: "notes" },
-      "reputation-tab":    { id: "reputation-tab", group: "sheet", icon: "fa-solid fa-user", label: "reputation" },
-      "specials-tab":      { id: "specials-tab", group: "sheet", icon: "fa-solid fa-user", label: "specials" },
-      "configuration-tab":     { id: "configuration-tab", group: "sheet", icon: "fa-solid fa-user", label: "configuration" },
-      "classes-tab":       { id: "classes-tab", group: "sheet", icon: "fa-solid fa-user", label: "classes" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -154,32 +116,31 @@ export default class ActorSheetEdDragon extends ActorSheetEdSentient {
       case "characteristics":
       case "tabs": 
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "talents-tab":
+      case "talents":
         break;
-      case "powers-tab":
+      case "powers":
         break;
-      case "skills-tab":
+      case "skills":
         break;
-      case "devotions-tab":
+      case "devotions":
         break;
-      case "spells-tab":
+      case "spells":
         break;
-      case "equipment-tab":
+      case "equipment":
         break;  
-      case "notes-tab":
+      case "notes":
         break;
-      case "reputation-tab":
+      case "reputation":
         break;
-      case "specials-tab":
+      case "specials":
         break;
-      case "configuration-tab":
+      case "configuration":
         break;
-      case "classes-tab":
+      case "classes":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -5,17 +5,16 @@ import ActorSheetEd from "./common-sheet.mjs";
  */
 export default class ActorSheetEdGroup extends ActorSheetEd {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "description-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "description", },
+      { id: "equipment", },
+      { id: "reputation", },
+    ] );
   }
-    
+
   // region DEFAULT_OPTIONS
-  /** 
-   * @override 
-   */
+  /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
     uniqueId: String( ++globalThis._appId ),
@@ -30,66 +29,41 @@ export default class ActorSheetEdGroup extends ActorSheetEd {
     }
   };
 
-
   // region PARTS
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
-      // id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "description-tab": {
+    description: {
       template: "systems/ed4e/templates/actor/actor-tabs/description.hbs",
-      // id:       "description-tab",
       classes:  [ "tab", "description" ]
     },
-    "equipment-tab": {
+    equipment: {
       template: "systems/ed4e/templates/actor/actor-tabs/equipment.hbs",
-      // id:       "equipment-tab",
       classes:  [ "tab", "equipment" ]
     },
-    "reputation-tab": {
+    reputation: {
       template: "systems/ed4e/templates/actor/actor-tabs/reputation.hbs",
-      // id:       "reputation-tab",
       classes:  [ "tab", "reputation" ]
     },
     footer: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-buttons.hbs",
-      // id:       "base-tab",
       classes:  [ "sheet-footer" ]
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "description-tab":         { id: "description-tab", group: "sheet", icon: "fa-solid fa-user", label: "description" },
-      "equipment-tab":     { id: "equipment-tab", group: "sheet", icon: "fa-solid fa-user", label: "equipment" },
-      "reputation-tab":    { id: "reputation-tab", group: "sheet", icon: "fa-solid fa-user", label: "reputation" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -100,14 +74,13 @@ export default class ActorSheetEdGroup extends ActorSheetEd {
       case "characteristics":
       case "tabs": 
         break;
-      case "description-tab":
+      case "description":
         break;
-      case "equipment-tab":
+      case "equipment":
         break;  
-      case "reputation-tab":
+      case "reputation":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/horror-sheet.mjs
+++ b/module/applications/actor/horror-sheet.mjs
@@ -2,15 +2,19 @@ import ActorSheetEdSentient from "./sentient-sheet.mjs";
 
 /**
  * Extend the basic ActorSheet with modifications
- * @augments {ActorSheet}
  */
 export default class ActorSheetEdHorror extends ActorSheetEdSentient {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "general-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "talents", },
+      { id: "powers", },
+      { id: "skills", },
+      { id: "devotions", },
+      { id: "reputation" },
+      { id: "classes" },
+      { id: "configuration" },
+    ] );
   }
 
   // region DEFAULT_OPTIONS
@@ -35,115 +39,73 @@ export default class ActorSheetEdHorror extends ActorSheetEdSentient {
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
-      // id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "general-tab": {
+    general: {
       template:   "systems/ed4e/templates/actor/actor-tabs/general.hbs",
-      // id:         "general-tab",
       classes:    [ "tab", "general" ],
     },
-    "talents-tab": {
+    talents: {
       template: "systems/ed4e/templates/actor/actor-tabs/talents.hbs",
-      // id:       "talents-tab",
       classes:  [ "tab", "talents" ]
     },
-    "powers-tab": {
+    powers: {
       template: "systems/ed4e/templates/actor/actor-tabs/powers.hbs",
-      // id:       "powers-tab",
       classes:  [ "tab", "powers" ]
     },
-    "skills-tab": {
+    skills: {
       template: "systems/ed4e/templates/actor/actor-tabs/skills.hbs",
-      // id:       "skills-tab",
       classes:  [ "tab", "skills" ]
     },
-    "devotions-tab": {
+    devotions: {
       template: "systems/ed4e/templates/actor/actor-tabs/devotions.hbs",
-      // id:       "devotions-tab",
       classes:  [ "tab", "devotions" ]
     },
-    "spells-tab": {
+    spells: {
       template: "systems/ed4e/templates/actor/actor-tabs/spells.hbs",
-      // id:       "spells-tab",
       classes:  [ "tab", "spells" ]
     },
-    "equipment-tab": {
+    equipment: {
       template: "systems/ed4e/templates/actor/actor-tabs/equipment.hbs",
-      // id:       "equipment-tab",
       classes:  [ "tab", "equipment" ]
     },
-    "notes-tab": {
+    notes: {
       template: "systems/ed4e/templates/actor/actor-tabs/notes.hbs",
-      // id:       "notes-tab",
       classes:  [ "tab", "notes" ]
     },
-    "reputation-tab": {
+    reputation: {
       template: "systems/ed4e/templates/actor/actor-tabs/reputation.hbs",
-      // id:       "reputation-tab",
       classes:  [ "tab", "reputation" ]
     },
-    "specials-tab": {
+    specials: {
       template: "systems/ed4e/templates/actor/actor-tabs/specials.hbs",
-      // id:       "specials-tab",
       classes:  [ "tab", "specials" ]
     },
-    "classes-tab": {
+    classes: {
       template: "systems/ed4e/templates/actor/actor-tabs/classes.hbs",
-      // id:       "classes-tab",
       classes:  [ "tab", "classes" ]
     },
-    "configuration-tab": {
+    configuration: {
       template: "systems/ed4e/templates/actor/actor-tabs/configuration.hbs",
-      // id:       "configuration-tab",
       classes:  [ "tab", "configuration" ]
     },
     footer: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-buttons.hbs",
-      // id:       "base-tab",
       classes:  [ "sheet-footer" ]
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "general-tab":       { id: "general-tab", group: "sheet", icon: "fa-solid fa-user", label: "general" },
-      "talents-tab":       { id: "talents-tab", group: "sheet", icon: "fa-solid fa-user", label: "talents" },
-      "powers-tab":        { id: "powers-tab", group: "sheet", icon: "fa-solid fa-user", label: "powers" },
-      "skills-tab":        { id: "skills-tab", group: "sheet", icon: "fa-solid fa-user", label: "skills" },
-      "devotions-tab":     { id: "devotions-tab", group: "sheet", icon: "fa-solid fa-user", label: "devotions" },
-      "spells-tab":        { id: "spells-tab", group: "sheet", icon: "fa-solid fa-user", label: "spells" },
-      "equipment-tab":     { id: "equipment-tab", group: "sheet", icon: "fa-solid fa-user", label: "equipment" },
-      "notes-tab":         { id: "notes-tab", group: "sheet", icon: "fa-solid fa-user", label: "notes" },
-      "reputation-tab":    { id: "reputation-tab", group: "sheet", icon: "fa-solid fa-user", label: "reputation" },
-      "specials-tab":      { id: "specials-tab", group: "sheet", icon: "fa-solid fa-user", label: "specials" },
-      "configuration-tab":     { id: "configuration-tab", group: "sheet", icon: "fa-solid fa-user", label: "configuration" },
-      "classes-tab":       { id: "classes-tab", group: "sheet", icon: "fa-solid fa-user", label: "classes" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -154,32 +116,31 @@ export default class ActorSheetEdHorror extends ActorSheetEdSentient {
       case "characteristics":
       case "tabs": 
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "talents-tab":
+      case "talents":
         break;
-      case "powers-tab":
+      case "powers":
         break;
-      case "skills-tab":
+      case "skills":
         break;
-      case "devotions-tab":
+      case "devotions":
         break;
-      case "spells-tab":
+      case "spells":
         break;
-      case "equipment-tab":
+      case "equipment":
         break;  
-      case "notes-tab":
+      case "notes":
         break;
-      case "reputation-tab":
+      case "reputation":
         break;
-      case "specials-tab":
+      case "specials":
         break;
-      case "configuration-tab":
+      case "configuration":
         break;
-      case "classes-tab":
+      case "classes":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/loot-sheet.mjs
+++ b/module/applications/actor/loot-sheet.mjs
@@ -5,17 +5,14 @@ import ActorSheetEd from "./common-sheet.mjs";
  */
 export default class ActorSheetEdLoot extends ActorSheetEd {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "description-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "description", },
+    ] );
   }
-    
+
   // region DEFAULT_OPTIONS
-  /** 
-   * @override 
-   */
+  /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
     uniqueId: String( ++globalThis._appId ),
@@ -30,24 +27,21 @@ export default class ActorSheetEdLoot extends ActorSheetEd {
     }
   };
 
-
   // region PARTS
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
       classes:  [ "tabs-navigation" ],
     },
-    "description-tab": {
+    description: {
       template: "systems/ed4e/templates/actor/actor-tabs/description.hbs",
       classes:  [ "tab", "description" ]
     },
@@ -57,24 +51,9 @@ export default class ActorSheetEdLoot extends ActorSheetEd {
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "description-tab":         { id: "description-tab", group: "sheet", icon: "fa-solid fa-user", label: "description" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -85,10 +64,9 @@ export default class ActorSheetEdLoot extends ActorSheetEd {
       case "characteristics":
       case "tabs": 
         break;
-      case "description-tab":
+      case "description":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/namegiver-sheet.mjs
+++ b/module/applications/actor/namegiver-sheet.mjs
@@ -1,19 +1,21 @@
-import ED4E from "../../config.mjs";
 import ActorSheetEdSentient from "./sentient-sheet.mjs";
 
 /**
  * Extend the basic ActorSheet with modifications
- * @augments {ActorSheet}
  */
 export default class ActorSheetEdNamegiver extends ActorSheetEdSentient {
 
-  constructor( options = {} ) {
-    super( options );
+  static {
+    this.addSheetTabs( [
+      { id: "talents", },
+      { id: "skills", },
+      { id: "devotions", },
+      { id: "reputation" },
+      { id: "classes" },
+    ] );
   }
 
-  /** 
-   * @override 
-   */
+  /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     classes:  [ "earthdawn4e", "sheet", "actor" ],
     window:   {
@@ -31,29 +33,12 @@ export default class ActorSheetEdNamegiver extends ActorSheetEdSentient {
     },
   };
 
-  async _prepareContext() {
+  async _prepareContext( options ) {
     // TODO: überprüfen was davon benötigt wird
-    const context = {
-      actor:                  this.document,
-      system:                 this.document.system,
-      items:                  this.document.items,
-      options:                this.options,
-      systemFields:           this.document.system.schema.fields,
-      // enrichment:             await this.document._enableHTMLEnrichment(),
-      // enrichmentEmbededItems: await this.document._enableHTMLEnrichmentEmbeddedItems(),
-      config:                 ED4E,
+    const context = await super._prepareContext( options );
+    foundry.utils.mergeObject( context, {
       splitTalents:           game.settings.get( "ed4e", "talentsSplit" ),
-    };
-
-
-    context.enrichedDescription = await TextEditor.enrichHTML(
-      this.document.system.description.value,
-      {
-        // Only show secret blocks to owner
-        secrets:    this.document.isOwner,
-        EdRollData: this.document.getRollData
-      }
-    );
+    } );
 
     return context;
   }

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -2,21 +2,18 @@ import ActorSheetEdNamegiver from "./namegiver-sheet.mjs";
 
 /**
  * An actor sheet application designed for actors of type "NPC"
- * @augments {ActorSheet}
  */
 export default class ActorSheetEdNpc extends ActorSheetEdNamegiver {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "general-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "powers" },
+      { id: "configuration" },
+    ] );
   }
-    
+
   // region DEFAULT_OPTIONS
-  /** 
-   * @override 
-   */
+  /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
     uniqueId: String( ++globalThis._appId ),
@@ -24,127 +21,84 @@ export default class ActorSheetEdNpc extends ActorSheetEdNamegiver {
     actions:  {
     },
     position: {
-      top:    50, 
+      top:    50,
       left:   220,
-      width:  800, 
+      width:  800,
       height: 800,
     }
   };
-
 
   // region PARTS
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
-      // id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "general-tab": {
+    general: {
       template:   "systems/ed4e/templates/actor/actor-tabs/general.hbs",
-      // id:         "general-tab",
       classes:    [ "tab", "general" ],
     },
-    "talents-tab": {
+    talents: {
       template: "systems/ed4e/templates/actor/actor-tabs/talents.hbs",
-      // id:       "talents-tab",
       classes:  [ "tab", "talents" ]
     },
-    "powers-tab": {
+    powers: {
       template: "systems/ed4e/templates/actor/actor-tabs/powers.hbs",
-      // id:       "powers-tab",
       classes:  [ "tab", "powers" ]
     },
-    "skills-tab": {
+    skills: {
       template: "systems/ed4e/templates/actor/actor-tabs/skills.hbs",
-      // id:       "skills-tab",
       classes:  [ "tab", "skills" ]
     },
-    "devotions-tab": {
+    devotions: {
       template: "systems/ed4e/templates/actor/actor-tabs/devotions.hbs",
-      // id:       "devotions-tab",
       classes:  [ "tab", "devotions" ]
     },
-    "spells-tab": {
+    spells: {
       template: "systems/ed4e/templates/actor/actor-tabs/spells.hbs",
-      // id:       "spells-tab",
       classes:  [ "tab", "spells" ]
     },
-    "equipment-tab": {
+    equipment: {
       template: "systems/ed4e/templates/actor/actor-tabs/equipment.hbs",
-      // id:       "equipment-tab",
       classes:  [ "tab", "equipment" ]
     },
-    "notes-tab": {
+    notes: {
       template: "systems/ed4e/templates/actor/actor-tabs/notes.hbs",
-      // id:       "notes-tab",
       classes:  [ "tab", "notes" ]
     },
-    "reputation-tab": {
+    reputation: {
       template: "systems/ed4e/templates/actor/actor-tabs/reputation.hbs",
-      // id:       "reputation-tab",
       classes:  [ "tab", "reputation" ]
     },
-    "specials-tab": {
+    specials: {
       template: "systems/ed4e/templates/actor/actor-tabs/specials.hbs",
-      // id:       "specials-tab",
       classes:  [ "tab", "specials" ]
     },
-    "classes-tab": {
+    classes: {
       template: "systems/ed4e/templates/actor/actor-tabs/classes.hbs",
-      // id:       "classes-tab",
       classes:  [ "tab", "classes" ]
     },
-    "configuration-tab": {
+    configuration: {
       template: "systems/ed4e/templates/actor/actor-tabs/configuration.hbs",
-      // id:       "configuration-tab",
       classes:  [ "tab", "configuration" ]
     },
     footer: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-buttons.hbs",
-      // id:       "base-tab",
       classes:  [ "sheet-footer" ]
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "general-tab":       { id: "general-tab", group: "sheet", icon: "fa-solid fa-user", label: "general" },
-      "talents-tab":       { id: "talents-tab", group: "sheet", icon: "fa-solid fa-user", label: "talents" },
-      "powers-tab":        { id: "powers-tab", group: "sheet", icon: "fa-solid fa-user", label: "powers" },
-      "skills-tab":        { id: "skills-tab", group: "sheet", icon: "fa-solid fa-user", label: "skills" },
-      "devotions-tab":     { id: "devotions-tab", group: "sheet", icon: "fa-solid fa-user", label: "devotions" },
-      "spells-tab":        { id: "spells-tab", group: "sheet", icon: "fa-solid fa-user", label: "spells" },
-      "equipment-tab":     { id: "equipment-tab", group: "sheet", icon: "fa-solid fa-user", label: "equipment" },
-      "notes-tab":         { id: "notes-tab", group: "sheet", icon: "fa-solid fa-user", label: "notes" },
-      "reputation-tab":    { id: "reputation-tab", group: "sheet", icon: "fa-solid fa-user", label: "reputation" },
-      "specials-tab":      { id: "specials-tab", group: "sheet", icon: "fa-solid fa-user", label: "specials" },
-      "configuration-tab":     { id: "configuration-tab", group: "sheet", icon: "fa-solid fa-user", label: "configuration" },
-      "classes-tab":       { id: "classes-tab", group: "sheet", icon: "fa-solid fa-user", label: "classes" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
-  async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+  async _prepareContext( options ) {
+    return await super._prepareContext( options );
   }
 
   // region _prepare Part Context
@@ -153,34 +107,33 @@ export default class ActorSheetEdNpc extends ActorSheetEdNamegiver {
     switch ( partId ) {
       case "header":
       case "characteristics":
-      case "tabs": 
+      case "tabs":
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "talents-tab":
+      case "talents":
         break;
-      case "powers-tab":
+      case "powers":
         break;
-      case "skills-tab":
+      case "skills":
         break;
-      case "devotions-tab":
+      case "devotions":
         break;
-      case "spells-tab":
+      case "spells":
         break;
-      case "equipment-tab":
-        break;  
-      case "notes-tab":
+      case "equipment":
         break;
-      case "reputation-tab":
+      case "notes":
         break;
-      case "specials-tab":
+      case "reputation":
         break;
-      case "configuration-tab":
+      case "specials":
         break;
-      case "classes-tab":
+      case "configuration":
+        break;
+      case "classes":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/spirit-sheet.mjs
+++ b/module/applications/actor/spirit-sheet.mjs
@@ -2,15 +2,19 @@ import ActorSheetEdSentient from "./sentient-sheet.mjs";
 
 /**
  * Extend the basic ActorSheet with modifications
- * @augments {ActorSheet}
  */
 export default class ActorSheetEdSpirit extends ActorSheetEdSentient {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "general-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "talents", },
+      { id: "powers", },
+      { id: "skills", },
+      { id: "devotions", },
+      { id: "reputation" },
+      { id: "classes" },
+      { id: "configuration" },
+    ] );
   }
 
   // region DEFAULT_OPTIONS
@@ -35,115 +39,73 @@ export default class ActorSheetEdSpirit extends ActorSheetEdSentient {
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
-      // id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "general-tab": {
+    general: {
       template:   "systems/ed4e/templates/actor/actor-tabs/general.hbs",
-      // id:         "general-tab",
       classes:    [ "tab", "general" ],
     },
-    "talents-tab": {
+    talents: {
       template: "systems/ed4e/templates/actor/actor-tabs/talents.hbs",
-      // id:       "talents-tab",
       classes:  [ "tab", "talents" ]
     },
-    "powers-tab": {
+    powers: {
       template: "systems/ed4e/templates/actor/actor-tabs/powers.hbs",
-      // id:       "powers-tab",
       classes:  [ "tab", "powers" ]
     },
-    "skills-tab": {
+    skills: {
       template: "systems/ed4e/templates/actor/actor-tabs/skills.hbs",
-      // id:       "skills-tab",
       classes:  [ "tab", "skills" ]
     },
-    "devotions-tab": {
+    devotions: {
       template: "systems/ed4e/templates/actor/actor-tabs/devotions.hbs",
-      // id:       "devotions-tab",
       classes:  [ "tab", "devotions" ]
     },
-    "spells-tab": {
+    spells: {
       template: "systems/ed4e/templates/actor/actor-tabs/spells.hbs",
-      // id:       "spells-tab",
       classes:  [ "tab", "spells" ]
     },
-    "equipment-tab": {
+    equipment: {
       template: "systems/ed4e/templates/actor/actor-tabs/equipment.hbs",
-      // id:       "equipment-tab",
       classes:  [ "tab", "equipment" ]
     },
-    "notes-tab": {
+    notes: {
       template: "systems/ed4e/templates/actor/actor-tabs/notes.hbs",
-      // id:       "notes-tab",
       classes:  [ "tab", "notes" ]
     },
-    "reputation-tab": {
+    reputation: {
       template: "systems/ed4e/templates/actor/actor-tabs/reputation.hbs",
-      // id:       "reputation-tab",
       classes:  [ "tab", "reputation" ]
     },
-    "specials-tab": {
+    specials: {
       template: "systems/ed4e/templates/actor/actor-tabs/specials.hbs",
-      // id:       "specials-tab",
       classes:  [ "tab", "specials" ]
     },
-    "classes-tab": {
+    classes: {
       template: "systems/ed4e/templates/actor/actor-tabs/classes.hbs",
-      // id:       "classes-tab",
       classes:  [ "tab", "classes" ]
     },
-    "configuration-tab": {
+    configuration: {
       template: "systems/ed4e/templates/actor/actor-tabs/configuration.hbs",
-      // id:       "configuration-tab",
       classes:  [ "tab", "configuration" ]
     },
     footer: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-buttons.hbs",
-      // id:       "base-tab",
       classes:  [ "sheet-footer" ]
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "general-tab":       { id: "general-tab", group: "sheet", icon: "fa-solid fa-user", label: "general" },
-      "talents-tab":       { id: "talents-tab", group: "sheet", icon: "fa-solid fa-user", label: "talents" },
-      "powers-tab":        { id: "powers-tab", group: "sheet", icon: "fa-solid fa-user", label: "powers" },
-      "skills-tab":        { id: "skills-tab", group: "sheet", icon: "fa-solid fa-user", label: "skills" },
-      "devotions-tab":     { id: "devotions-tab", group: "sheet", icon: "fa-solid fa-user", label: "devotions" },
-      "spells-tab":        { id: "spells-tab", group: "sheet", icon: "fa-solid fa-user", label: "spells" },
-      "equipment-tab":     { id: "equipment-tab", group: "sheet", icon: "fa-solid fa-user", label: "equipment" },
-      "notes-tab":         { id: "notes-tab", group: "sheet", icon: "fa-solid fa-user", label: "notes" },
-      "reputation-tab":    { id: "reputation-tab", group: "sheet", icon: "fa-solid fa-user", label: "reputation" },
-      "specials-tab":      { id: "specials-tab", group: "sheet", icon: "fa-solid fa-user", label: "specials" },
-      "configuration-tab":     { id: "configuration-tab", group: "sheet", icon: "fa-solid fa-user", label: "configuration" },
-      "classes-tab":       { id: "classes-tab", group: "sheet", icon: "fa-solid fa-user", label: "classes" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -154,32 +116,31 @@ export default class ActorSheetEdSpirit extends ActorSheetEdSentient {
       case "characteristics":
       case "tabs": 
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "talents-tab":
+      case "talents":
         break;
-      case "powers-tab":
+      case "powers":
         break;
-      case "skills-tab":
+      case "skills":
         break;
-      case "devotions-tab":
+      case "devotions":
         break;
-      case "spells-tab":
+      case "spells":
         break;
-      case "equipment-tab":
+      case "equipment":
         break;  
-      case "notes-tab":
+      case "notes":
         break;
-      case "reputation-tab":
+      case "reputation":
         break;
-      case "specials-tab":
+      case "specials":
         break;
-      case "configuration-tab":
+      case "configuration":
         break;
-      case "classes-tab":
+      case "classes":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/trap-sheet.mjs
+++ b/module/applications/actor/trap-sheet.mjs
@@ -5,17 +5,14 @@ import ActorSheetEd from "./common-sheet.mjs";
  */
 export default class ActorSheetEdTrap extends ActorSheetEd {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "description-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "description", },
+    ] );
   }
-    
+
   // region DEFAULT_OPTIONS
-  /** 
-   * @override 
-   */
+  /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
     uniqueId: String( ++globalThis._appId ),
@@ -30,24 +27,21 @@ export default class ActorSheetEdTrap extends ActorSheetEd {
     }
   };
 
-
   // region PARTS
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
       classes:  [ "tabs-navigation" ],
     },
-    "description-tab": {
+    description: {
       template: "systems/ed4e/templates/actor/actor-tabs/description.hbs",
       classes:  [ "tab", "description" ]
     },
@@ -57,24 +51,9 @@ export default class ActorSheetEdTrap extends ActorSheetEd {
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "description-tab":         { id: "description-tab", group: "sheet", icon: "fa-solid fa-user", label: "description" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -85,10 +64,9 @@ export default class ActorSheetEdTrap extends ActorSheetEd {
       case "characteristics":
       case "tabs": 
         break;
-      case "description-tab":
+      case "description":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -5,17 +5,14 @@ import ActorSheetEd from "./common-sheet.mjs";
  */
 export default class ActorSheetEdVehicle extends ActorSheetEd {
 
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      sheet: "description-tab",
-    };
+  static {
+    this.addSheetTabs( [
+      { id: "description", },
+    ] );
   }
     
   // region DEFAULT_OPTIONS
-  /** 
-   * @override 
-   */
+  /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
     uniqueId: String( ++globalThis._appId ),
@@ -35,19 +32,17 @@ export default class ActorSheetEdVehicle extends ActorSheetEd {
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-name.hbs",
-      // id:       "header",
       classes:  [ "sheet-header" ],
     },
     characteristics: {
       template: "systems/ed4e/templates/actor/actor-partials/actor-section-top.hbs",
-      // id:       "characteristics",
       classes:  [ "characteristics" ],
     },
     tabs: {
       template: "templates/generic/tab-navigation.hbs",
       classes:  [ "tabs-navigation" ],
     },
-    "description-tab": {
+    description: {
       template: "systems/ed4e/templates/actor/actor-tabs/description.hbs",
       classes:  [ "tab", "description" ]
     },
@@ -57,24 +52,9 @@ export default class ActorSheetEdVehicle extends ActorSheetEd {
     },
   };
 
-  // region getTabs 
-  #getTabs() {
-    const tabs = {
-      "description-tab":         { id: "description-tab", group: "sheet", icon: "fa-solid fa-user", label: "description" },
-    };
-    for ( const tab of Object.values( tabs ) ) {
-      tab.active = this.tabGroups[tab.group] === tab.id;
-      tab.cssClass = tab.active ? "active" : "";
-    }
-    return tabs;
-  }
-
   // region _prepareContext
   async _prepareContext() {
-    const context = await super._prepareContext();
-    context.tabs = this.#getTabs();
-
-    return context;
+    return await super._prepareContext();
   }
 
   // region _prepare Part Context
@@ -85,10 +65,9 @@ export default class ActorSheetEdVehicle extends ActorSheetEd {
       case "characteristics":
       case "tabs": 
         break;
-      case "description-tab":
+      case "description":
         break;
     }
-    context.tab = context.tabs[partId];  
     return context;
   }
 }

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -11,16 +11,10 @@ const { ItemSheetV2 } = foundry.applications.sheets;
  */
 export default class ItemSheetEd extends HandlebarsApplicationMixin( ItemSheetV2 ) {
   
-  constructor( options = {} ) {
-    super( options );
-    this.tabGroups = {
-      "item-sheet": "general-tab",
-    };
-  }
-
-  /**
-   * @override
-   */
+  tabGroups = {
+    sheet:             "general",
+    classAdvancements: "options",
+  };
 
   static DEFAULT_OPTIONS = {
     id:       "item-sheet-{id}",
@@ -69,32 +63,32 @@ export default class ItemSheetEd extends HandlebarsApplicationMixin( ItemSheetV2
       id:       "-tabs-navigation",
       classes:  [ "tabs-navigation" ],
     },
-    "general-tab": { 
+    "general": {
       template: "systems/ed4e/templates/item/item-partials/item-description.hbs", 
       classes:  [ "general" ] 
     },
-    "details-tab": { 
+    "details": {
       template: "systems/ed4e/templates/item/item-partials/item-details.hbs", 
       classes:  [ "details" ] 
     },
-    "effects-tab": { 
+    "effects": {
       template: "systems/ed4e/templates/item/item-partials/item-details/item-effects.hbs", 
       classes:  [ "effects" ] 
     },
   };
 
-  #getTabs() {
-    const tabs = {
-      "general-tab":    { id: "general-tab", group: "item-sheet", icon: "fa-solid fa-user", label: "general" },
-      "details-tab":    { id: "details-tab", group: "item-sheet", icon: "fa-solid fa-user", label: "details" },
-      "effects-tab":     { id: "effects-tab", group: "item-sheet", icon: "fa-solid fa-user", label: "effects" },
-    };
-    for ( const v of Object.values( tabs ) ) {
-      v.active = this.tabGroups[v.group] === v.id;
-      v.cssClass = v.active ? "active" : "";
-    }
-    return tabs;
-  }
+  /** @inheritDoc */
+  static TABS = {
+    sheet: {
+      tabs:        [
+        { id:    "general", },
+        { id:    "details", },
+        { id:    "effects", },
+      ],
+      initial:     "general",
+      labelPrefix: "ED.Item.Tabs",
+    },
+  };
 
   // region _prepare Part Context
   async _preparePartContext( partId, contextInput, options ) {
@@ -104,32 +98,29 @@ export default class ItemSheetEd extends HandlebarsApplicationMixin( ItemSheetV2
       case "top":
       case "tabs": 
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "details-tab":
+      case "details":
         break;
-      case "effects-tab":
+      case "effects":
         break;
     }
-    context.tab = context.tabs[partId];
     return context;
   }
 
-  async _prepareContext() {
-    
-    const context = {
-      item:                   this.document,
-      system:                 this.document.system,
-      options:                this.options,
-      systemFields:           this.document.system.schema.fields,
-      isGM:                   game.user.isGM,
-      // enrichment:             await this.document._enableHTMLEnrichment(),
-      // enrichmentEmbededItems: await this.document._enableHTMLEnrichmentEmbeddedItems(),
-      config:                 ED4E,
-    };
-
-    // context = await super._prepareContext();
-    context.tabs = this.#getTabs();
+  async _prepareContext( options ) {
+    const context = await super._prepareContext( options );
+    foundry.utils.mergeObject(
+      context,
+      {
+        item:                   this.document,
+        system:                 this.document.system,
+        options:                this.options,
+        systemFields:           this.document.system.schema.fields,
+        isGM:                   game.user.isGM,
+        config:                 ED4E,
+      }
+    );
 
     context.enrichedDescription = await TextEditor.enrichHTML(
       this.document.system.description.value,

--- a/module/applications/item/physical-item-sheet.mjs
+++ b/module/applications/item/physical-item-sheet.mjs
@@ -3,18 +3,10 @@ import ItemSheetEd from "./item-sheet.mjs";
 
 /**
  * Extend the basic ActorSheet with modifications
- * @augments {ItemSheet}
  */
 export default class PhysicalItemSheetEd extends ItemSheetEd {
-  
-  constructor( options = {} ) {
-    super( options );
-  }
 
-  /**
-   * @override
-   */
-
+  /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     actions:  {
       tailorToNamegiver:  PhysicalItemSheetEd.tailorToNamegiver,
@@ -41,40 +33,41 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
       classes:    [ "tabs-navigation" ],
       scrollable: [ "" ],
     },
-    "general-tab": { 
+    "general": {
       template: "systems/ed4e/templates/item/item-partials/item-description.hbs", 
       classes:  [ "general" ] 
     },
-    "details-tab": { 
+    "details": {
       template: "systems/ed4e/templates/item/item-partials/item-details.hbs", 
       classes:  [ "details" ] 
     },
-    "effects-tab": { 
+    "effects": {
       template: "systems/ed4e/templates/item/item-partials/item-details/item-effects.hbs", 
       classes:  [ "effects" ] 
     },
-    "thread-tab": { 
+    "thread": {
       template:   "systems/ed4e/templates/item/item-partials/item-details/other-tabs/threads.hbs", 
-      id:         "-thread-tab",
+      id:         "-thread",
       classes:    [ "thread" ],
       scrollable: [ "" ], 
     },
   };
-  
-  #getTabs() {
-    const tabs = {
-      "general-tab":     { id: "general-tab", group: "item-sheet", icon: "fa-solid fa-user", label: "general" },
-      "details-tab":     { id: "details-tab", group: "item-sheet", icon: "fa-solid fa-user", label: "details" },
-      "effects-tab":     { id: "effects-tab", group: "item-sheet", icon: "fa-solid fa-user", label: "effects" },
-      "thread-tab":     { id: "thread-tab", group: "item-sheet", icon: "fa-solid fa-user", label: "threads" },
-    };
-    for ( const v of Object.values( tabs ) ) {
-      v.active = this.tabGroups[v.group] === v.id;
-      v.cssClass = v.active ? "active" : "";
-    }
-    return tabs;
-  }
 
+  // region TABS
+  /** @inheritDoc */
+  static TABS = {
+    sheet: {
+      tabs:        [
+        { id:    "general", },
+        { id:    "details", },
+        { id:    "effects", },
+        { id:    "thread", },
+      ],
+      initial:     "general",
+      labelPrefix: "ED.Item.Tabs",
+    },
+  };
+  
   async _preparePartContext( partId, contextInput, options ) {
     const context = await super._preparePartContext( partId, contextInput, options );
     switch ( partId ) {
@@ -82,31 +75,32 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
       case "top":
       case "tabs": 
         break;
-      case "general-tab":
+      case "general":
         break;
-      case "details-tab":
+      case "details":
         break;
-      case "effects-tab":
+      case "effects":
         break;
-      case "thread-tab":
+      case "thread":
         break;
     }
-    context.tab = context.tabs[partId];
     return context;
   }
   
-  async _prepareContext() {
-    const context = {
-      item:                   this.document,
-      system:                 this.document.system,
-      options:                this.options,
-      systemFields:           this.document.system.schema.fields,
-      config:                 ED4E,
-      isGM:                   game.user.isGM,
-    };
+  async _prepareContext( options ) {
+    const context = super._prepareContext( options );
+    foundry.utils.mergeObject(
+      context,
+      {
+        item:                   this.document,
+        system:                 this.document.system,
+        options:                this.options,
+        systemFields:           this.document.system.schema.fields,
+        config:                 ED4E,
+        isGM:                   game.user.isGM,
+      },
+    );
     
-    context.tabs = this.#getTabs();
-  
     context.enrichedDescription = await TextEditor.enrichHTML(
       this.document.system.description.value,
       {

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -1357,9 +1357,11 @@ ED4E.icons = {
   effect:           "fa-biohazard",
   halfmagic:        "fa-hat-wizard",
   initiative:       "fa-running",
+  itemHistory:      "fa-history",
   ok:               "fa-check",
   patterncraft:     "fa-thin fa-group-arrows-rotate",
   recovery:         "fa-heartbeat",
+  research:         "fa-thin fa-search",
   spellcasting:     "fa-thin fa-sparkles",
   threadWeaving:    "fa-thin fa-chart-network",
   finishCharGen:    "fa-thin fa-check-double",
@@ -1367,6 +1369,8 @@ ED4E.icons = {
   nextCharGen:      "fa-thin fa-arrow-right",
   resetPoints:      "fa-arrows-rotate",
   undo:             "fa-arrow-rotate-left",
+  Tabs:             {
+  },
 };
 
 

--- a/module/data/advancement/base-advancement.mjs
+++ b/module/data/advancement/base-advancement.mjs
@@ -104,8 +104,8 @@ export default class AdvancementData extends SparseDataModel {
    * Add a new level to this advancement.
    * @param {object} [data]    If provided, will initialize the new level with the given data.
    */
-  addLevel( data = {} ) {
-    this.parent.parent.update( {
+  async addLevel( data = {} ) {
+    await this.parent.parent.update( {
       "system.advancement.levels": this.levels.concat(
         new AdvancementLevelData(
           {
@@ -121,8 +121,8 @@ export default class AdvancementData extends SparseDataModel {
    * Remove the last {@link amount} levels added from this advancement.
    * @param {number} [amount]   The number of levels to remove.
    */
-  deleteLevel( amount = 1 ) {
-    this.parent.parent.update( {
+  async deleteLevel( amount = 1 ) {
+    await this.parent.parent.update( {
       "system.advancement.levels": this.levels.slice( 0, -( amount ?? 1 ) )
     } );
   }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -25,10 +25,11 @@ export default class SpellData extends ItemDataModel.mixin(
     return this.mergeSchema( super.defineSchema(), {
       spellcastingType: new StringField( {
         required: true,
-        nullable: true,
+        nullable: false,
         blank:    false,
         trim:     true,
         choices:  ED4E.spellcastingTypes,
+        initial:  "elementalism",
         label:    this.labelKey( "Spell.spellcastingType" ),
         hint:     this.hintKey( "Spell.spellcastingType" ),
       } ),

--- a/templates/actor/actor-tabs/classes.hbs
+++ b/templates/actor/actor-tabs/classes.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="classes-tab">
+<section class="tab {{tabs.classes.cssClass}}" data-group="sheet" data-tab="classes">
 <div>
     <div class="class-card__grid--container font__bold text-break__auto">
         <div class="class-card__grid--item text__alignment--center"></div>

--- a/templates/actor/actor-tabs/configuration.hbs
+++ b/templates/actor/actor-tabs/configuration.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="configuration-tab">
+<section class="tab {{tabs.configuration.cssClass}}" data-group="sheet" data-tab="configuration">
 <div>
     {{formField systemFields.isMob name="system.isMob" value=actor.system.isMob localize=true}}
 </div>

--- a/templates/actor/actor-tabs/description.hbs
+++ b/templates/actor/actor-tabs/description.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="description-tab">
+<section class="tab {{tabs.description.cssClass}}" data-group="sheet" data-tab="description">
   <div class="sheet__editor">
     <h3>{{localize "ED.Actor.Header.information"}}</h3>
     {{> "systems/ed4e/templates/global/editor.hbs"}}

--- a/templates/actor/actor-tabs/devotions.hbs
+++ b/templates/actor/actor-tabs/devotions.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="devotions-tab">
+<section class="tab {{tabs.devotions.cssClass}}" data-group="sheet" data-tab="devotions">
 <div>
     <div class="ability-card__grid--container font__bold text-break__auto">
         <div class="ability-card__grid--item"></div>

--- a/templates/actor/actor-tabs/equipment.hbs
+++ b/templates/actor/actor-tabs/equipment.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="equipment-tab">
+<section class="tab {{tabs.equipment.cssClass}}" data-group="sheet" data-tab="equipment">
 {{localize "ED.Actor.Header.carryingCapacity"}}
 
 <div>

--- a/templates/actor/actor-tabs/general.hbs
+++ b/templates/actor/actor-tabs/general.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="general-tab">
+<section class="tab {{tabs.general.cssClass}}" data-group="sheet" data-tab="general">
 <div class="left-part">
     {{!-- Attribute --}}
     <div>

--- a/templates/actor/actor-tabs/notes.hbs
+++ b/templates/actor/actor-tabs/notes.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="notes-tab">
+<section class="tab {{tabs.notes.cssClass}}" data-group="sheet" data-tab="notes">
   <div class="sheet__editor">
     <h3>{{localize "ED.Actor.Header.information"}}</h3>
     {{#if (ne actor.type "character")}}

--- a/templates/actor/actor-tabs/powers.hbs
+++ b/templates/actor/actor-tabs/powers.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="powers-tab">
+<section class="tab {{tabs.powers.cssClass}}" data-group="sheet" data-tab="powers">
 {{!-- Attacks --}}
 <div class="power-card__grid--container font__bold text-break__auto">
     <div class="power-card__grid--item text__alignment--center"></div>

--- a/templates/actor/actor-tabs/reputation.hbs
+++ b/templates/actor/actor-tabs/reputation.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="reputation-tab">
+<section class="tab {{tabs.reputation.cssClass}}" data-group="sheet" data-tab="reputation">
 <div class="undefined">
     tbd
 </div>

--- a/templates/actor/actor-tabs/skills.hbs
+++ b/templates/actor/actor-tabs/skills.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="skills-tab">
+<section class="tab {{tabs.skills.cssClass}}" data-group="sheet" data-tab="skills">
 <div>
     <div class="ability-card__grid--container font__bold text-break__auto">
         <div class="ability-card__grid--item"></div>

--- a/templates/actor/actor-tabs/specials.hbs
+++ b/templates/actor/actor-tabs/specials.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="specials-tab">
+<section class="tab {{tabs.specials.cssClass}}" data-group="sheet" data-tab="specials">
   <p class="undefined">effecte die zu "effect-items" gehören werden eingerückt</p>
   <div>
     <h3>{{localize "ED.Actor.Header.effectsTemporary"}}

--- a/templates/actor/actor-tabs/spells.hbs
+++ b/templates/actor/actor-tabs/spells.hbs
@@ -1,88 +1,64 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="spells-tab">
-<div class="input--centered">
-    <div id="actor-navigation" class="navigator">
-        <nav class="actor-sheet-spell-tabs navigator__flex" data-group="spells">
-
-            <a class="navigator__tab" data-tab="spell-matrix-tab">{{localize "ED.Actor.Spellcasting.matrix"}}</a>
-            <a class="navigator__tab" data-tab="spell-elementalist-tab">{{localize
-                "ED.Actor.Spellcasting.elementalist"}}</a>
-            <a class="navigator__tab" data-tab="spell-illusionist-tab">{{localize
-                "ED.Actor.Spellcasting.illusionist"}}</a>
-            <a class="navigator__tab" data-tab="spell-nethermancer-tab">{{localize
-                "ED.Actor.Spellcasting.nethermancer"}}</a>
-            <a class="navigator__tab" data-tab="spell-shaman-tab">{{localize "ED.Actor.Spellcasting.shaman"}}</a>
-            <a class="navigator__tab" data-tab="spell-wizard-tab">{{localize "ED.Actor.Spellcasting.wizard"}}</a>
-        </nav>
-    </div>
+<section class="tab {{tabs.spells.cssClass}}" data-group="sheet" data-tab="spells">
+  <div class="input--centered">
+    <nav class="tabs navigator__flex" data-group="spellsContent">
+      {{#each tabsSpells as |tab|}}
+        <a class="navigator__tab {{tab.cssClass}}" data-action="tab" data-group="{{tab.group}}" data-tab="{{tab.id}}"
+           {{#if tab.tooltip}}data-tooltip="{{tab.tooltip}}"{{/if}}>
+          {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
+          {{#if tab.label}}<label>{{localize tab.label}}</label>{{/if}}
+        </a>
+      {{/each}}
+    </nav>
     <div class="main">
-        <div class="actor-sheet-spell-body">
-            <div class="tab tab__matrix" data-tab="spell-matrix-tab" data-group="spells">
-                <div class="undefined">
-                    <p>matrizen</p>
-                    <p>zeige alle Matrizen und Matrix items und funktionen für aktunement etc.</p>
-                </div>
-                {{#each actor.itemTypes.matrix}}
-                <div class="item-id item-name__card" data-item-id="{{_id}}">
-                    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
-                </div>
-                {{/each}}
+      <!--spells tabs-->
+      <div class="actor-sheet-spell-body">
+
+        <!-- matrices -->
+        <div class="tab {{tabsSpells.matrix.cssClass}}" data-group="spellsContent" data-tab="matrix">
+          <div class="undefined">
+            <p>matrizen</p>
+            <p>zeige alle Matrizen und Matrix items und funktionen für aktunement etc.</p>
+          </div>
+          {{#each actor.itemTypes.matrix}}
+            <div class="item-id item-name__card" data-uuid="{{uuid}}">
+              {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
             </div>
-            <div class="tab tab__elementalist" data-tab="spell-elementalist-tab" data-group="spells">
-                <div class="undefined">
-                    <p>Elementalist Zauber</p>
-                    <p>zeige alle Elementaristen Zauber, spellKnacks und binding secrets</p>
-                </div>
-                {{#each actor.itemTypes.spell}}
-                <div class="item-id item-name__card" data-item-id="{{_id}}">
-                    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
-                </div>
-                {{/each}}
-            </div>
-            <div class="tab tab__illusionist" data-tab="spell-illusionist-tab" data-group="spells">
-                <div class="undefined">
-                    <p>illusionist Zauber</p>
-                    <p>zeige alle illusionist Zauber, spellKnacks und binding secrets</p>
-                </div>
-                {{#each actor.itemTypes.spell}}
-                <div class="item-id item-name__card" data-item-id="{{_id}}">
-                    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
-                </div>
-                {{/each}}
-            </div>
-            <div class="tab tab__nethermancer" data-tab="spell-nethermancer-tab" data-group="spells">
-                <div class="undefined">
-                    <p>nethermancer Zauber</p>
-                    <p>zeige alle nethermancer Zauber, spellKnacks und binding secrets</p>
-                </div>
-                {{#each actor.itemTypes.spell}}
-                <div class="item-id item-name__card" data-item-id="{{_id}}">
-                    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
-                </div>
-                {{/each}}
-            </div>
-            <div class="tab tab__shaman" data-tab="spell-shaman-tab" data-group="spells">
-                <div class="undefined">
-                    <p>shaman Zauber</p>
-                    <p>zeige alle shaman Zauber, spellKnacks und binding secrets</p>
-                </div>
-                {{#each actor.itemTypes.spell}}
-                <div class="item-id item-name__card" data-item-id="{{_id}}">
-                    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
-                </div>
-                {{/each}}
-            </div>
-            <div class="tab tab__wizard" data-tab="spell-wizard-tab" data-group="spells">
-                <div class="undefined">
-                    <p>wizard Zauber</p>
-                    <p>zeige alle wizard Zauber, spellKnacks und binding secrets</p>
-                </div>
-                {{#each actor.itemTypes.spell}}
-                <div class="item-id item-name__card" data-item-id="{{_id}}">
-                    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
-                </div>
-                {{/each}}
-            </div>
+          {{/each}}
         </div>
+
+        <!-- all spells -->
+        <div class="tab {{tabsSpells.all.cssClass}}" data-group="spellsContent" data-tab="all">
+          <div class="undefined">
+            <p>Alle Zauber</p>
+            <p>Zeige alle Zauber, spellKnacks und binding secrets</p>
+          </div>
+          {{#each actor.itemTypes.spell}}
+            <div class="item-id item-name__card" data-uuid="{{uuid}}">
+              {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
+            </div>
+          {{/each}}
+        </div>
+
+        <!-- spells by spellcasting discipline -->
+        {{#each tabsSpells as |tab|}}
+          {{#unless (or (eq tab.id "matrix") (eq tab.id "all"))}}
+            <div class="tab {{tab.cssClass}}" data-group="spellsContent" data-tab="{{tab.id}}">
+              <div class="undefined">
+                <p>{{tab.label}}</p>
+                <p>zeige alle {{tab.label}} Zauber, spellKnacks und binding secrets</p>
+              </div>
+              {{#each @root/actor.itemTypes.spell as |spell| }}
+                {{#if (eq spell.system.spellcastingType ../id)}}
+                  <div class="item-id item-name__card" data-uuid="{{spell.uuid}}">
+                    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
+                  </div>
+                {{/if}}
+              {{/each}}
+            </div>
+          {{/unless}}
+        {{/each}}
+
+      </div>
     </div>
-</div>
+  </div>
 </section>

--- a/templates/actor/actor-tabs/talents.hbs
+++ b/templates/actor/actor-tabs/talents.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="talents-tab">
+<section class="tab {{tabs.talents.cssClass}}" data-group="sheet" data-tab="talents">
 <div>
     <div class="ability-card__grid--container font__bold text-break__auto">
         <div class="ability-card__grid--item"></div>

--- a/templates/item/item-partials/item-description.hbs
+++ b/templates/item/item-partials/item-description.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="item-sheet" data-tab="general-tab">
+<section class="tab {{tabs.general.cssClass}}" data-group="sheet" data-tab="general">
     {{#if (eq item.type "armor") }}
     {{> "systems/ed4e/templates/item/item-partials/item-details/descriptions/item-description-armor.hbs"}}
     {{/if}}

--- a/templates/item/item-partials/item-details.hbs
+++ b/templates/item/item-partials/item-details.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="item-sheet" data-tab="details-tab">
+<section class="tab {{tabs.details.cssClass}}" data-group="sheet" data-tab="details">
     {{formField systemFields.edid name="system.edid" hint=(localize "ED.Data.Item.Hints.edid") value=item.system.edid localize=true}}
 
     {{#if (eq item.type "armor") }}

--- a/templates/item/item-partials/item-details/item-effects.hbs
+++ b/templates/item/item-partials/item-details/item-effects.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="item-sheet" data-tab="effects-tab">
+<section class="tab {{tabs.effects.cssClass}}" data-group="sheet" data-tab="effects">
   <div id="effects-information-item">
     <p>effecte</p>
     <p>embedded items</p>

--- a/templates/item/item-partials/item-details/other-tabs/discipline-advancement.hbs
+++ b/templates/item/item-partials/item-details/other-tabs/discipline-advancement.hbs
@@ -1,119 +1,107 @@
-<section class="tab {{tab.cssClass}}" data-group="item-sheet" data-tab="advancement-tab">
-<div id="advancement-information-class-item" class="advancement__level">
+<section class="tab {{tabs.advancement.cssClass}}" data-group="sheet" data-tab="advancement">
+  <div id="advancement-information-class-item" class="advancement__level">
 
-  <!-- Button controls -->
-  <div class="item-controls flexrow">
-    <a class="advancement__title class__add-level" data-action="addClassLevel" data-type="add-class-level" title="{{localize "X-Levels"}}">
-      <b>{{localize "ED.Item.Discipline.addLevel"}}</b>
-      <i class="fas fa-plus"></i>
-    </a>
-    <a class="item-control class__delete-level text-align-middle" data-action="deleteClassLevel"  title="{{localize "X-Delete-Item"}}"
-       data-drop-function="delete-pool-ability">
-      <b>{{localize "ED.Item.Discipline.deleteLevel"}}</b>
-      <i class="fas fa-trash" data-drop-function="delete-pool-ability"></i>
-    </a>
-  </div>
+    <!-- Content -->
+    <section class="content flexcol">
 
-  <!-- Content -->
-  <section class="content flexrow">
-
-    <div class="advancement__navigator">
-      <nav class="item-advancement-tabs flexcol" data-group="advancement">
-        <ul class="no-bullets">
-          <li>
-            <a data-tab="item-advancement-options-pools" data-group="advancement">
-              {{localize "ED.Item.Discipline.optionalAbilities"}}
-            </a>
-          </li>
-
-
-
-          {{#each item.system.advancement.levels}}
-            <li>
-              <a data-tab="item-advancement-level-tab-{{this.level}}" data-group="advancement">
-                {{localize "ED.Item.Discipline.circle" circle=this.level}}
-              </a>
-            </li>
-          {{/each}}
-        </ul>
-      </nav>
-    </div>
-
-    <div class="advancement__content item-advancement-body">
-      <div id="ability-list"  class="tab advancement-options-pools flexcol" data-group="advancement" data-tab="item-advancement-options-pools">
-        {{#each item.system.advancement.abilityOptions}}
-        <div class="{{@key}}-abilities">
-          <div class="form-group {{@key}}-pool">
-            <label>{{lookup @root.config.tier @key}}</label>
-            <div class="form-fields">
-              <document-tags name="system.advancement.abilityOptions.{{@key}}" value="{{ed-commaList this}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
-            </div>
-            {{!-- <p class="advancement-hint">{{localize (concat "ED.Item.Discipline.talentOptionsForTier " @key)}}</p> --}}
-          </div>
-        </div>
+      <nav class="classAdvancements-tabs tabs scrollable">
+        {{#each tabs.classAdvancements as |tab|}}
+          <a class="{{tab.cssClass}}" data-action="tab" data-group="{{tab.group}}" data-tab="{{tab.id}}"
+             {{#if tab.tooltip}}data-tooltip="{{tab.tooltip}}"{{/if}}>
+            {{#if tab.icon}}<i class="{{tab.icon}}"></i>{{/if}}
+            {{#if tab.label}}<label>{{localize tab.label circle=tab.level}}</label>{{/if}}
+          </a>
         {{/each}}
+      </nav>
+
+      <!-- Button controls -->
+      <div class="item-controls flexrow">
+        <a class="advancement__title class__add-level" data-action="addClassLevel" data-type="add-class-level" title="{{localize "X-Levels"}}">
+          <b>{{localize "ED.Item.Discipline.addLevel"}}</b>
+          <i class="fas fa-plus"></i>
+        </a>
+        <a class="item-control class__delete-level text-align-middle" data-action="deleteClassLevel"  title="{{localize "X-Delete-Item"}}"
+           data-drop-function="delete-pool-ability">
+          <b>{{localize "ED.Item.Discipline.deleteLevel"}}</b>
+          <i class="fas fa-trash" data-drop-function="delete-pool-ability"></i>
+        </a>
       </div>
 
-      <!-- Level Contents -->
-
-      {{#each item.system.advancement.levels}}
-        <div id="level-{{this.level}}" class="tab item-id advancement-level" name="system.advancement.level.{{@index}}.id"
-             data-tab="item-advancement-level-tab-{{this.level}}" data-group="advancement" data-value="{{@index}}" data-level-index="{{@index}}"
-             data-level="{{this.level}}">
-
-          <!-- Level Number -->
-          <div class="title-level-number">
-            {{formField this.schema.fields.level name=(concat "system.advancement.levels." @index ".level") value=this.level readonly=true hint="" localize=true}}
-          </div>
-
-          <!-- Tier -->
-          {{formField this.schema.fields.tier name=(concat "system.advancement.levels." @index ".tier") value=this.tier required=true}}
-
-          <!-- Resource Step -->
-          {{formField this.schema.fields.resourceStep name=(concat "system.advancement.levels." @index ".resourceStep") value=this.resourceStep required=true}}
-
-          <!-- Class Talents -->
-          <div class="form-group class-abilities">
-            <label>{{localize "X-Talents"}}</label>
-            <div class="form-fields">
-              <document-tags name="system.advancement.levels.{{@index}}.abilities.class" value="{{ed-commaList this.abilities.class}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
+      <div class="advancement__content item-advancement-body">
+        <div id="ability-list"  class="tab {{tabs.classAdvancements.options.cssClass}} advancement-options-pools flexcol" data-group="classAdvancements" data-tab="options">
+          {{#each item.system.advancement.abilityOptions}}
+            <div class="{{@key}}-abilities">
+              <div class="form-group {{@key}}-pool">
+                <label>{{lookup @root.config.tier @key}}</label>
+                <div class="form-fields">
+                  <document-tags name="system.advancement.abilityOptions.{{@key}}" value="{{ed-commaList this}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
+                </div>
+                {{!-- <p class="advancement-hint">{{localize (concat "ED.Item.Discipline.talentOptionsForTier " @key)}}</p> --}}
+              </div>
             </div>
-            <p class="advancement-hint">{{localize "ED.Item.Discipline.disciplineTalents"}}</p>
-          </div>
-
-
-          <!-- Free Abilities -->
-          <div class="form-group free-abilities">
-            <label>{{localize "X-Free"}}</label>
-            <div class="form-fields">
-              <document-tags name="system.advancement.levels.{{@index}}.abilities.free" value="{{ed-commaList this.abilities.free}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
-            </div>
-            <p class="advancement-hint">{{localize "X-Abilities you get for free"}}</p>
-          </div>
-
-          <!-- Special Abilities -->
-          <div class="form-group special-abilities">
-            <label>{{localize "X-Special"}}</label>
-            <div class="form-fields">
-              <document-tags name="system.advancement.levels.{{@index}}.abilities.special" value="{{ed-commaList this.abilities.special}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
-            </div>
-            <p class="advancement-hint">{{localize "X-Special abilities you get here"}}</p>
-          </div>
-
-          <!-- Effects -->
-          <div class="form-group class-effects">
-            <label>{{localize "X-Effects"}}</label>
-            <div class="form-fields">
-              <document-tags name="system.advancement.levels.{{@index}}.effects" value="{{ed-commaList this.effects}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
-            </div>
-            <p class="advancement-hint">{{localize "X-Effects that are applied automatically when reaching this circle"}}</p>
-          </div>
-
+          {{/each}}
         </div>
-      {{else}}
-        {{localize "X-No levels added yet. Click the plus sign above to add some. Go ahead, just try. You can do it!"}}
-      {{/each}}
-    </div>
-  </section>
-</div>
+
+        <!-- Level Contents -->
+
+        {{#each item.system.advancement.levels}}
+          <div id="level-{{this.level}}" class="tab {{lookup (lookup @root/tabs.classAdvancements (concat "level" this.level)) "cssClass"}} item-id advancement-level" name="system.advancement.level.{{@index}}.id"
+               data-tab="level{{this.level}}" data-group="classAdvancements" data-value="{{@index}}" data-level-index="{{@index}}"
+               data-level="{{this.level}}">
+
+            <!-- Level Number -->
+            <div class="title-level-number">
+              {{formField this.schema.fields.level name=(concat "system.advancement.levels." @index ".level") value=this.level readonly=true hint="" localize=true}}
+            </div>
+
+            <!-- Tier -->
+            {{formField this.schema.fields.tier name=(concat "system.advancement.levels." @index ".tier") value=this.tier required=true}}
+
+            <!-- Resource Step -->
+            {{formField this.schema.fields.resourceStep name=(concat "system.advancement.levels." @index ".resourceStep") value=this.resourceStep required=true}}
+
+            <!-- Class Talents -->
+            <div class="form-group class-abilities">
+              <label>{{localize "X-Talents"}}</label>
+              <div class="form-fields">
+                <document-tags name="system.advancement.levels.{{@index}}.abilities.class" value="{{ed-commaList this.abilities.class}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
+              </div>
+              <p class="advancement-hint">{{localize "ED.Item.Discipline.disciplineTalents"}}</p>
+            </div>
+
+
+            <!-- Free Abilities -->
+            <div class="form-group free-abilities">
+              <label>{{localize "X-Free"}}</label>
+              <div class="form-fields">
+                <document-tags name="system.advancement.levels.{{@index}}.abilities.free" value="{{ed-commaList this.abilities.free}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
+              </div>
+              <p class="advancement-hint">{{localize "X-Abilities you get for free"}}</p>
+            </div>
+
+            <!-- Special Abilities -->
+            <div class="form-group special-abilities">
+              <label>{{localize "X-Special"}}</label>
+              <div class="form-fields">
+                <document-tags name="system.advancement.levels.{{@index}}.abilities.special" value="{{ed-commaList this.abilities.special}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
+              </div>
+              <p class="advancement-hint">{{localize "X-Special abilities you get here"}}</p>
+            </div>
+
+            <!-- Effects -->
+            <div class="form-group class-effects">
+              <label>{{localize "X-Effects"}}</label>
+              <div class="form-fields">
+                <document-tags name="system.advancement.levels.{{@index}}.effects" value="{{ed-commaList this.effects}}" placeholder="{{localize "X-No abilities added yet. You can do it by just dragging and dropping them onto this field"}}"></document-tags>
+              </div>
+              <p class="advancement-hint">{{localize "X-Effects that are applied automatically when reaching this circle"}}</p>
+            </div>
+
+          </div>
+        {{else}}
+          {{localize "X-No levels added yet. Click the plus sign above to add some. Go ahead, just try. You can do it!"}}
+        {{/each}}
+      </div>
+    </section>
+  </div>
 </section>

--- a/templates/item/item-partials/item-details/other-tabs/threads.hbs
+++ b/templates/item/item-partials/item-details/other-tabs/threads.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}} scrollable" data-group="item-sheet" data-tab="thread-tab">
+<section class="tab {{tabs.thread.cssClass}} scrollable" data-group="sheet" data-tab="thread">
   {{#if isGM}}
     <!-- Button controls -->
   <div class="item-controls flexrow">
@@ -17,7 +17,7 @@
   <!-- basic information -->
   <fieldset>
     <div>
-      <divc class="undefined">
+      <div class="undefined">
         is GM = {{isGM}}
       </div>
       
@@ -61,19 +61,19 @@
     <button data-action="itemHistoryCheck" title="{{localize "ED.ToolTips.itemHistoryCheck"}}">
       <span>
         <b>{{localize "ED.Item.PhysicalItems.itemHistoryCheck"}}</b>
-        <i class="fas fa-history"></i>
+        <i class="fas {{config.icons.itemHistory}}"></i>
       </span>
     </button>
     <button data-action="researchCheck" title="{{localize "ED.ToolTips.researchCheck"}}">
       <span>
         <b>{{localize "ED.Item.PhysicalItems.researchCheck"}}</b>
-        <i class="fas fa-search"></i>
+        <i class="fas {{config.icons.research}}"></i>
       </span>
     </button>
     <button data-action="weaveThreadCheck" title="{{localize "ED.ToolTips.weaveThreadCheck"}}">
       <span>
         <b>{{localize "ED.Item.PhysicalItems.weaveThreadCheck"}}</b>
-        <i class="fas fa-connectdevelop"></i>
+        <i class="fas {{config.icons.threadWeaving}}"></i>
       </span>
     </button>
   </div>


### PR DESCRIPTION
Implement Foundry native tab handling. It is a big PR but the only logical split would be by document type which doesnt make difference, sorry :(
It is the same idea for everything though, just needed to accommodate the different subclasses.
No native handling for multiple tab groups, so implement this manually.
For spell tabs, the spells system property `spellcastingType` needed to be made required and non nullable.