### PR TITLE
Fix EAE change key filtering and add localization

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -247,7 +247,7 @@
         "takeDamageTitle":                                          "Nimm den Schaden für deinen Charakter"
       },
       "Flavor": {
-        "takeDamage":                                               "{actor} nimmt {amount} Schaden",  
+        "takeDamage":                                               "{actor} nimmt {amount} Schaden",
         "takeStrainDamage":                                         "{actor} nimmt {amount} Überanstrengungsschaden durch {ability}",
         "jumpUp":                                                   "{sourceActor} springt auf mit Stufe {step}",
         "knockdownTest":                                            "{sourceActor} versucht dem Niederschlag zu widerstehen {step}",
@@ -436,13 +436,13 @@
         "threadWeaving": "Fadenweben"
       },
       "RecoveryProperty": {
-                "noRecovery":                                       "Keine Erholung",
-                "arbitrary":                                        "Willkürlich",
-                "arbitraryAndAttribute":                            "Willkürlich und Attribut",
-                "arbitraryOptionalAttribute":                       "Willkürlich und/oder Attribut",
-                "abilityStep":                                      "Fähigkeitsstufe",
-                "noHealing":                                        "Keine Heilung"
-            },
+        "noRecovery":                                       "Keine Erholung",
+        "arbitrary":                                        "Willkürlich",
+        "arbitraryAndAttribute":                            "Willkürlich und Attribut",
+        "arbitraryOptionalAttribute":                       "Willkürlich und/oder Attribut",
+        "abilityStep":                                      "Fähigkeitsstufe",
+        "noHealing":                                        "Keine Heilung"
+      },
       "ScalarTimePeriods": {
         "turn":                                                     "Zug",
         "round":                                                    "Runde",
@@ -540,17 +540,97 @@
       },
       "Actor": {
         "Hints": {
-          "isMob":                                        "Dieser Akteur benutzt Wunden anstatt Schaden",
-          "challengeRate":                                "Herausforderungsrate",
+          "attributes":                                   "Die Attribute des Charakters",
+          "attributeValue":                               "Der Wert des Attributs",
+          "challenge":                                    "Wie herausfordernd bin ich?",
+          "challengeRate":                                "Eine Beschreibung der Herausforderung als Berechnung",
+          "characteristics":                              "Werte die den Charakter beschreiben, wie Verteidung, Gesundheit oder Rüstung",
+          "description":                                  "Eine Beschreibung des Charakters",
+          "descriptionValue":                             "Der Text darüber wer ich bin",
+          "devotion":                                     "Die verfügbaren Weihpunkte die dazugehörige Stufe",
+          "devotionMax":                                  "Maximale Anzahl an insgesamt verfügbaren Weihepunkten",
+          "devotionStep":                                 "Die Stufe die verwendet wird wenn Weihpunkte ausgegeben werden",
+          "durabilityBonus":                              "Extra Bonus auf Unempfindlichkeit",
+          "encumbrance":                                  "Berechnung der Traglast und damit verbundene Effekte",
+          "encumbranceBonus":                             "Bonus auf den Stärkewert zur Bestimmung der Traglast",
+          "encumbranceMax":                               "Die maximale Last die getragen werden kann ohne negative Effekte",
+          "globalBonuses":                                "Allgemeine globale Wertänderungen",
+          "healthRate":                                   "Gesundheitswerte für Token Module, nicht system-relevant",
+          "initiative":                                   "Die Stufe die ich in der Initiative würfle",
+          "isMob":                                        "Hier werden Wunden anstatt Schaden verwendet",
+          "karma":                                        "Die verfügbaren Karmapunkte und die dazugehörige Stufe",
+          "karmaMax":                                     "Maximale Anzahl an verfügbaren Karmapunkten pro Tag",
+          "karmaStep":                                    "Die Stufe die verwendet wird wenn Karmapunkte ausgegeben werden",
+          "singleBonuses":                                "Einzelne Wertänderungen ",
           "Characteristics":{
-            "recoveryTestsCurrent":                       "Aktuelle Erholungsproben"
+            "armor":                                      "Werte die von erlittenem Schaden abgezogen werden",
+            "armorValue":                                 "Der Wert dieser Rüstung",
+            "bloodMagic":                                 "Einflüsse auf die Gesundheit die durch Blutmagie verursacht werden",
+            "bloodMagicDamage":                           "Permanenter Schaden durch Blutmagie",
+            "bloodMagicWounds":                           "Permanente Wunden durch Blutmagie",
+            "damage":                                     "Die Anzahl an Schadenspunkten",
+            "damageStandard":                             "Normaler Schaden",
+            "damageStun":                                 "Schaden der nicht zum Tod führen kann",
+            "damageTotal":                                "Gesamter Schaden aus Standard und Betäubung",
+            "defenses":                                   "Werte die bestimme wie schwer es ist zu treffen",
+            "defenseValue":                               "Der Wert dieser Verteidigung",
+            "deathRating":                                "Wie viel Schaden kann ich nehmen bevor ich sterbe?",
+            "health":                                     "Werte die die Gesundheit des Charakters beschreiben",
+            "maxWounds":                                  "Die Anzahl an Wunden um den Mob zu besiegen",
+            "recoveryTestsCurrent":                       "Die aktuelle Anzahl an Erholungsproben für diesen Tag",
+            "recoveryTestsMax":                           "Die maximale Anzahl an Erholungsproben pro Tag",
+            "recoveryTestsResource":                      "Die Ressource die unter anderem für Erholungsproben verwendet wird",
+            "unconsciousRate":                            "Wie viel Schaden kann ich nehmen bevor ich bewusstlos werde?",
+            "stunRecoveryAvailable":                      "Kann Betäubungsschaden aktuell geheilt werden?",
+            "wounds":                                     "Anzahl der Wunden",
+            "woundThreshold":                             "Der Schaden der erlitten werden muss um eine Wunde zu verursachen"
           }
         },
         "Labels": {
-          "challengeRate":                                "Herausforderungsrate des Akteurs",
-          "isMob":                                        "Mob Regeln",
-          "Characteristics":{
-            "recoveryTestsCurrent":                       "Aktuelle Erholungsproben"
+          "attributes":                                   "Attribute",
+          "attributeValue":                               "Attribut Wert",
+          "challenge":                                    "Herausforderung",
+          "challengeRate":                                "Herausforderungsrate",
+          "characteristics":                              "Charakteristiken",
+          "description":                                  "Beschreibung",
+          "descriptionValue":                             "Beschreibungstext",
+          "devotion":                                     "Weihe",
+          "devotionMax":                                  "Maximale Weihepunkte",
+          "devotionStep":                                 "Weihe Stufe",
+          "durabilityBonus":                              "Unempfindlichkeitsbonus",
+          "encumbrance":                                  "Traglast",
+          "encumbranceBonus":                             "Traglast - Bonus",
+          "encumbranceMax":                               "Maximale Traglast",
+          "globalBonuses":                                "Globale Boni",
+          "healthRate":                                   "Gesundheitswerte",
+          "initiative":                                   "Initiative",
+          "isMob":                                        "Mob-Regeln",
+          "karma":                                        "Karma",
+          "karmaMax":                                     "Maximale Karmapunkte",
+          "karmaStep":                                    "Karma Stufe",
+          "singleBonuses":                                "Einzelne Boni",
+          "Characteristics": {
+            "armor":                                      "Rüstung",
+            "armorValue":                                 "Rüstungswert",
+            "bloodMagic":                                 "Blutmagie",
+            "bloodMagicDamage":                           "Blutmagie Schaden",
+            "bloodMagicWounds":                           "Blutmagie Wunden",
+            "damage":                                     "Schaden",
+            "damageStandard":                             "Normaler Schaden",
+            "damageStun":                                 "Betäubungsschaden",
+            "damageTotal":                                "Gesamtschaden",
+            "defenses":                                   "Verteidigung",
+            "defenseValue":                               "Verteidigungswert",
+            "deathRating":                                "Todesschwelle",
+            "health":                                     "Gesundheit",
+            "maxWounds":                                  "Mob: Max. Wunden",
+            "recoveryTestsCurrent":                       "Aktuelle Erholungsproben",
+            "recoveryTestsMax":                           "Maximale Erholungsproben",
+            "recoveryTestsResource":                      "Ressource - Erholungsproben",
+            "stunRecoveryAvailable":                      "Betäubungserholung verfügbar",
+            "unconsciousRate":                            "Bewusstlosigkeitsschwelle",
+            "wounds":                                     "Wunden",
+            "woundThreshold":                             "Wundschwelle"
           }
         }
       },
@@ -665,10 +745,10 @@
           },
           "edid":                                           "Eine ID mit der ein Item unabhängig vom Namen identifziert werden kann",
           "Equipment": {
-              "consumable":                               "Wird dieser Gegenstand bei der benutzung verbraucht?",
-              "ammunition":                                "Welcher Munitionstyp ist dieser Gegenstand?",
-              "bundleSize":                               "Wie viele Gegenstände gehören zu einem Bündel?"
-            },
+            "consumable":                               "Wird dieser Gegenstand bei der benutzung verbraucht?",
+            "ammunition":                                "Welcher Munitionstyp ist dieser Gegenstand?",
+            "bundleSize":                               "Wie viele Gegenstände gehören zu einem Bündel?"
+          },
           "Knack":{
             "isPathKnack":                                  "Ist dieser Kniff ein Pfadkniff?",
             "standardEffect":                               "Wird der Effekt des Ursprungtalentes mit ausgelöst?",
@@ -741,7 +821,7 @@
               "calculated":                                 "Wurde dieser Gegenstand bereits mit dem Multipliktor des Namensgebers berechnet?",
               "multiplier":                                 "Der Multiplikator des Namensgebers"
             }
-            
+
           },
           "PoisonDisease": {
             "damageStep":                                   "Schadensstufe des Giftes/der Krankheit",
@@ -893,10 +973,10 @@
           },
           "edid":                                           "ED-ID",
           "Equipment": {
-              "consumable":                               "Verbrauchsgegenstand?",
-              "ammunition":                                "Munitionstyp",
-              "bundleSize":                               "Bündelgröße"
-            },
+            "consumable":                               "Verbrauchsgegenstand?",
+            "ammunition":                                "Munitionstyp",
+            "bundleSize":                               "Bündelgröße"
+          },
           "Knack":{
             "isPathKnack":                                  "Pfad Kniff",
             "standardEffect":                               "Standard Effekt",
@@ -1054,6 +1134,7 @@
       },
       "Other": {
         "Hints": {
+          "movement":                                    "Die Geschwindigkeiten der verschiedenen Fortbewegungsarten",
           "AreaUnit": {
             "angle":                                        "Der Winkel des Bereichs",
             "areaTyp":                                      "Die geometrische Form des Bereichs",
@@ -1121,6 +1202,7 @@
           }
         },
         "Labels": {
+          "movement":                                    "Bewegung",
           "AreaUnit": {
             "angle":                                        "Winkel",
             "areaTyp":                                      "Typ",
@@ -1298,7 +1380,7 @@
         "disciplineTalents":                      "Disziplin Talente",
         "questorDevotion":                        "Questor Weihekraft",
         "availableRanks":                         "Verfügbare Ränge",
-        "abilities":                              "Wähle deine Fähigkeiten",    
+        "abilities":                              "Wähle deine Fähigkeiten",
         "chooseNamegiver":                        "Wähle einen Namensgeber",
         "discipline":                             "Wähle eine Disziplin",
         "questor":                                "Wähle einen Questor",
@@ -1309,7 +1391,7 @@
         "chooseClassRules":                       "Wähle entweder eine Disziplin aus den Optionen oder schalte um auf Questoren um dort ein Questor zu werden.",
         "chooseSpellsRules":                      "Wähle Zauber aus den unten aufgeführten Listen aus.<br>Es können Zauber gleich der Wahrnehmungsstufe gewählt werden.<br> Kreis 1 Zauber kosten 1 Punkt, Kreis 2 Zauber kosten 2.",
         "chooseSkillsRules":                      "Wähle Fähigkeiten aus den unten aufgeführten Listen aus.<br>Es muss mindestens ein Kunsthandwerk und mindestens zwei Ränge in Wissensfertigkeiten gewählt werden.",
-        "chooseLanguagesRules":                   "Wähle die Sprachen aus die der Charakter spricht und liest/schreibt.<br>Es können maximal so viele Sprachen gewählt werden wie die Ränge in Lesen/Schreiben und Fremdsprachen entsprechen (redo this Text)",	
+        "chooseLanguagesRules":                   "Wähle die Sprachen aus die der Charakter spricht und liest/schreibt.<br>Es können maximal so viele Sprachen gewählt werden wie die Ränge in Lesen/Schreiben und Fremdsprachen entsprechen (redo this Text)",
         "chooseAttributesRules":                  "Verteile die freien Attributspunkte auf die sechs Attribute. Nicht verteilte Attributespunkte werden 1:1 als zusätztliche Karmapunkte umgewandelt.<br>Unter Vorschau sind die Werteänderungen zu sehen wenn das jeweilige Attribut erhöht oder gesenkt wird."
       },
       "Configs": {
@@ -1442,16 +1524,16 @@
       "physical":                                 "Körperlicher Schaden"
     },
     "Documents": {
-        "ActorSheetEdCharacter":                                "Charakterbogen",
-        "ActorSheetEdCreature":                                 "Kreaturen-Bogen",
-        "ActorSheetEdDragon":                                   "Drachen-Bogen",
-        "ActorSheetEdGroup":                                    "Gruppen-Bogen",
-        "ActorSheetEdHorror":                                   "Dämonen-Bogen",
-        "ActorSheetEdLoot":                                     "Schatz-Bogen",
-        "ActorSheetEdNpc":                                      "NSC-Bogen",
-        "ActorSheetEdSpirit":                                   "Geister-Bogen",
-        "ActorSheetEdTrap":                                     "Fallen-Bogen",
-        "ActorSheetEdVehicle":                                  "Transportmittel-Bogen"
+      "ActorSheetEdCharacter":                                "Charakterbogen",
+      "ActorSheetEdCreature":                                 "Kreaturen-Bogen",
+      "ActorSheetEdDragon":                                   "Drachen-Bogen",
+      "ActorSheetEdGroup":                                    "Gruppen-Bogen",
+      "ActorSheetEdHorror":                                   "Dämonen-Bogen",
+      "ActorSheetEdLoot":                                     "Schatz-Bogen",
+      "ActorSheetEdNpc":                                      "NSC-Bogen",
+      "ActorSheetEdSpirit":                                   "Geister-Bogen",
+      "ActorSheetEdTrap":                                     "Fallen-Bogen",
+      "ActorSheetEdVehicle":                                  "Transportmittel-Bogen"
     },
     "Item": {
       "Ability": {
@@ -1662,10 +1744,10 @@
         "unarmedCombatHint":                                    "Identifiziert die Fähigkeit die für den Waffenlosen Kampf verwendet wird"
       },
       "Hint": {
-          "enforceLivingArmor":                               "Prüft ob ausschließlich legendige Rüstung getragen werden kann."
+        "enforceLivingArmor":                               "Prüft ob ausschließlich legendige Rüstung getragen werden kann."
       },
       "Label": {
-          "enforceLivingArmor":                               "Lebendig Rüstungs Prüfung"
+        "enforceLivingArmor":                               "Lebendig Rüstungs Prüfung"
       },
       "LpTracking": {
         "allTalents": "Alle Talente für Kreisaufstieg",

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -23,10 +23,12 @@ export function buildSelectOptionsFromModel( fields ) {
     if( field.fields ) {
       options.push( ...buildSelectOptionsFromModel( field.fields ) );
     } else {
+      const groupName = field.parent?.label || field.parent?.name;
+      const group = groupName === "system" ? "" : game.i18n.localize( groupName ) || "";
       const option = {
         value:    field.fieldPath,
         label:    game.i18n.localize( field.label ),
-        group:    game.i18n.localize( field.parent?.label || field.parent?.name ) || "",
+        group:    group,
         disabled: false,
         selected: false,
         rule:     false,

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -30,6 +30,12 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
     this._EAE_EXCLUDE_KEYS = [];
   }
 
+  static initEAE() {
+    for ( const cls of foundry.utils.getParentClasses( this ) ) {
+      if ( cls._EAE_EXCLUDE_KEYS ) this._EAE_EXCLUDE_KEYS.push( ...cls._EAE_EXCLUDE_KEYS );
+    }
+  }
+
   constructor( data={}, options={} ) {
     super( data, options );
 

--- a/module/data/actor/pc.mjs
+++ b/module/data/actor/pc.mjs
@@ -21,11 +21,34 @@ export default class PcData extends NamegiverTemplate {
   static _systemType = "character";
 
   static {
-    /** @inheritdoc */
     this._EAE_EXCLUDE_KEYS = [
-      ...this._EAE_EXCLUDE_KEYS ?? [],
+      "system.attributes.dex.initialValue",
+      "system.attributes.str.initialValue",
+      "system.attributes.tou.initialValue",
+      "system.attributes.per.initialValue",
+      "system.attributes.wil.initialValue",
+      "system.attributes.cha.initialValue",
+      "system.attributes.dex.baseValue",
+      "system.attributes.str.baseValue",
+      "system.attributes.tou.baseValue",
+      "system.attributes.per.baseValue",
+      "system.attributes.wil.baseValue",
+      "system.attributes.cha.baseValue",
+      "system.attributes.dex.valueModifier",
+      "system.attributes.str.valueModifier",
+      "system.attributes.tou.valueModifier",
+      "system.attributes.per.valueModifier",
+      "system.attributes.wil.valueModifier",
+      "system.attributes.cha.valueModifier",
+      "system.attributes.dex.timesIncreased",
+      "system.attributes.str.timesIncreased",
+      "system.attributes.tou.timesIncreased",
+      "system.attributes.per.timesIncreased",
+      "system.attributes.wil.timesIncreased",
+      "system.attributes.cha.timesIncreased",
       "system.lp",
     ];
+    this.initEAE();
   }
 
   /* -------------------------------------------- */
@@ -65,7 +88,9 @@ export default class PcData extends NamegiverTemplate {
         step:     1,
         initial:  1,
         integer:  true,
-        positive: true
+        positive: true,
+        label:    this.labelKey( "attributeValue" ),
+        hint:     this.hintKey( "attributeValue" )
       } ),
       timesIncreased: new fields.NumberField( {
         required: true,
@@ -85,7 +110,8 @@ export default class PcData extends NamegiverTemplate {
         step:     1,
         initial:  0,
         integer:  true,
-        label:    "ED.General.durabilityBonus"
+        label:    this.labelKey( "durabilityBonus" ),
+        hint:     this.hintKey( "durabilityBonus" ),
       } ),
       lp: new foundry.data.fields.EmbeddedDataField(
         LpTrackingData,

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -25,7 +25,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(
       } ), {
         initialKeys:     CONFIG.ED4E.globalBonuses,
         initialKeysOnly: true,
-        label:           "ED.Attributes.globalBonuses"
+        label:           this.labelKey( "globalBonuses" ),
+        hint:            this.hintKey( "globalBonuses" ),
       } ),
       singleBonuses: new MappingField( new fields.SchemaField( {
         value: new fields.NumberField( {
@@ -38,7 +39,8 @@ export default class CommonTemplate extends ActorDataModel.mixin(
       } ), {
         initialKeys:     CONFIG.ED4E.singleBonuses,
         initialKeysOnly: true,
-        label:           "ED.Config.Eae"
+        label:           this.labelKey( "singleBonuses" ),
+        hint:            this.hintKey( "singleBonuses" ),
       } )
     } );
   }

--- a/module/data/actor/templates/description.mjs
+++ b/module/data/actor/templates/description.mjs
@@ -14,8 +14,12 @@ export default class ActorDescriptionTemplate extends SystemDataModel {
         value: new fields.HTMLField( {
           required: true, 
           nullable: true, 
-          label:    "ED.Description"
+          label:    "ED.Data.Actor.Labels.descriptionValue",
+          hint:     "ED.Data.Actor.Hints:descriptionValue",
         } ), 
+      }, {
+        label: "ED.Data.Actor.Labels.description",
+        hint:  "ED.Data.Actor.Hints:description",
       } )
     };
   }

--- a/module/data/actor/templates/movement.mjs
+++ b/module/data/actor/templates/movement.mjs
@@ -55,7 +55,8 @@ export default class MovementFields {
         } )
       },
       {
-        label: "ED.Item.Namegiver.movement"
+        label: "ED.Data.Other.Labels.movement",
+        hint:  "ED.Data.Other.Hints.movement"
       }
       )
     };

--- a/module/data/actor/templates/namegiver.mjs
+++ b/module/data/actor/templates/namegiver.mjs
@@ -10,6 +10,13 @@ const futils = foundry.utils;
  */
 export default class NamegiverTemplate extends SentientTemplate {
 
+  static {
+    this._EAE_EXCLUDE_KEYS = [
+      "system.languages",
+    ];
+    this.initEAE();
+  }
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/actor/templates/sentient.mjs
+++ b/module/data/actor/templates/sentient.mjs
@@ -9,6 +9,25 @@ import MappingField from "../../fields/mapping-field.mjs";
  */
 export default class SentientTemplate extends CommonTemplate {
 
+  static {
+    this._EAE_EXCLUDE_KEYS = [
+      "system.healthRate",
+      "system.isMob",
+      "system.condition",
+      "system.relations",
+      "system.characteristics.defenses.baseValue",
+      "system.characteristics.armor.baseValue",
+      "system.characteristics.recoveryTestsResource.stunRecoveryAvailable",
+      "system.health.damage.total",
+      "system.devotion.value",
+      "system.karma.value",
+      "system.karma.useAlways",
+      "system.karma.freeAttributePoints",
+      "system.encumbrance.value",
+      "system.encumbrance.status",
+    ];
+    this.initEAE();
+  }
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -35,7 +54,8 @@ export default class SentientTemplate extends CommonTemplate {
       } ), {
         initialKeys:     ED4E.attributes,
         initialKeysOnly: true,
-        label:           "ED.Attributes.attributes"
+        label:           this.labelKey( "attributes" ),
+        hint:            this.hintKey( "attributes" )
       } ),
       healthRate: new fields.SchemaField( {
         value: new fields.NumberField( {
@@ -52,6 +72,9 @@ export default class SentientTemplate extends CommonTemplate {
           initial:  0,
           integer:  true,
         } )
+      }, {
+        label: this.labelKey( "healthRate" ),
+        hint:  this.hintKey( "healthRate" ),
       } ),
       characteristics: new fields.SchemaField( {
         defenses: new MappingField( new fields.SchemaField( {
@@ -70,11 +93,13 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
+            label:    this.labelKey( "Characteristics.defenseValue" ),
+            hint:     this.hintKey( "Characteristics.defenseValue" )
           } ),
         } ), {
           initialKeys:     [ "physical", "mystical", "social" ],
           initialKeysOnly: true,
-          label:           "ED.Actor.Characteristics.defenses"
+          label:           this.labelKey( "Characteristics.defenses" )
         } ),
         armor: new MappingField( new fields.SchemaField( {
           baseValue: new fields.NumberField( {
@@ -92,11 +117,14 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
+            label:    this.labelKey( "Characteristics.armorValue" ),
+            hint:     this.hintKey( "Characteristics.armorValue" )
           } ) ,
         } ), {
           initialKeys:     [ "physical", "mystical" ],
           initialKeysOnly: true,
-          label:           "ED.Actor.Characteristics.armor"
+          label:           this.labelKey( "Characteristics.armor" ),
+          hint:            this.hintKey( "Characteristics.armor" ),
         } ),
         health: new fields.SchemaField( {
           death: new fields.NumberField( {
@@ -106,7 +134,8 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
-            label:    "ED.Actor.Characteristics.deathRate"
+            label:    this.labelKey( "Characteristics.deathRating" ),
+            hint:     this.hintKey( "Characteristics.deathRating" )
           } ),
           unconscious: new fields.NumberField( {
             required: true,
@@ -115,7 +144,8 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
-            label:    "ED.Actor.Characteristics.unconsciousRate"
+            label:    this.labelKey( "Characteristics.unconsciousRate" ),
+            hint:     this.hintKey( "Characteristics.unconsciousRate" )
           } ),
           woundThreshold: new fields.NumberField( {
             required: true,
@@ -124,7 +154,8 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
-            label:    "ED.Actor.Characteristics.woundThreshold"
+            label:    this.labelKey( "Characteristics.woundThreshold" ),
+            hint:     this.hintKey( "Characteristics.woundThreshold" )
           } ),
           bloodMagic: new fields.SchemaField( {
             damage: new fields.NumberField( {
@@ -134,7 +165,8 @@ export default class SentientTemplate extends CommonTemplate {
               step:     1,
               initial:  0,
               integer:  true,
-              label:    "ED.Actor.Characteristics.unconsciousRate"
+              label:    this.labelKey( "Characteristics.bloodMagicDamage" ),
+              hint:     this.hintKey( "Characteristics.bloodMagicDamage" )
             } ),
             wounds: new fields.NumberField( {
               required: true,
@@ -143,8 +175,12 @@ export default class SentientTemplate extends CommonTemplate {
               step:     1,
               initial:  0,
               integer:  true,
-              label:    "ED.Actor.Characteristics.unconsciousRate"
+              label:    this.labelKey( "Characteristics.bloodMagicWounds" ),
+              hint:     this.hintKey( "Characteristics.bloodMagicWounds" )
             } ),
+          }, {
+            label: this.labelKey( "Characteristics.bloodMagic" ),
+            hint:  this.hintKey( "Characteristics.bloodMagic" ),
           } ),
           damage: new fields.SchemaField( {
             standard: new fields.NumberField( {
@@ -154,7 +190,8 @@ export default class SentientTemplate extends CommonTemplate {
               step:     1,
               initial:  0,
               integer:  true,
-              label:    "ED.Actor.Characteristics.damageLethal"
+              label:    this.labelKey( "Characteristics.damageStandard" ),
+              hint:     this.hintKey( "Characteristics.damageStandard" ),
             } ),
             stun: new fields.NumberField( {
               required: true,
@@ -163,7 +200,8 @@ export default class SentientTemplate extends CommonTemplate {
               step:     1,
               initial:  0,
               integer:  true,
-              label:    "ED.Actor.Characteristics.damageStun"
+              label:    this.labelKey( "Characteristics.damageStun" ),
+              hint:     this.hintKey( "Characteristics.damageStun" ),
             } ),
             total: new fields.NumberField( {
               required: true,
@@ -172,12 +210,14 @@ export default class SentientTemplate extends CommonTemplate {
               step:     1,
               initial:  0,
               integer:  true,
-              label:    "ED.Actor.Characteristics.damage"
+              label:    this.labelKey( "Characteristics.damageTotal" ),
+              hint:     this.hintKey( "Characteristics.damageTotal" ),
             } )
           }, {
             required: true,
             nullable: false,
-            label:    "ED.Actor.Characteristics.damage"
+            label:    this.labelKey( "Characteristics.damage" ),
+            hint:     this.hintKey( "Characteristics.damage" ),
           } ),
           wounds: new fields.NumberField( {
             required: true,
@@ -186,16 +226,20 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
-            label:    "ED.Actor.Characteristics.wounds"
+            label:    this.labelKey( "Characteristics.wounds" ),
+            hint:     this.hintKey( "Characteristics.wounds" )
           } ),
           maxWounds: new fields.NumberField( {
             required: true,
             nullable: true,
             min:      0,
             integer:  true,
-            label:    "ED.Actor.Data.Label.maxWounds",
-            hint:     "ED.Actor.Data.Hint.maxWounds"
+            label:    this.labelKey( "Characteristics.maxWounds" ),
+            hint:     this.hintKey( "Characteristics.maxWounds" ),
           } ),
+        }, {
+          label: this.labelKey( "Characteristics.health" ),
+          hint:  this.hintKey( "Characteristics.health" ),
         } ),
         recoveryTestsResource: new fields.SchemaField( {
           max: new fields.NumberField( {
@@ -205,7 +249,8 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
-            label:    "ED.Actor.Characteristics.recoveryTestsDaily"
+            label:    this.labelKey( "Characteristics.recoveryTestsMax" ),
+            hint:     this.hintKey( "Characteristics.recoveryTestsMax" )
           } ),
           value: new fields.NumberField( {
             required: true,
@@ -214,22 +259,30 @@ export default class SentientTemplate extends CommonTemplate {
             step:     1,
             initial:  0,
             integer:  true,
-            label:    "ED.Data.Actor.Labels.Characteristics.recoveryTestsCurrent"
+            label:    this.labelKey( "Characteristics.recoveryTestsCurrent" ),
+            hint:     this.hintKey( "Characteristics.recoveryTestsCurrent" )
 
           } ),
           stunRecoveryAvailable: new fields.BooleanField( {
             required: true,
             initial:  true,
-            label:    "ED.Actor.Characteristics.recoveryTestsStun"
+            label:    this.labelKey( "Characteristics.stunRecoveryAvailable" ),
+            hint:     this.hintKey( "Characteristics.stunRecoveryAvailable" )
           } ),
+        }, {
+          label: this.labelKey( "Characteristics.recoveryTestsResource" ),
+          hint:  this.hintKey( "Characteristics.recoveryTestsResource" ),
         } ),
         ...MovementFields.movement
+      }, {
+        label: this.labelKey( "characteristics" ),
+        hint:  this.hintKey( "characteristics" ),
       } ),
       isMob: new fields.BooleanField( {
         required: true,
         initial:  false,
-        label:    "ED.Data.Actor.Labels.isMob",
-        hint:     "ED.Data.Actor.Hints.isMob"
+        label:    this.labelKey( "isMob" ),
+        hint:     this.hintKey( "isMob" ),
       } ),
       challenge: new fields.SchemaField( {
         rate: new fields.NumberField( {
@@ -239,8 +292,12 @@ export default class SentientTemplate extends CommonTemplate {
           step:     1,
           initial:  0,
           integer:  true,
-          label:    "ED.Data.Actor.Labels.challengeRate"
+          label:    this.labelKey( "challengeRate" ),
+          hint:     this.hintKey( "challengeRate" )
         } ),
+      }, {
+        label: this.labelKey( "challenge" ),
+        hint:  this.hintKey( "challenge" ),
       } ),
       condition: new fields.SchemaField( {
         aggressiveAttack: new fields.BooleanField( {
@@ -341,7 +398,8 @@ export default class SentientTemplate extends CommonTemplate {
           step:     1,
           initial:  0,
           integer:  true,
-          label:    "ED.General.devotion.maximum"
+          label:    this.labelKey( "devotionMax" ),
+          hint:     this.hintKey( "devotionMax" )
         } ),
         step: new fields.NumberField( {
           required: true,
@@ -350,8 +408,12 @@ export default class SentientTemplate extends CommonTemplate {
           step:     1,
           initial:  3,
           integer:  true,
-          label:    "ED.General.devotion.step"
+          label:    this.labelKey( "devotionStep" ),
+          hint:     this.hintKey( "devotionStep" )
         } ),
+      }, {
+        label: this.labelKey( "devotion" ),
+        hint:  this.hintKey( "devotion" ),
       } ),
       encumbrance: new fields.SchemaField( {
         // current load / weight carried
@@ -369,7 +431,8 @@ export default class SentientTemplate extends CommonTemplate {
           min:      0,
           step:     1,
           initial:  0,
-          label:    "ED.General.carryingCapacity"
+          label:    this.labelKey( "encumbranceMax" ),
+          hint:     this.hintKey( "encumbranceMax" ),
         } ),
         // bonus value to strength value for determining max capacity
         bonus: new fields.NumberField( {
@@ -378,7 +441,8 @@ export default class SentientTemplate extends CommonTemplate {
           step:     1,
           initial:  0,
           integer:  true,
-          label:    "ED.General.carryingCapacityBonus"
+          label:    this.labelKey( "encumbranceBonus" ),
+          hint:     this.hintKey( "encumbranceBonus" ),
         } ),
         // encumbrance / overload status
         status: new fields.StringField( {
@@ -387,6 +451,9 @@ export default class SentientTemplate extends CommonTemplate {
           nullable: false,
           initial:  "notEncumbered"
         } )
+      }, {
+        label: this.labelKey( "encumbrance" ),
+        hint:  this.hintKey( "encumbrance" ),
       } ),
       initiative: new fields.NumberField( {
         required: true,
@@ -395,7 +462,8 @@ export default class SentientTemplate extends CommonTemplate {
         step:     1,
         initial:  0,
         integer:  true,
-        label:    "ED.General.Initiative"
+        label:    this.labelKey( "initiative" ),
+        hint:     this.hintKey( "initiative" ),
       } ),
       karma: new fields.SchemaField( {
         useAlways: new fields.BooleanField( {
@@ -419,7 +487,8 @@ export default class SentientTemplate extends CommonTemplate {
           step:     1,
           initial:  0,
           integer:  true,
-          label:    "ED.General.karma.maximum"
+          label:    this.labelKey( "karmaMax" ),
+          hint:     this.hintKey( "karmaMax" ),
         } ),
         step: new fields.NumberField( {
           required: true,
@@ -428,7 +497,8 @@ export default class SentientTemplate extends CommonTemplate {
           step:     1,
           initial:  4,
           integer:  true,
-          label:    "ED.General.karma.step"
+          label:    this.labelKey( "karmaStep" ),
+          hint:     this.hintKey( "karmaStep" ),
         } ),
         freeAttributePoints: new fields.NumberField( {
           required: false,
@@ -439,6 +509,9 @@ export default class SentientTemplate extends CommonTemplate {
           integer:  true,
           label:    "ED.General.freeAttributePoints"
         } ),
+      }, {
+        label: this.labelKey( "karma" ),
+        hint:  this.hintKey( "karma" ),
       } ),
       relations: new MappingField( new fields.SchemaField( {
         attitude: new fields.StringField( {


### PR DESCRIPTION
The automatically generated keys for Earthdawn Active Effects changes were not correctly filtered based on  `_EAE_EXCLUDE_KEYS`. Fixed.

Add localization for actor data fields that are present in the keys list, for a better idea of the looks.