### PR TITLE
chris-rework-knack-data-model-approach

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -328,6 +328,14 @@
         "throwing":                                                 "Wurfwaffen Fernkampf",
         "unarmed":                                                  "Unbewaffneter Nahkampf"
       },
+      "Constraints": {
+        "ability":                                                "Fähigkeit",
+        "attribute":                                              "Attribut",
+        "class":                                                  "Berufung",
+        "language":                                               "Sprache",
+        "namegiver":                                              "Namensgeber",
+        "relation":                                               "Beziehung"
+      },
       "curseType": {
         "minor":                                                    "Kleiner Fluch",
         "major":                                                    "Großer Fluch",
@@ -1159,7 +1167,7 @@
           },
           "AttributeConstraint": {
             "attribute":                                  "Das Attribute das vorausgesetzt wird",
-            "rank":                                       "Der Wert (nicht Stufe!) des Attributs der vorausgesetzt wird"
+            "value":                                      "Der Wert (nicht Stufe!) des Attributs der vorausgesetzt wird"
           },
           "BaseUnit": {
             "special":                                     "Beschreibung des speziellen Wertes",
@@ -1169,7 +1177,7 @@
           },
           "ClassConstraint": {
             "class":                                      "Die ED-ID der Berufung die vorausgesetzt wird",
-            "rank":                                       "Optional: ein Mindestrang/-kreis den die Berufung haben muss"
+            "level":                                       "Optional: ein Mindestrang/-kreis den die Berufung haben muss"
           },
           "DurationUnit": {
             "unit":                                        "Die Zeiteinheit der Dauer"
@@ -1447,6 +1455,10 @@
         "SpellEnhancement": {
           "title":                                "Konfiguration: Zauber Verstärkung",
           "hint":                          "Um eine Verstärkung hinzuzufügen, ziehe sie aus der Liste in den unteren Bereich. (noch nicht implementiert, kommt mit V13)"
+        },
+        "Constraints": {
+          "title":                                "Konfiguration: Einschränkungen",
+          "hint":                          "Um eine Einschränkung hinzuzufügen, ziehe sie aus der Liste in den unteren Bereich. (noch nicht implementiert, kommt mit V13)"
         }
       },
       "Errors": {

--- a/lang/de.json
+++ b/lang/de.json
@@ -759,7 +759,7 @@
           "Knack":{
             "isPathKnack":                                  "Ist dieser Kniff ein Pfadkniff?",
             "standardEffect":                               "Wird der Effekt des Ursprungtalentes mit ausgelöst?",
-            "sourceTalentUuid":                             "Von welchem Talent stammt dieser Kniff?",
+            "sourceTalent":                             "Von welchem Talent stammt dieser Kniff?",
             "minLevel":                                     "welchen Rang muss das Ursprungstalent mindestens haben?",
             "lpCost":                                       "Hat dieser Kniff abweichende LP Kosten zum Ursprungstalentrang?"
           },
@@ -987,7 +987,7 @@
           "Knack":{
             "isPathKnack":                                  "Pfad Kniff",
             "standardEffect":                               "Standard Effekt",
-            "sourceTalentUuid":                             "Ursprungstalent",
+            "sourceTalent":                             "Ursprungstalent",
             "minLevel":                                     "Min. Rang",
             "lpCost":                                       "LP Kosten"
           },

--- a/lang/de.json
+++ b/lang/de.json
@@ -656,6 +656,10 @@
       },
       "General": {
         "Hints": {
+          "Knacks": {
+            "restrictions":                               "Mindestens eine dieser Einschränkungen muss erfüllt sein um den Kniff zu lernen",
+            "requirements":                               "Alle Voraussetzungen müssen erfüllt sein, um den Kniff zu lernen. Fertigkeiten gelten hierfür nicht, nur Talente und Kniffe."
+          },
           "Rollable": {
             "type":                                         "Welche Aktionsart wird für diese Fähigkeit verwendet?"
           },
@@ -666,6 +670,10 @@
           }
         },
         "Labels": {
+          "Knack": {
+            "restrictions":                               "Einschränkungen",
+            "requirements":                               "Voraussetzungen"
+          },
           "Rollable": {
             "type":                                         "Aktionsart"
           },
@@ -1134,6 +1142,10 @@
       "Other": {
         "Hints": {
           "movement":                                    "Die Geschwindigkeiten der verschiedenen Fortbewegungsarten",
+          "AbilityConstraint": {
+            "ability":                                   "Die ED-ID der Fähigkeit die vorausgesetzt wird",
+            "rank":                                      "Optional: ein Mindestrang den die Fähigkeit haben muss"
+          },
           "AreaUnit": {
             "angle":                                        "Der Winkel des Bereichs",
             "areaTyp":                                      "Die geometrische Form des Bereichs",
@@ -1145,11 +1157,19 @@
             "unit":                                         "Die Maßeinheit des Bereichs",
             "width":                                        "Die Breite des Bereichs"
           },
+          "AttributeConstraint": {
+            "attribute":                                  "Das Attribute das vorausgesetzt wird",
+            "rank":                                       "Der Wert (nicht Stufe!) des Attributs der vorausgesetzt wird"
+          },
           "BaseUnit": {
             "special":                                     "Beschreibung des speziellen Wertes",
             "type":                                        "Die Art von Maß die beschrieben wird",
             "unit":                                        "Die Maßeinheit des Wertes",
             "value":                                       "Der eigentliche Wert"
+          },
+          "ClassConstraint": {
+            "class":                                      "Die ED-ID der Berufung die vorausgesetzt wird",
+            "rank":                                       "Optional: ein Mindestrang/-kreis den die Berufung haben muss"
           },
           "DurationUnit": {
             "unit":                                        "Die Zeiteinheit der Dauer"
@@ -1172,6 +1192,9 @@
             "type":                                     "In welcher Form wird die Dauer des Effekts gemessen",
             "uses":                                     "Wie oft kann dieser Effekt angewendet werden bevor er endet"
           },
+          "LanguageConstraint": {
+            "language":                                   "Die Sprache die vorausgesetzt wird, wie sie in den Einstellungen angegeben ist"
+          },
           "MetricData": {
             "area":                                       "Verändere den Wirkungsbereich. Wenn sich nur die Einheit verändern soll (z.B. von Fuß auf Schritt), dann lasse die anderen Felder leer.",
             "duration":                                   "Verändere die Dauer. Wenn sich nur die Einheit verändern soll (z.B. von Runden auf Minuten), dann lasse die anderen Felder leer.",
@@ -1181,8 +1204,14 @@
             "special":                                    "Eine textuelle Beschreibung der Veränderung. Das ist ein spezieller Wert, der nicht in die anderen Kategorien passt.",
             "target":                                     "Verändere die Anzahl an möglichen Zielen. Hier kann eine Formel genutzt werden die mit '@' auf die Daten des würfelnden <i>actors</i> zugreifen kann."
           },
+          "NamegiverConstraint": {
+            "namegiver":                                  "Der Namensgeber der vorausgesetzt wird"
+          },
           "RangeUnit": {
             "unit":                                        "Die Maßeinheit der Reichweite"
+          },
+          "RelationConstraint": {
+            "relation":                                   "Eine Form von Beziehung die vorausgesetzt wird, z.B. eine Mitgliedschaft in einer Vereinigung (tbd)"
           },
           "SpellEnhancement": {
             "enhancementType":                              "Die Art der Verstärkung",
@@ -1202,6 +1231,10 @@
         },
         "Labels": {
           "movement":                                    "Bewegung",
+          "AbilityConstraint": {
+            "ability":                                   "Fähigkeit",
+            "rank":                                      "Rang"
+          },
           "AreaUnit": {
             "angle":                                        "Winkel",
             "areaTyp":                                      "Typ",
@@ -1213,11 +1246,19 @@
             "unit":                                         "Maßeinheit",
             "width":                                        "Breite"
           },
+          "AttributeConstraint": {
+            "attribute":                                  "Attribut",
+            "value":                                      "Wert"
+          },
           "BaseUnit": {
             "special":                                     "Spezial",
             "type":                                        "Typ",
             "unit":                                        "Einheit",
             "value":                                       "Wert"
+          },
+          "ClassConstraint": {
+            "class":                                      "Disziplin / Questor / Pfad",
+            "level":                                      "Kreis / Rang"
           },
           "DurationUnit": {
             "unit":                                        "Zeiteinheit"
@@ -1240,8 +1281,17 @@
             "type":                                     "Typ",
             "uses":                                     "Anwendungen"
           },
+          "LanguageConstraint": {
+            "language":                                  "Sprache"
+          },
+          "NamegiverConstraint": {
+            "namegiver":                                  "Namensgeber"
+          },
           "RangeUnit": {
             "unit":                                        "Maßeinheit"
+          },
+          "RelationConstraint": {
+            "relation":                                   "Beziehungen"
           },
           "SpellEnhancement": {
             "enhancementType":                              "Art",

--- a/lang/en.json
+++ b/lang/en.json
@@ -459,7 +459,7 @@
                     "Knack":{
                         "isPathKnack":                                  "Path Knack",
                         "standardEffect":                               "Standard Effect",
-                        "sourceTalentUuid":                             "Source Talent",
+                        "sourceTalent":                             "Source Talent",
                         "minLevel":                                     "Min. Rank",
                         "lpCost":                                       "LP cost"
                     },
@@ -648,7 +648,7 @@
                     "Knack":{
                         "isPathKnack":                                  "Path Knack",
                         "standardEffect":                               "Standard Effect",
-                        "sourceTalentUuid":                             "Source Talent",
+                        "sourceTalent":                             "Source Talent",
                         "minLevel":                                     "Min. Rank",
                         "lpCost":                                       "LP cost"  
                     },

--- a/module/applications/configs/base-config-sheet.mjs
+++ b/module/applications/configs/base-config-sheet.mjs
@@ -1,3 +1,5 @@
+import ED4E from "../../config.mjs";
+
 const { DocumentSheetV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 /**
@@ -13,5 +15,20 @@ export default class BaseConfigSheet extends HandlebarsApplicationMixin( Documen
       submitOnChange: true
     }
   };
+
+  /** @inheritDoc */
+  async _preparePartContext( partId, context, options ) {
+    const newContext = await super._preparePartContext( partId, context, options );
+
+    if ( this.document ) {
+      newContext.document = this.document;
+      newContext.system = this.document.system;
+      newContext.options = this.options;
+      newContext.systemFields = this.document.system.schema.fields;
+      newContext.config = ED4E;
+    }
+
+    return newContext;
+  }
 
 }

--- a/module/applications/configs/constraints-config.mjs
+++ b/module/applications/configs/constraints-config.mjs
@@ -1,18 +1,18 @@
 import BaseConfigSheet from "./base-config-sheet.mjs";
-import { MetricData } from "../../data/common/metrics.mjs";
+import { ConstraintData } from "../../data/common/restrict-require.mjs";
 
 const { getProperty } = foundry.utils;
 
 /**
- * Base application for configuring data fields that use {@link MetricData} and its subclasses.
+ * Base application for configuring data fields that use {@link ConstraintData} and its subclasses.
  */
-export default class SpellEnhancementsConfig extends BaseConfigSheet {
+export default class ConstraintsConfig extends BaseConfigSheet {
 
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
-    classes: [ "spell-enhancements-config" ],
+    classes: [ "constraints-config" ],
     window:  {
-      title: "ED.Dialogs.Configs.SpellEnhancement.title",
+      title: "ED.Dialogs.Configs.Constraints.title",
     },
     form:    {
       handler: this.#onSubmitForm,
@@ -24,7 +24,7 @@ export default class SpellEnhancementsConfig extends BaseConfigSheet {
   /** @inheritDoc */
   static PARTS = {
     config: {
-      template: "systems/ed4e/templates/configs/spell-enhancements-config.hbs",
+      template: "systems/ed4e/templates/configs/constraints-config.hbs",
     },
   };
 
@@ -33,24 +33,24 @@ export default class SpellEnhancementsConfig extends BaseConfigSheet {
   /* -------------------------------------------- */
 
   /**
-   * The data for the enhancements field on the document's system property.
+   * The data for the constraints field on the document's system property.
    * @type {object}
    */
-  get enhancements() {
+  get constraints() {
     return getProperty( this.document.system, this.keyPath );
   }
 
   /**
-   * The schema data field for the enhancements field on the document's system property.
+   * The schema data field for the constraints field on the document's system property.
    * @type {DataField}
    */
-  get enhancementsField() {
+  get constraintsField() {
     return this.document.system.schema.fields[ this.keyPath ];
   }
 
   /**
-   * Path to the extraThreads or extraSuccess data on the document's system property.
-   * E.g., "extraThreads" for the document type "spell" system.extraThreads field.
+   * Path to the requirements or restrictions data on the document's system property.
+   * E.g., "requirements" for the document type "knackAbility" system.requirements field.
    * @type {string}
    */
   get keyPath() {
@@ -69,10 +69,10 @@ export default class SpellEnhancementsConfig extends BaseConfigSheet {
     newContext.item = newContext.document;
 
     newContext.keyPath = this.keyPath;
-    newContext.enhancements = this.enhancements;
-    newContext.enhancementsField = this.enhancementsField;
+    newContext.constraints = this.constraints;
+    newContext.constraintsField = this.constraintsField;
 
-    newContext.availableEnhancements = Object.values( MetricData.TYPES );
+    newContext.availableConstraints = Object.values( ConstraintData.TYPES );
 
     return newContext;
   }
@@ -94,8 +94,8 @@ export default class SpellEnhancementsConfig extends BaseConfigSheet {
     const data = foundry.utils.expandObject( formData.object );
 
     const updates = Array.from(
-      Object.values( this.enhancements ),
-      ( element, index ) => new this.enhancements[ index ].constructor( data.system[ this.keyPath ][ index ] )
+      Object.values( this.constraints ),
+      ( element, index ) => new this.constraints[ index ].constructor( data.system[ this.keyPath ][ index ] )
     );
 
     await this.document.update( {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -1,5 +1,6 @@
 import ED4E from "../../config.mjs";
 import SpellEnhancementsConfig from "../configs/spell-enhancements-config.mjs";
+import ConstraintsConfig from "../configs/constraints-config.mjs";
 
 const { HandlebarsApplicationMixin } = foundry.applications.api;
 const { ItemSheetV2 } = foundry.applications.sheets;
@@ -143,6 +144,13 @@ export default class ItemSheetEd extends HandlebarsApplicationMixin( ItemSheetV2
       case "extraSuccess":
       case "extraThreads":
         app = new SpellEnhancementsConfig( {
+          document: this.document,
+          type:     target.dataset.configType,
+        } );
+        break;
+      case "requirements":
+      case "restrictions":
+        app = new ConstraintsConfig( {
           document: this.document,
           type:     target.dataset.configType,
         } );

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -627,6 +627,34 @@ ED4E.attributeIncreaseRules = {
 };
 preLocalize( "attributeIncreaseRules" );
 
+ED4E.constraints = {
+  ability: {
+    label:         "ED.Config.Constraints.ability",
+    inputTemplate: "systems/ed4e/templates/form/input/base-constraint.hbs",
+  },
+  attribute: {
+    label:         "ED.Config.Constraints.attribute",
+    inputTemplate: "systems/ed4e/templates/form/input/base-constraint.hbs",
+  },
+  class: {
+    label:         "ED.Config.Constraints.class",
+    inputTemplate: "systems/ed4e/templates/form/input/base-constraint.hbs",
+  },
+  language: {
+    label:         "ED.Config.Constraints.language",
+    inputTemplate: "",
+  },
+  namegiver: {
+    label:         "ED.Config.Constraints.namegiver",
+    inputTemplate: "",
+  },
+  relation: {
+    label:         "ED.Config.Constraints.relation",
+    inputTemplate: "",
+  },
+};
+preLocalize( "constraints", { key: "label", sort: true } );
+
 
 /* -------------------------------------------- */
 /*  Character Generation                        */

--- a/module/data/common/_module.mjs
+++ b/module/data/common/_module.mjs
@@ -8,13 +8,29 @@ import {
   SpecialMetricData,
   TargetMetricData,
 } from "./metrics.mjs";
+import {
+  ConstraintData,
+  AbilityConstraintData,
+  AttributeConstraintData,
+  ClassConstraintData,
+  LanguageConstraintData,
+  NamegiverConstraintData,
+  RelationConstraintData,
+} from "./restrict-require.mjs";
 
 export {
+  AbilityConstraintData,
   AreaMetricData,
+  AttributeConstraintData,
+  ClassConstraintData,
+  ConstraintData,
   DurationMetricData,
   EffectMetricData,
+  LanguageConstraintData,
   MetricData,
+  NamegiverConstraintData,
   RangeMetricData,
+  RelationConstraintData,
   SectionMetricData,
   SpecialMetricData,
   TargetMetricData,

--- a/module/data/common/restrict-require.mjs
+++ b/module/data/common/restrict-require.mjs
@@ -1,0 +1,188 @@
+import { SparseDataModel } from "../abstract.mjs";
+import EdIdField from "../fields/edid-field.mjs";
+import ED4E from "../../config.mjs";
+
+const { fields } = foundry.data;
+
+/**
+ * Base model for storing data that represents a restriction or requirement for learning something, mainly knacks.
+ * Intended to be used as an EmbeddedDataField.
+ * @abstract
+ */
+export class ConstraintData extends SparseDataModel {
+
+  /* -------------------------------------------- */
+  /* Properties                                   */
+  /* -------------------------------------------- */
+
+  static get TYPES() {
+    // eslint-disable-next-line no-return-assign
+    return ConstraintData.#TYPES ??= Object.freeze( {
+      [AbilityConstraintData.TYPE]:    AbilityConstraintData,
+      [AttributeConstraintData.TYPE]:  AttributeConstraintData,
+      [ClassConstraintData.TYPE]:      ClassConstraintData,
+      [LanguageConstraintData.TYPE]:   LanguageConstraintData,
+      [NamegiverConstraintData.TYPE]:  NamegiverConstraintData,
+      [RelationConstraintData.TYPE]:   RelationConstraintData,
+    } );
+  }
+
+  static #TYPES;
+
+  static TYPE = "";
+
+  /* -------------------------------------------- */
+  /*  Schema                                      */
+  /* -------------------------------------------- */
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return {
+      type: new fields.StringField( {
+        required:        true,
+        blank:           false,
+        initial:         this.TYPE,
+        validate:        value => value === this.TYPE,
+        validationError: `must be equal to "${this.TYPE}"`,
+        label:           this.labelKey( "BaseConstraint.type" ),
+        hint:            this.hintKey( "BaseConstraint.type" ),
+      } ),
+    };
+  }
+
+}
+
+export class AbilityConstraintData extends ConstraintData {
+
+  static {
+    Object.defineProperty( this, "TYPE", { value: "ability", } );
+  }
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      ability: new EdIdField( {
+        label:    this.labelKey( "AbilityConstraint.ability" ),
+        hint:     this.hintKey( "AbilityConstraint.ability" ),
+      } ),
+      rank: new fields.NumberField( {
+        required: false,
+        integer:  true,
+        positive: true,
+        label:    this.labelKey( "AbilityConstraint.rank" ),
+        hint:     this.hintKey( "AbilityConstraint.rank" ),
+      } ),
+    } );
+  }
+
+}
+
+export class AttributeConstraintData extends ConstraintData {
+
+  static {
+    Object.defineProperty( this, "TYPE", { value: "attribute", } );
+  }
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      attribute: new fields.StringField( {
+        required: true,
+        choices:  ED4E.attributes,
+        label:    this.labelKey( "AttributeConstraint.attribute" ),
+        hint:     this.hintKey( "AttributeConstraint.attribute" ),
+      } ),
+      value: new fields.NumberField( {
+        required: true,
+        integer:  true,
+        positive: true,
+        label:    this.labelKey( "AttributeConstraint.value" ),
+        hint:     this.hintKey( "AttributeConstraint.value" ),
+      } ),
+    } );
+  }
+
+}
+
+export class ClassConstraintData extends ConstraintData {
+
+  static {
+    Object.defineProperty( this, "TYPE", { value: "class", } );
+  }
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      ability: new EdIdField( {
+        label:    this.labelKey( "ClassConstraint.ability" ),
+        hint:     this.hintKey( "ClassConstraint.ability" ),
+      } ),
+      rank: new fields.NumberField( {
+        required: false,
+        integer:  true,
+        positive: true,
+        label:    this.labelKey( "ClassConstraint.rank" ),
+        hint:     this.hintKey( "ClassConstraint.rank" ),
+      } ),
+    } );
+  }
+
+}
+
+export class LanguageConstraintData extends ConstraintData {
+
+  static {
+    Object.defineProperty( this, "TYPE", { value: "language", } );
+  }
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      language: new fields.StringField( {
+        required: true,
+        // this needs to be adjusted? Or will be fine if the config <-> settings interaction is cleared up
+        // or, prepare choices during rendering...
+        choices:  ED4E.languages,
+        label:    this.labelKey( "LanguageConstraint.language" ),
+        hint:     this.hintKey( "LanguageConstraint.language" ),
+      } ),
+    } );
+  }
+
+}
+
+export class NamegiverConstraintData extends ConstraintData {
+
+  static {
+    Object.defineProperty( this, "TYPE", { value: "namegiver", } );
+  }
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      namegiver: new EdIdField( {
+        label:    this.labelKey( "NamegiverConstraint.namegiver" ),
+        hint:     this.hintKey( "NamegiverConstraint.namegiver" ),
+      } ),
+    } );
+  }
+
+}
+
+export class RelationConstraintData extends ConstraintData {
+
+  static {
+    Object.defineProperty( this, "TYPE", { value: "relation", } );
+  }
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      relation: new fields.StringField( {
+        label:    this.labelKey( "RelationConstraint.relation" ),
+        hint:     this.hintKey( "RelationConstraint.relation" ),
+      } ),
+    } );
+  }
+
+}

--- a/module/data/common/restrict-require.mjs
+++ b/module/data/common/restrict-require.mjs
@@ -50,6 +50,13 @@ export class ConstraintData extends SparseDataModel {
     };
   }
 
+  get summaryString() {
+    return [
+      `<em>${ ED4E.constraints[ this.constructor.TYPE ].label }</em>`,
+      "&emsp;",
+      ...Object.values( this )
+    ].join( " " );
+  }
 }
 
 export class AbilityConstraintData extends ConstraintData {
@@ -89,6 +96,7 @@ export class AttributeConstraintData extends ConstraintData {
       attribute: new fields.StringField( {
         required: true,
         choices:  ED4E.attributes,
+        initial:  "str",
         label:    this.labelKey( "AttributeConstraint.attribute" ),
         hint:     this.hintKey( "AttributeConstraint.attribute" ),
       } ),
@@ -113,16 +121,16 @@ export class ClassConstraintData extends ConstraintData {
   /** @inheritdoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {
-      ability: new EdIdField( {
-        label:    this.labelKey( "ClassConstraint.ability" ),
-        hint:     this.hintKey( "ClassConstraint.ability" ),
+      class: new EdIdField( {
+        label:    this.labelKey( "ClassConstraint.class" ),
+        hint:     this.hintKey( "ClassConstraint.class" ),
       } ),
-      rank: new fields.NumberField( {
+      level: new fields.NumberField( {
         required: false,
         integer:  true,
         positive: true,
-        label:    this.labelKey( "ClassConstraint.rank" ),
-        hint:     this.hintKey( "ClassConstraint.rank" ),
+        label:    this.labelKey( "ClassConstraint.level" ),
+        hint:     this.hintKey( "ClassConstraint.level" ),
       } ),
     } );
   }
@@ -139,10 +147,10 @@ export class LanguageConstraintData extends ConstraintData {
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {
       language: new fields.StringField( {
-        required: true,
         // this needs to be adjusted? Or will be fine if the config <-> settings interaction is cleared up
         // or, prepare choices during rendering...
         choices:  ED4E.languages,
+        initial:  "dwarf",
         label:    this.labelKey( "LanguageConstraint.language" ),
         hint:     this.hintKey( "LanguageConstraint.language" ),
       } ),

--- a/module/data/item/_module.mjs
+++ b/module/data/item/_module.mjs
@@ -56,6 +56,7 @@ export {
 
 export {default as AbilityTemplate} from "./templates/ability.mjs";
 export {default as ClassTemplate} from "./templates/class.mjs";
+export {default as IncreasableAbilityTemplate} from "./templates/increasable-ability.mjs";
 export {default as ItemDescriptionTemplate} from "./templates/item-description.mjs";
 export {default as KnackTemplate} from "./templates/knack-item.mjs";
 export {default as LpIncreaseTemplate} from "./templates/lp-increase.mjs";

--- a/module/data/item/devotion.mjs
+++ b/module/data/item/devotion.mjs
@@ -1,13 +1,13 @@
-import AbilityTemplate from "./templates/ability.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ED4E from "../../config.mjs";
 import { createContentLink } from "../../utils.mjs";
+import IncreasableAbilityTemplate from "./templates/increasable-ability.mjs";
 const { DialogV2 } = foundry.applications.api;
 
 /**
  * Data model template with information on Devotion items.
  */
-export default class DevotionData extends AbilityTemplate.mixin(
+export default class DevotionData extends IncreasableAbilityTemplate.mixin(
   ItemDescriptionTemplate
 )  {
 

--- a/module/data/item/skill.mjs
+++ b/module/data/item/skill.mjs
@@ -1,12 +1,12 @@
-import AbilityTemplate from "./templates/ability.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ED4E from "../../config.mjs";
+import IncreasableAbilityTemplate from "./templates/increasable-ability.mjs";
 
 /**
  * Data model template with information on Skill items.
  * @mixes ItemDescriptionTemplate
  */
-export default class SkillData extends AbilityTemplate.mixin(
+export default class SkillData extends IncreasableAbilityTemplate.mixin(
   ItemDescriptionTemplate
 )  {
 

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -300,8 +300,8 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
       "system.knacks.available": [ ...this.knacks.available, data.uuid ],
     } );
     fromUuid( data.uuid ).then( knack => {
-      if ( !knack.system.sourceTalentUuid ) knack.update( {
-        "system.sourceTalentUuid": item.uuid,
+      if ( !knack.system.sourceTalent ) knack.update( {
+        "system.sourceTalent": item.edid,
       } );
     } );
     return data;

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -1,14 +1,14 @@
-import AbilityTemplate from "./templates/ability.mjs";
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ED4E from "../../config.mjs";
 import KnackTemplate from "./templates/knack-item.mjs";
 import PromptFactory from "../../applications/global/prompt-factory.mjs";
+import IncreasableAbilityTemplate from "./templates/increasable-ability.mjs";
 
 /**
  * Data model template with information on talent items.
  * @mixes ItemDescriptionTemplate
  */
-export default class TalentData extends AbilityTemplate.mixin(
+export default class TalentData extends IncreasableAbilityTemplate.mixin(
   ItemDescriptionTemplate
 ) {
 

--- a/module/data/item/templates/increasable-ability.mjs
+++ b/module/data/item/templates/increasable-ability.mjs
@@ -1,0 +1,139 @@
+import LpIncreaseTemplate from "./lp-increase.mjs";
+import PromptFactory from "../../../applications/global/prompt-factory.mjs";
+import LpSpendingTransactionData from "../../advancement/lp-spending-transaction.mjs";
+import AbilityTemplate from "./ability.mjs";
+const isEmpty = foundry.utils.isEmpty;
+
+/**
+ * Data model template with information on abilities that have rank and therefore can be increased with LP.
+ * @property {number} level rank
+ * @mixes LpIncreaseTemplate
+ */
+export default class IncreasableAbilityTemplate extends AbilityTemplate.mixin(
+  LpIncreaseTemplate,
+) {
+  /** @inheritDoc */
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return this.mergeSchema( super.defineSchema(), {
+      level: new fields.NumberField( {
+        required: true,
+        nullable: false,
+        min:      0,
+        initial:  0,
+        integer:  true,
+        label:    this.labelKey( "Ability.rank" ),
+        hint:     this.hintKey( "Ability.rank" )
+      } ),
+    } );
+  }
+
+  /* -------------------------------------------- */
+  /*  Getters                   */
+  /* -------------------------------------------- */
+
+  get baseRollOptions() {
+    const rollOptions = super.baseRollOptions;
+    rollOptions.updateSource( {
+      step:             {
+        base:      this.rankFinal,
+      },
+    } );
+
+    return rollOptions;
+  }
+
+  /** @inheritDoc */
+  get rankFinal() {
+    return super.rankFinal + this.level;
+  }
+
+  /* -------------------------------------------- */
+  /*  Legend                                      */
+  /* -------------------------------------------- */
+
+  async adjustLevel( amount ) {
+    const currentLevel = this.level;
+    const updatedItem = await this.parent.update( {
+      "system.level": currentLevel + amount,
+    } );
+
+    if ( isEmpty( updatedItem ) ) {
+      ui.notifications.warn(
+        game.i18n.localize( "ED.Notifications.Warn.Legend.abilityIncreaseProblems" )
+      );
+      return;
+    }
+
+    return updatedItem;
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async increase() {
+    if ( !this.isActorEmbedded ) return;
+
+    const promptFactory = PromptFactory.fromDocument( this.parent );
+    const spendLp = await promptFactory.getPrompt( "lpIncrease" );
+
+    if ( !spendLp
+      || spendLp === "cancel"
+      || spendLp === "close" ) return;
+
+    const currentLevel = this.level;
+
+    const updatedItem = await this.parent.update( {
+      "system.level": currentLevel + 1,
+    } );
+
+    if ( foundry.utils.isEmpty( updatedItem ) ) {
+      ui.notifications.warn(
+        game.i18n.localize( "ED.Notifications.Warn.Legend.abilityIncreaseProblems" )
+      );
+      return;
+    }
+
+    const updatedActor = await this.parent.actor.addLpTransaction(
+      "spendings",
+      LpSpendingTransactionData.dataFromLevelItem(
+        this.parent,
+        spendLp === "spendLp" ? this.requiredLpForIncrease : 0,
+        this.lpSpendingDescription,
+      ),
+    );
+
+    if ( foundry.utils.isEmpty( updatedActor ) )
+      ui.notifications.warn(
+        game.i18n.localize( "ED.Notifications.Warn.Legend.abilityIncreaseProblems" )
+      );
+
+    return this.parent;
+  }
+
+  /** @inheritDoc */
+  static async learn( actor, item, createData ) {
+    if ( !item.system.canBeLearned ) {
+      ui.notifications.warn(
+        game.i18n.format( "ED.Notifications.Warn.Legend.cannotLearn", {itemType: item.type} )
+      );
+      return;
+    }
+    const itemData = foundry.utils.mergeObject(
+      item.toObject(),
+      foundry.utils.expandObject( createData ),
+    );
+    if ( !createData?.system?.level ) itemData.system.level = 0;
+    return ( await actor.createEmbeddedDocuments( "Item", [ itemData ] ) )?.[0];
+  }
+
+  /* -------------------------------------------- */
+  /*  Migrations                                  */
+  /* -------------------------------------------- */
+
+  /** @inheritDoc */
+  static migrateData( source ) {
+    super.migrateData( source );
+    // specific migration functions
+  }
+}

--- a/module/data/item/templates/knack-item.mjs
+++ b/module/data/item/templates/knack-item.mjs
@@ -1,6 +1,8 @@
 import SystemDataModel from "../../abstract.mjs";
 import TargetTemplate from "./targeting.mjs";
 import LearnableTemplate from "./learnable.mjs";
+import { ConstraintData } from "../../common/restrict-require.mjs";
+import EdIdField from "../../fields/edid-field.mjs";
 
 /**
  * Data model template for Knacks
@@ -15,58 +17,40 @@ export default class KnackTemplate extends SystemDataModel.mixin(
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
-      sourceTalentUuid: new fields.DocumentUUIDField( {
-        required: false,
-        nullable: true,
-        trim:     true,
-        blank:    false,
-        validate: ( value, options ) => {
-          if ( fromUuidSync( value, {strict: false} )?.type !== "talent" ) return false;
-          return undefined; // undefined means do further validation
-        },
-        validationError: "must be of type 'talent'",
-        label:           this.labelKey( "Knack.sourceTalentUuid" ),
-        hint:            this.hintKey( "Knack.sourceTalentUuid" ),
+      sourceTalent: new EdIdField( {
+        label:           this.labelKey( "Knack.sourceTalent" ),
+        hint:            this.hintKey( "Knack.sourceTalent" ),
       } ),
-      minLevel:      new fields.NumberField( {
-        required: false,
-        nullable: true,
+      minLevel:         new fields.NumberField( {
+        required: true,
         positive: true,
         integer:  true,
-        min:      1,
         initial:  1,
         label:    this.labelKey( "Knack.minLevel" ),
         hint:     this.hintKey( "Knack.minLevel" ),
       } ),
-      lpCost:      new fields.NumberField( {
+      lpCost:           new fields.NumberField( {
         required: false,
-        initial:  0,
+        positive: true,
+        integer:  true,
         label:    this.labelKey( "Knack.lpCost" ),
         hint:     this.hintKey( "Knack.lpCost" ),
       } ),
-      restrictions: new fields.NumberField(),
-      requirements: new fields.NumberField(),
-      // TODO @Chris how do we do this
-      // restrictions: [], // there will be several options possible see issue #212
-      // requirements: [], // there will be several options possible see issue #212 
+      restrictions:     new fields.ArrayField(
+        new fields.TypedSchemaField( ConstraintData.TYPES ),
+        {
+          label: this.labelKey( "Knack.restrictions" ),
+          hint:  this.hintKey( "Knack.restrictions" ),
+        }
+      ),
+      requirements:     new fields.ArrayField(
+        new fields.TypedSchemaField( ConstraintData.TYPES ),
+        {
+          label: this.labelKey( "Knack.requirements" ),
+          hint:  this.hintKey( "Knack.requirements" ),
+        }
+      ),
     } );
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
-  get increasable() {
-    return false;
-  }
-
-  /* -------------------------------------------- */
-
-  /** @inheritdoc */
-  static _cleanData( source, options ) {
-    if ( source?.sourceTalentUuid ) {
-      source.sourceTalentUuid = fromUuidSync( source.sourceTalentUuid ) ? source.sourceTalentUuid : null;
-      if ( options ) options.source = source;
-    }
   }
 
   /* -------------------------------------------- */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -636,7 +636,8 @@ export async function preloadHandlebarsTemplates() {
     // Form Inputs and Groups
     "systems/ed4e/templates/form/input/area-metric.hbs",
     "systems/ed4e/templates/form/input/base-metric.hbs",
-    "systems/ed4e/templates/form/input/spell-enhancement.hbs",
+    "systems/ed4e/templates/form/input/base-constraint.hbs",
+    "systems/ed4e/templates/form/input/configurable-array-summary.hbs",
     "systems/ed4e/templates/form/group/general.hbs",
 
     // Character Generation

--- a/templates/configs/constraints-config.hbs
+++ b/templates/configs/constraints-config.hbs
@@ -1,0 +1,47 @@
+<section>
+  <!--TODO: ADD BUTTONS FOR ADDING/REMOVING CONSTRAINTS, OR VIA DRAG DROP-->
+
+  <div class="hint">
+    {{localize "ED.Dialogs.Configs.Constraints.hint"}}
+  </div>
+
+  <div class="tags input-element-tags">
+    {{#each availableConstraints}}
+      <div class="tag" data-key="{{this.TYPE}}">
+        <span>{{lookup (lookup ../config.constraints this.TYPE) "label"}}</span>
+      </div>
+    {{/each}}
+  </div>
+
+  <hr>
+
+  <div class="scrollable">
+    {{#each constraints as | constraint |}}
+      <fieldset>
+        {{#with (lookup ../config.constraints this.type) as | constraintConfig |}}
+          <legend>{{lookup constraintConfig "label"}}</legend>
+          {{#with (lookup constraintConfig "inputTemplate") as | inputTemplate |}}
+
+            {{> "systems/ed4e/templates/form/group/general.hbs"
+              dataField=constraint.schema
+              inputTemplate=inputTemplate
+              data=constraint
+              fields=constraint.schema.fields
+              fieldPath=(concat "system." @root.keyPath "." @index)
+              config=config
+            }}
+
+          {{else}}
+            {{formGroup
+              (lookup constraint.schema.fields constraint.type)
+              value=(lookup constraint constraint.type)
+              name=(concat "system." @root.keyPath "." @index "." constraint.type)
+              localize=true
+            }}
+
+          {{/with}}
+        {{/with}}
+      </fieldset>
+    {{/each}}
+  </div>
+</section>

--- a/templates/configs/spell-enhancements-config.hbs
+++ b/templates/configs/spell-enhancements-config.hbs
@@ -16,17 +16,19 @@
 
   <hr>
 
-  {{#each enhancements}}
-    <fieldset>
-      <legend>{{lookup (lookup ../config.spellEnhancements this.type) "label"}}</legend>
-      {{> "systems/ed4e/templates/form/group/general.hbs"
-        dataField=this.schema
-        inputTemplate=(lookup (lookup ../config.spellEnhancements this.type) "inputTemplate")
-        data=this
-        fields=this.schema.fields
-        fieldPath=(concat "system." @root.keyPath "." @index)
-        config=config
-      }}
-    </fieldset>
-  {{/each}}
+  <div class="scrollable">
+    {{#each enhancements}}
+      <fieldset>
+        <legend>{{lookup (lookup ../config.spellEnhancements this.type) "label"}}</legend>
+        {{> "systems/ed4e/templates/form/group/general.hbs"
+          dataField=this.schema
+          inputTemplate=(lookup (lookup ../config.spellEnhancements this.type) "inputTemplate")
+          data=this
+          fields=this.schema.fields
+          fieldPath=(concat "system." @root.keyPath "." @index)
+          config=config
+        }}
+      </fieldset>
+    {{/each}}
+  </div>
 </section>

--- a/templates/form/input/base-constraint.hbs
+++ b/templates/form/input/base-constraint.hbs
@@ -1,0 +1,19 @@
+{{!--
+Expects parameters:
+@param data - The data model from the system field.
+@param fields - The schema fields of the data model of this field.
+@param fieldPath - The path to the field in the document, e.g. "system.extraThreads.0". If not provided, the path is generated automatically in the `toInput` method.
+@param config - The global ED4E configuration object.
+--}}
+
+<!-- ability, attribute, class -->
+
+{{#each fields as | field |}}
+  {{#unless (eq field.name "type")}}
+    {{formGroup field value=(lookup data field.name) name=(concat fieldPath "." field.name) localize=true}}
+  {{/unless}}
+{{else}}
+  <div class="undefined-field">
+    NO FIELDS HERE
+  </div>
+{{/each}}

--- a/templates/form/input/configurable-array-summary.hbs
+++ b/templates/form/input/configurable-array-summary.hbs
@@ -3,6 +3,7 @@ Expects parameters:
 @param dataField - The data field that is rendered.
 @param data - The data model from the system field.
 @param config - The global ED4E configuration object.
+@param configType - The type of config application.
 --}}
 
 <span class="flexcol">
@@ -14,5 +15,5 @@ Expects parameters:
   dataField=dataField
   withLabel=false
   config=config
-  configType="spellEnhancement"
+  configType=configType
 }}

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackAbility.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackAbility.hbs
@@ -6,7 +6,7 @@
     {{!-- Source --}}
     <div class="knack-ability__source-min-level">
         <div class="knack-ability__source">
-            {{formField systemFields.sourceTalentUuid name="system.sourceTalentUuid" value=item.system.sourceTalentUuid label=(localize "ED.Data.Item.Labels.Knack.sourceTalentUuid") localize=true}}
+            {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent label=(localize "ED.Data.Item.Labels.Knack.sourceTalent") localize=true}}
         </div>
         <div class="knack-ability__min-level">
             {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackAbility.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackAbility.hbs
@@ -1,8 +1,12 @@
 <div class="item__left--main">
+
     <h3>{{localize "ED.Item.Header.general"}}</h3>
+
     {{> "systems/ed4e/templates/item/item-partials/item-details/partials/abilities.hbs"}}
+
     {{!-- Standard Effect --}}
     {{formField systemFields.standardEffect name="system.standardEffect" value=item.system.standardEffect localize=true}}
+
     {{!-- Source --}}
     <div class="knack-ability__source-min-level">
         <div class="knack-ability__source">
@@ -12,7 +16,23 @@
             {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}
         </div>
     </div>
+
+  {{> "systems/ed4e/templates/form/group/general.hbs"
+    dataField=systemFields.requirements
+    inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
+    data=item.system.requirements
+    config=config
+  }}
+
+  {{> "systems/ed4e/templates/form/group/general.hbs"
+    dataField=systemFields.restrictions
+    inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
+    data=item.system.restrictions
+    config=config
+  }}
+
 </div>
+
 <div class="item__right--main sheet__editor">
     <h3>{{localize "ED.Item.Header.description"}}</h3>
     {{> "systems/ed4e/templates/global/editor.hbs"}}

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackKarma.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackKarma.hbs
@@ -3,7 +3,7 @@
     {{!-- Source --}}
     <div class="knack-ability__source-min-level">
     <div class="knack-ability__source">
-        {{formField systemFields.sourceTalentUuid name="system.sourceTalentUuid" value=item.system.sourceTalentUuid label=(localize "ED.Data.Item.Labels.Knack.sourceTalentUuid") localize=true}}
+        {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent label=(localize "ED.Data.Item.Labels.Knack.sourceTalent") localize=true}}
     </div>
     <div class="knack-ability__min-level">
         {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackKarma.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackKarma.hbs
@@ -1,16 +1,34 @@
 <div class="item__left--main">
-    <h3>{{localize "ED.Item.Header.general"}}</h3>
-    {{!-- Source --}}
-    <div class="knack-ability__source-min-level">
+
+  <h3>{{localize "ED.Item.Header.general"}}</h3>
+
+  {{!-- Source --}}
+  <div class="knack-ability__source-min-level">
     <div class="knack-ability__source">
-        {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent label=(localize "ED.Data.Item.Labels.Knack.sourceTalent") localize=true}}
+      {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent label=(localize "ED.Data.Item.Labels.Knack.sourceTalent") localize=true}}
     </div>
     <div class="knack-ability__min-level">
-        {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}
+      {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}
     </div>
+  </div>
+
+  {{> "systems/ed4e/templates/form/group/general.hbs"
+    dataField=systemFields.requirements
+    inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
+    data=item.system.requirements
+    config=config
+  }}
+
+  {{> "systems/ed4e/templates/form/group/general.hbs"
+    dataField=systemFields.restrictions
+    inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
+    data=item.system.restrictions
+    config=config
+  }}
+
 </div>
-</div>
+
 <div class="item__right--main sheet__editor">
-    <h3>{{localize "ED.Item.Header.description"}}</h3>
-    {{> "systems/ed4e/templates/global/editor.hbs"}}
+  <h3>{{localize "ED.Item.Header.description"}}</h3>
+  {{> "systems/ed4e/templates/global/editor.hbs"}}
 </div>

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackManeuver.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackManeuver.hbs
@@ -1,18 +1,36 @@
 <div class="item__left--main">
-    <h3>{{localize "ED.Item.Header.general"}}</h3>
-    {{!-- Source --}}
-    <div class="knack-ability__source-min-level">
+
+  <h3>{{localize "ED.Item.Header.general"}}</h3>
+
+  {{!-- Source --}}
+  <div class="knack-ability__source-min-level">
     <div class="knack-ability__source">
-        {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent label=(localize "ED.Data.Item.Labels.Knack.sourceTalent") localize=true}}
+      {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent label=(localize "ED.Data.Item.Labels.Knack.sourceTalent") localize=true}}
     </div>
     <div class="knack-ability__min-level">
-        {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}
+      {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}
     </div>
     {{!-- Required Extra Successes --}}
     {{formField systemFields.extraSuccesses name="system.extraSuccesses" value=item.system.extraSuccesses localize=true}}
+  </div>
+
+  {{> "systems/ed4e/templates/form/group/general.hbs"
+    dataField=systemFields.requirements
+    inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
+    data=item.system.requirements
+    config=config
+  }}
+
+  {{> "systems/ed4e/templates/form/group/general.hbs"
+    dataField=systemFields.restrictions
+    inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
+    data=item.system.restrictions
+    config=config
+  }}
+
 </div>
-</div>
+
 <div class="item__right--main sheet__editor">
-    <h3>{{localize "ED.Item.Header.description"}}</h3>
-    {{> "systems/ed4e/templates/global/editor.hbs"}}
+  <h3>{{localize "ED.Item.Header.description"}}</h3>
+  {{> "systems/ed4e/templates/global/editor.hbs"}}
 </div>

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackManeuver.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackManeuver.hbs
@@ -3,7 +3,7 @@
     {{!-- Source --}}
     <div class="knack-ability__source-min-level">
     <div class="knack-ability__source">
-        {{formField systemFields.sourceTalentUuid name="system.sourceTalentUuid" value=item.system.sourceTalentUuid label=(localize "ED.Data.Item.Labels.Knack.sourceTalentUuid") localize=true}}
+        {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent label=(localize "ED.Data.Item.Labels.Knack.sourceTalent") localize=true}}
     </div>
     <div class="knack-ability__min-level">
         {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}

--- a/templates/item/item-partials/item-details/details/item-details-spell.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-spell.hbs
@@ -37,16 +37,18 @@
 
     {{> "systems/ed4e/templates/form/group/general.hbs"
       dataField=systemFields.extraSuccess
-      inputTemplate="systems/ed4e/templates/form/input/spell-enhancement.hbs"
+      inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
       data=item.system.extraSuccess
       config=config
+      configType="spellEnhancement"
     }}
 
     {{> "systems/ed4e/templates/form/group/general.hbs"
       dataField=systemFields.extraThreads
-      inputTemplate="systems/ed4e/templates/form/input/spell-enhancement.hbs"
+      inputTemplate="systems/ed4e/templates/form/input/configurable-array-summary.hbs"
       data=item.system.extraThreads
       config=config
+      configType="spellEnhancement"
     }}
 
   </fieldset>

--- a/templates/item/item-partials/item-details/partials/abilities.hbs
+++ b/templates/item/item-partials/item-details/partials/abilities.hbs
@@ -1,5 +1,7 @@
+{{#if systemFields.level}}
 {{!-- Rank --}}
-{{formField systemFields.level name="system.level" value=item.system.level localize=true}}
+  {{formField systemFields.level name="system.level" value=item.system.level localize=true}}
+{{/if}}
 {{!-- Strain --}}
 {{formField systemFields.strain name="system.strain" value=item.system.strain localize=true}}
 {{!-- Attribute --}}


### PR DESCRIPTION
Add requirements and restrictions as config apps (like spell enhancements).
Move reference to other unspecific Items from UUIDFields to EdId-Fields, such that they're more easily searched for in a world or embedded.