### PR TITLE
move-active-effect-change-key-choices-a-config-object

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2,6 +2,12 @@
   "ED": {
     "ActiveEffect": {
       "newEffectName": "Neuer Earthdawn ActiveEffect",
+      "ChangeKeys": {
+        "Groups": {
+          "globalBonuses": "Globale Boni",
+          "singleBonuses": "Einzelne Boni"
+        }
+      },
       "Header": {
         "applyToAbility": "Auf Fähigkeit anwenden"
       },
@@ -94,6 +100,11 @@
         "current": "Aktuell",
         "max": "Max",
         "step": "Stufe"
+      },
+      "GlobalBonus": {
+        "allEffects": "Alle Effekte",
+        "allActions": "Alle Aktionen",
+        "allRangedAttacks": "Alle Fernkampfangriffe"
       },
       "Header": {
         "action":                                           "Aktion",

--- a/lang/de.json
+++ b/lang/de.json
@@ -4,7 +4,20 @@
       "newEffectName": "Neuer Earthdawn ActiveEffect",
       "ChangeKeys": {
         "Groups": {
+          "armor": "Rüstung",
+          "attribute": "Attribut",
+          "attributeStep": "Attribut Stufe",
+          "attributeValue": "Attribut Wert",
+          "bloodMagic": "Blutmagie",
+          "defense": "Verteidigung",
+          "devotion": "Weihe",
+          "encumbrance": "Traglast",
           "globalBonuses": "Globale Boni",
+          "health": "Gesundheitswerte",
+          "initiative": "Initiative",
+          "karma": "Karma",
+          "movement": "Bewegung",
+          "recoveryTestsResource": "Ressource - Erholungsproben",
           "singleBonuses": "Einzelne Boni"
         }
       },
@@ -102,9 +115,18 @@
         "step": "Stufe"
       },
       "GlobalBonus": {
+        "allAttacks": "Alle Angriffe",
         "allEffects": "Alle Effekte",
         "allActions": "Alle Aktionen",
-        "allRangedAttacks": "Alle Fernkampfangriffe"
+        "allRangedAttacks": "Alle Fernkampfangriffe",
+        "allCloseAttacks": "Alle Nahkampfangriffe",
+        "allSpellcasting": "Alle Spruchzauberei",
+        "allDamage": "Jeder Schadenswurf",
+        "allMeleeDamage": "Jeder Nahkampfschaden",
+        "allRangedDamage": "Jeder Fernkampfschaden",
+        "allRecoveryEffects": "Alle Erholungseffekte",
+        "allKnockdownEffects": "Alle Niederschlageffekte",
+        "allSpellEffects": "Alle Spruchzauber-Effekte"
       },
       "Header": {
         "action":                                           "Aktion",
@@ -321,6 +343,10 @@
         "needle":                                                   "Nadel",
         "stone":                                                    "Stein"
       },
+      "Armor": {
+        "physical":                                                "Physische Rüstung",
+        "mystical":                                                "Mystische Rüstung"
+      },
       "Availability": {
         "everyday":                                                 "Alltäglich",
         "average":                                                  "Durchschnittlich",
@@ -357,9 +383,9 @@
         "highestX":                                                 "Höchste der Gruppe + Ziele",
         "lowestOfGroup":                                            "Niedrigste der Gruppe",
         "lowestX":                                                  "Niedrigste der Gruppe + Ziele",
-        "mystical":                                                 "Mystisch",
-        "physical":                                                 "Körperlich",
-        "social":                                                   "Sozial"
+        "mystical":                                                 "Mystische Verteidung",
+        "physical":                                                 "Körperliche Verteidigung",
+        "social":                                                   "Soziale Verteidigung"
       },
       "Denomination": {
         "copper":                                                   "Kupfer",
@@ -418,6 +444,13 @@
         "feet":                                                     "Fuß",
         "yard":                                                     "Schritt",
         "mile":                                                     "Meile"
+      },
+      "MovementTypes": {
+        "burrow":                                                  "Graben",
+        "climb":                                                   "Klettern",
+        "fly":                                                     "Fliegen",
+        "swim":                                                    "Schwimmen",
+        "walk":                                                    "Gehen"
       },
       "Skills": {
         "general":                                              "Allgemein",

--- a/lang/de.json
+++ b/lang/de.json
@@ -4,6 +4,8 @@
       "newEffectName": "Neuer Earthdawn ActiveEffect",
       "ChangeKeys": {
         "Groups": {
+          "ability": "Fähigkeit",
+          "action": "Aktion",
           "armor": "Rüstung",
           "attribute": "Attribut",
           "attributeStep": "Attribut Stufe",
@@ -18,7 +20,12 @@
           "karma": "Karma",
           "movement": "Bewegung",
           "recoveryTestsResource": "Ressource - Erholungsproben",
-          "singleBonuses": "Einzelne Boni"
+          "rollable": "Würfeln",
+          "shield": "Schild",
+          "singleBonuses": "Einzelne Boni",
+          "targeting": "Ziel / Schwierigkeit",
+          "weapon": "Waffe",
+          "weaponRange": "Waffenreichweite"
         }
       },
       "Header": {

--- a/module/applications/effect/eae-sheet.mjs
+++ b/module/applications/effect/eae-sheet.mjs
@@ -1,5 +1,6 @@
 import { getEdIds } from "../../settings.mjs";
 import FormulaField from "../../data/fields/formula-field.mjs";
+import ED4E from "../../config.mjs";
 
 const { ActiveEffectConfig } = foundry.applications.sheets;
 
@@ -28,6 +29,24 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
     duration: { template: "systems/ed4e/templates/effect/duration.hbs" },
     changes:  { template: "systems/ed4e/templates/effect/changes.hbs" },
   };
+
+  // region Properties
+
+  /**
+   * @type {FormInputConfig[]}
+   */
+  get keyOptions() {
+    if ( !this.document ) return [];
+    if ( this.document.system.appliedToItem ) return ED4E.eaeChangeKeysItem;
+    if ( this.document.system.appliedToActor ) return ED4E.eaeChangeKeysActor;
+    return [ {
+      value:    "",
+      label:    game.i18n.localize( "ED4E.Data.placeholderBlankSelectOption" ),
+      selected: true,
+    } ];
+  }
+
+  // endregion
 
   // region Form Handling
 
@@ -104,7 +123,7 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
       case "duration":
         break;
       case "changes":
-        partContext.keyOptions = this.document.parent?.system?.constructor.EAE_SELECT_OPTIONS;
+        partContext.keyOptions = this.keyOptions;
         partContext.edids = getEdIds();
         break;
     }

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -75,59 +75,6 @@ ED4E.attributes = {
 preLocalize( "attributes", {keys: [ "label", "abbreviation" ]} );
 
 /**
- * configuration data for Global Bonuses
- * @typedef {object} GlobalBonusConfiguration
- * @property {string} label                               Localized label.
- * @property {{[key: string]: number|string}} [defaults]  Default values for this Attribute based on actor type.
- */
-
-/**
- * @description the global bonus configurations
- * @enum { GlobalBonusConfiguration }
- */
-ED4E.globalBonuses = {
-  allAttacks: {
-    label:       "ED.Actor.GlobalBonus.allAttacks"
-  },
-  allEffects: {
-    label:       "ED.Actor.GlobalBonus.allEffects"
-  },
-  allActions: {
-    label:       "ED.Actor.GlobalBonus.allActions"
-  },
-  allRangedAttacks: {
-    label:       "ED.Actor.GlobalBonus.allRangedAttacks"
-  },
-  allCloseAttacks: {
-    label:       "ED.Actor.GlobalBonus.allCloseAttacks"
-  },
-  allSpellcasting: {
-    label:       "ED.Actor.GlobalBonus.allSpellcasting"
-  },
-  allDamage: {
-    label:       "ED.Actor.GlobalBonus.allDamage"
-  },
-  allMeleeDamage: {
-    label:       "ED.Actor.GlobalBonus.allMeleeDamage"
-  },
-  allRangedDamage: {
-    label:       "ED.Actor.GlobalBonus.allRangedDamage"
-  },
-  allRecoveryEffects: {
-    label:       "ED.Actor.GlobalBonus.allRecoveryEffects"
-  },
-  allKnockdownEffects: {
-    label:       "ED.Actor.GlobalBonus.allKnockDownEffects"
-  },
-  allSpellEffects: {
-    label:       "ED.Actor.GlobalBonus.allSpellEffects"
-  }
-};
-preLocalize( "globalBonuses", {key: "label"} );
-
-
-
-/**
  * Denomination options
  * @enum {string}
  */
@@ -439,9 +386,7 @@ ED4E.spellEnhancements = {
 preLocalize( "spellEnhancements", { key: "label", sort: true } );
 
 
-/* -------------------------------------------- */
-/*  Active Effects                              */
-/* -------------------------------------------- */
+// region Active Effects
 
 /**
  * Indicates how the duration of an effect is determined, via real time, combat time, or times used.
@@ -455,10 +400,109 @@ ED4E.eaeDurationTypes = {
 };
 preLocalize( "eaeDurationTypes" );
 
-ED4E.singleBonuses = {
-  knockdownEffects: "ED.Config.Eae.allKnockDownEffects",
+/**
+ * configuration data for Global Bonuses
+ * @typedef {object} GlobalBonusConfiguration
+ * @property {string} label                               Localized label.
+ * @property {{[key: string]: number|string}} [defaults]  Default values for this Attribute based on actor type.
+ */
+
+/**
+ * @description the global bonus configurations
+ * @enum { GlobalBonusConfiguration }
+ */
+ED4E.globalBonuses = {
+  allAttacks: {
+    label:       "ED.Actor.GlobalBonus.allAttacks"
+  },
+  allEffects: {
+    label:       "ED.Actor.GlobalBonus.allEffects"
+  },
+  allActions: {
+    label:       "ED.Actor.GlobalBonus.allActions"
+  },
+  allRangedAttacks: {
+    label:       "ED.Actor.GlobalBonus.allRangedAttacks"
+  },
+  allCloseAttacks: {
+    label:       "ED.Actor.GlobalBonus.allCloseAttacks"
+  },
+  allSpellcasting: {
+    label:       "ED.Actor.GlobalBonus.allSpellcasting"
+  },
+  allDamage: {
+    label:       "ED.Actor.GlobalBonus.allDamage"
+  },
+  allMeleeDamage: {
+    label:       "ED.Actor.GlobalBonus.allMeleeDamage"
+  },
+  allRangedDamage: {
+    label:       "ED.Actor.GlobalBonus.allRangedDamage"
+  },
+  allRecoveryEffects: {
+    label:       "ED.Actor.GlobalBonus.allRecoveryEffects"
+  },
+  allKnockdownEffects: {
+    label:       "ED.Actor.GlobalBonus.allKnockDownEffects"
+  },
+  allSpellEffects: {
+    label:       "ED.Actor.GlobalBonus.allSpellEffects"
+  }
 };
-preLocalize( "singleBonuses" );
+preLocalize( "globalBonuses", { key: "label" } );
+
+ED4E.singleBonuses = {
+  knockdownEffects: {
+    label: "ED.Config.Eae.allKnockDownEffects",
+  },
+};
+preLocalize( "singleBonuses", { key: "label" } );
+
+/**
+ * A list of select input options that map a human-readable label to the field path for the change.
+ * @type {FormSelectOption[]}
+ */
+ED4E.eaeChangeKeysActor = [
+  ...Object.entries( ED4E.globalBonuses ).map( ( [ key, { label } ] ) => {
+    return {
+      value:    `system.globalBonuses.${key}`,
+      label:    label,
+      group:    "ED.ActiveEffect.ChangeKeys.Groups.globalBonuses",
+      disabled: false,
+      selected: false,
+      rule:     false,
+    };
+  } ),
+  ...Object.entries( ED4E.singleBonuses ).map( ( [ key, { label } ] ) => {
+    return {
+      value:    `system.singleBonuses.${key}`,
+      label:    label,
+      group:    "ED.ActiveEffect.ChangeKeys.Groups.singleBonuses",
+    };
+  } ),
+];
+preLocalize( "eaeChangeKeysActor", { key: "label" } );
+
+/**
+ * A list of select input options that map a human-readable label to the field path for the change.
+ * @type {FormSelectOption[]}
+ */
+ED4E.eaeChangeKeysItem = [
+  {
+    value:    "system.attribute",
+    label:    "ED.Data.Item.Ability.attribute",
+    group:    "",
+  },
+  {
+    value:    "system.level",
+    label:    "ED.Data.Item.Ability.rank",
+    group:    "",
+  },
+];
+preLocalize( "eaeChangeKeysItem", { key: "label" } );
+
+// endregion
+
 
 /* -------------------------------------------- */
 /*  Advancement & Char Gen                      */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -186,12 +186,23 @@ ED4E.groupDifficulty = {
 preLocalize( "groupDifficulty" );
 
 /**
+ * Defense Types
+ * @enum {string}
+ */
+ED4E.defense = {
+  mystical:   "ED.Config.Defenses.mystical",
+  physical:   "ED.Config.Defenses.physical",
+  social:     "ED.Config.Defenses.social",
+};
+preLocalize( "defense" );
+
+/**
  * Armor
  * @enum {string}
  */
 ED4E.armor = {
-  physical:   "ED.Armor.physical",
-  mystical:   "ED.Armor.mystical",
+  physical:   "ED.Config.Armor.physical",
+  mystical:   "ED.Config.Armor.mystical",
 };
 preLocalize( "armor" );
 
@@ -386,6 +397,225 @@ ED4E.spellEnhancements = {
 preLocalize( "spellEnhancements", { key: "label", sort: true } );
 
 
+// region System
+
+/**
+ * Reserved earthdawn ids.
+ * @enum {string}
+ */
+ED4E.reserved_edid = {
+  DEFAULT:    "none",
+  ANY:        "any",
+};
+
+ED4E.formulaValueTypes = {
+  attribute:  "ED.Config.FormulaValueTypes.attribute",
+  circle:     "ED.Config.FormulaValueTypes.circle",
+  numeric:    "ED.Config.FormulaValueTypes.numeric",
+  rank:       "ED.Config.FormulaValueTypes.rank",
+  special:    "ED.Config.FormulaValueTypes.special",
+};
+
+/**
+ * Time periods that accept a numeric value.
+ * @enum {string}
+ */
+ED4E.scalarTimePeriods = {
+  turn:   "ED.Config.ScalarTimePeriods.turn",
+  round:  "ED.Config.ScalarTimePeriods.round",
+  minute: "ED.Config.ScalarTimePeriods.minute",
+  hour:   "ED.Config.ScalarTimePeriods.hour",
+  day:    "ED.Config.ScalarTimePeriods.day",
+  week:   "ED.Config.ScalarTimePeriods.week",
+  month:  "ED.Config.ScalarTimePeriods.month",
+  year:   "ED.Config.ScalarTimePeriods.year"
+};
+preLocalize( "scalarTimePeriods" );
+
+/**
+ * Time periods for spells that don't have a defined ending.
+ * @enum {string}
+ */
+ED4E.permanentTimePeriods = {
+  perm: "ED.Config.PermanentTimePeriods.perm"
+};
+preLocalize( "permanentTimePeriods" );
+
+/* -------------------------------------------- */
+
+/**
+ * Time periods that don't accept a numeric value.
+ * @enum {string}
+ */
+ED4E.specialTimePeriods = {
+  inst: "ED.Config.SpecialTimePeriods.inst",
+  spec: "ED.Config.SpecialTimePeriods.special"
+};
+preLocalize( "specialTimePeriods" );
+
+/* -------------------------------------------- */
+
+/**
+ * The various lengths of time over which effects can occur.
+ * @enum {string}
+ */
+ED4E.timePeriods = {
+  ...ED4E.specialTimePeriods,
+  ...ED4E.permanentTimePeriods,
+  ...ED4E.scalarTimePeriods
+};
+preLocalize( "timePeriods" );
+
+/* -------------------------------------------- */
+
+/**
+ * The various types of movement of moving entities.
+ * @enum {string}
+ */
+ED4E.movementTypes = {
+  burrow: "ED.Config.MovementTypes.burrow",
+  climb:  "ED.Config.MovementTypes.climb",
+  fly:    "ED.Config.MovementTypes.fly",
+  swim:   "ED.Config.MovementTypes.swim",
+  walk:   "ED.Config.MovementTypes.walk"
+};
+preLocalize( "movementTypes", { sort: true } );
+
+/* -------------------------------------------- */
+
+/**
+ * The valid units of measure for movement distances in the game system.
+ * By default, this uses the imperial units of feet and miles.
+ * @enum {string}
+ */
+ED4E.movementUnits = {
+  in: "ED.Config.MovementUnits.inch",
+  ft: "ED.Config.MovementUnits.feet",
+  yd: "ED.Config.MovementUnits.yard",
+  mi: "ED.Config.MovementUnits.mile",
+};
+preLocalize( "movementUnits" );
+
+/* -------------------------------------------- */
+
+/**
+ * The types of range that are used for measuring actions and effects.
+ * @enum {string}
+ */
+ED4E.rangeTypes = {
+  self:  "ED.Config.RangeTypes.self",
+  touch: "ED.Config.RangeTypes.touch",
+  spec:  "ED.Config.RangeTypes.special",
+  any:   "ED.Config.RangeTypes.any",
+};
+preLocalize( "rangeTypes" );
+
+/* -------------------------------------------- */
+
+/**
+ * The valid units of measure for the range of an action or effect. A combination of {@link ED4E.movementUnits}
+ * and {@link ED4E.rangeTypes}.
+ * @enum {string}
+ */
+ED4E.distanceUnits = {
+  ...ED4E.movementUnits,
+  ...ED4E.rangeTypes,
+};
+preLocalize( "distanceUnits" );
+
+/* -------------------------------------------- */
+
+/**
+ * Information needed to represent different area of effect target types.
+ * @typedef {object} AreaTargetDefinition
+ * @property {string} label        Localize(d) label for this type.
+ * @property {string} template     Type of `MeasuredTemplate` create for this target type.
+ * @property {string} [reference]  Reference to a rule page describing this area of effect.
+ * @property {string[]} [sizes]    List of available sizes for this template. Options are chosen from the list: "angle",
+ *                                 "radius", "width", "height", "length", "thickness". No more than 3 dimensions may
+ *                                 be specified.
+ */
+
+/**
+ * Types for effects that cover an area.
+ * @enum {AreaTargetDefinition}
+ */
+ED4E.areaTargetDefinition = {
+  circle:   {
+    label:    "ED.Config.AreaTargets.circle",
+    template: "circle",
+    sizes:    [ "radius" ],
+  },
+  cone:     {
+    label:    "ED.Config.AreaTargets.cone",
+    template: "cone",
+    sizes:    [ "angle", "radius" ],
+  },
+  cube:     {
+    label:    "ED.Config.AreaTargets.cube",
+    template: "rect",
+    sizes:    [ "width" ],
+  },
+  cylinder: {
+    label:    "ED.Config.AreaTargets.cylinder",
+    template: "circle",
+    sizes:    [ "radius", "height" ],
+  },
+  line:     {
+    label:    "ED.Config.AreaTargets.line",
+    template: "ray",
+    sizes:    [ "length", "width" ],
+  },
+  radius:   {
+    label:    "ED.Config.AreaTargets.radius",
+    template: "circle",
+  },
+  sphere:   {
+    label:    "ED.Config.AreaTargets.sphere",
+    template: "circle",
+    sizes:    [ "radius" ],
+  },
+  square:   {
+    label:    "ED.Config.AreaTargets.square",
+    template: "rect",
+    sizes:    [ "width" ],
+  },
+  wall:     {
+    label:    "ED.Config.AreaTargets.wall",
+    template: "ray",
+    sizes:    [ "length", "thickness", "height" ],
+  },
+};
+preLocalize( "areaTargetDefinition", { key: "label", sort: true } );
+
+ED4E.spellEnhancementUnits = {
+  ...ED4E.movementUnits,
+  ...ED4E.scalarTimePeriods,
+};
+preLocalize( "spellEnhancementUnits" );
+
+/* -------------------------------------------- */
+/*  Chat Commands                               */
+/* -------------------------------------------- */
+
+/**
+ * The available chat commands with their corresponding help text.
+ * @enum {string}
+ */
+ED4E.chatCommands = {
+  char:     "X.chatCommandCharHelp no parameters, trigger char gen",
+  coin:     "X.chatCommandCoinHelp number plus coinage, pass out coins",
+  group:    "X.chatCommandGroupHelp no parameters?, calc CR for group",
+  h:        "X.chatCommandHelp optional param 'chatCommand', show general help or for given command",
+  help:     "X.chatCommandHelp optional param 'chatCommand', show general help or for given command",
+  lp:       "X.chatCommandLpHelp number, award LP points",
+  s:        "X.chatCommandSHelp any number of steps separated by whitespace or +, roll the given steps",
+};
+preLocalize( "chatCommands" );
+
+// endregion
+
+
 // region Active Effects
 
 /**
@@ -443,7 +673,7 @@ ED4E.globalBonuses = {
     label:       "ED.Actor.GlobalBonus.allRecoveryEffects"
   },
   allKnockdownEffects: {
-    label:       "ED.Actor.GlobalBonus.allKnockDownEffects"
+    label:       "ED.Actor.GlobalBonus.allKnockdownEffects"
   },
   allSpellEffects: {
     label:       "ED.Actor.GlobalBonus.allSpellEffects"
@@ -473,15 +703,156 @@ ED4E.eaeChangeKeysActor = [
       rule:     false,
     };
   } ),
-  ...Object.entries( ED4E.singleBonuses ).map( ( [ key, { label } ] ) => {
+  /* ...Object.entries( ED4E.singleBonuses ).map( ( [ key, { label } ] ) => {
     return {
       value:    `system.singleBonuses.${key}`,
       label:    label,
       group:    "ED.ActiveEffect.ChangeKeys.Groups.singleBonuses",
     };
+  } ), */
+  ...Object.entries( ED4E.attributes ).map( ( [ key, { label } ] ) => {
+    return {
+      value:    `system.attribute.${key}.baseStep`,
+      label:    label,
+      group:    "ED.ActiveEffect.ChangeKeys.Groups.attributeStep",
+    };
   } ),
+  ...Object.entries( ED4E.attributes ).map( ( [ key, { label } ] ) => {
+    return {
+      value:     `system.attribute.${key}.baseValue`,
+      label:     label,
+      group:     "ED.ActiveEffect.ChangeKeys.Groups.attributeValue",
+    };
+  } ),
+  ...Object.entries( ED4E.movementTypes ).map( ( [ key, label ] ) => {
+    return {
+      value:    `system.characteristics.movement.${key}`,
+      label:    label,
+      group:    "ED.ActiveEffect.ChangeKeys.Groups.movement",
+    };
+  } ),
+  ...Object.entries( ED4E.defense ).map( ( [ key, label ] ) => {
+    return {
+      value:    `system.characteristics.defenses.${key}.baseValue`,
+      label:    label,
+      group:    "ED.ActiveEffect.ChangeKeys.Groups.defense",
+    };
+  } ),
+  ...Object.entries( ED4E.armor ).map( ( [ key, label ] ) => {
+    return {
+      value:    `system.characteristics.armor.${key}.baseValue`,
+      label:    label,
+      group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
+    };
+  } ),
+  // initiative
+  {
+    value:    "system.initiative",
+    label:    "ED.Data.Actor.Labels.initiative",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.initiative",
+  },
+  // encumbrance
+  {
+    value:    "system.characteristics.encumbrance.value",
+    label:    "ED.Data.Actor.Labels.encumbrance",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.encumbrance",
+  },
+  {
+    value:    "system.characteristics.encumbrance.max",
+    label:    "ED.Data.Actor.Labels.encumbranceMax",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.encumbrance",
+  },
+  {
+    value:    "system.characteristics.encumbrance.bonus",
+    label:    "ED.Data.Actor.Labels.encumbranceBonus",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.encumbrance",
+  },
+  // health
+  {
+    value:    "system.durabilityBonus",
+    label:    "ED.Data.Actor.Labels.durabilityBonus",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.health",
+  },
+  {
+    value:    "system.characteristics.health.death",
+    label:    "ED.Data.Actor.Labels.Characteristics.deathRating",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.health",
+  },
+  {
+    value:    "system.characteristics.health.unconscious",
+    label:    "ED.Data.Actor.Labels.Characteristics.unconsciousRate",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.health",
+  },
+  {
+    value:    "system.characteristics.health.bloodMagic.damage",
+    label:    "ED.Data.Actor.Labels.Characteristics.bloodMagicDamage",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.bloodMagic",
+  },
+  {
+    value:    "system.characteristics.health.bloodMagic.wounds",
+    label:    "ED.Data.Actor.Labels.Characteristics.bloodMagicWounds",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.bloodMagic",
+  },
+  {
+    value:    "system.characteristics.health.woundThreshold",
+    label:    "ED.Data.Actor.Labels.Characteristics.woundThreshold",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.health",
+  },
+  {
+    value:    "system.characteristics.health.wounds",
+    label:    "ED.Data.Actor.Labels.Characteristics.wounds",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.health",
+  },
+  {
+    value:    "system.characteristics.health.maxWounds",
+    label:    "ED.Data.Actor.Labels.Characteristics.maxWounds",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.health",
+  },
+  // recovery
+  {
+    value:    "system.characteristics.recoveryTestsResource.value",
+    label:    "ED.Data.Actor.Labels.Characteristics.recoveryTestsCurrent",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.recoveryTestsResource",
+  },
+  {
+    value:    "system.characteristics.recoveryTestsResource.max",
+    label:    "ED.Data.Actor.Labels.Characteristics.recoveryTestsMax",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.recoveryTestsResource",
+  },
+  // karma
+  {
+    value:    "system.karma.value",
+    label:    "ED.Data.Actor.Labels.karma",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.karma",
+  },
+  {
+    value:    "system.karma.max",
+    label:    "ED.Data.Actor.Labels.karmaMax",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.karma",
+  },
+  {
+    value:    "system.karma.step",
+    label:    "ED.Data.Actor.Labels.karmaStep",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.karma",
+  },
+  // devotion
+  {
+    value:    "system.devotion.value",
+    label:    "ED.Data.Actor.Labels.devotion",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.devotion",
+  },
+  {
+    value:    "system.devotion.max",
+    label:    "ED.Data.Actor.Labels.devotionMax",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.devotion",
+  },
+  {
+    value:    "system.devotion.step",
+    label:    "ED.Data.Actor.Labels.devotionStep",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.devotion",
+  },
 ];
-preLocalize( "eaeChangeKeysActor", { key: "label" } );
+preLocalize( "eaeChangeKeysActor", { keys: [ "label", "group" ] } );
 
 /**
  * A list of select input options that map a human-readable label to the field path for the change.
@@ -498,8 +869,15 @@ ED4E.eaeChangeKeysItem = [
     label:    "ED.Data.Item.Ability.rank",
     group:    "",
   },
+  ...Object.entries( ED4E.attributes ).map( ( [ key, { label } ] )  => {
+    return {
+      value:    `system.attribute.${key}`,
+      label:    label,
+      group:    "ED.ActiveEffect.ChangeKeys.Groups.attribute",
+    };
+  } ),
 ];
-preLocalize( "eaeChangeKeysItem", { key: "label" } );
+preLocalize( "eaeChangeKeysItem", { keys: [ "label", "group" ] } );
 
 // endregion
 
@@ -1139,225 +1517,6 @@ ED4E.resourceDefaultStep = {
   karma:    4,
   devotion: 3,
 };
-
-
-/* -------------------------------------------- */
-/*  System                                      */
-/* -------------------------------------------- */
-
-/**
- * Reserved earthdawn ids.
- * @enum {string}
- */
-ED4E.reserved_edid = {
-  DEFAULT:    "none",
-  ANY:        "any",
-};
-
-ED4E.formulaValueTypes = {
-  attribute:  "ED.Config.FormulaValueTypes.attribute",
-  circle:     "ED.Config.FormulaValueTypes.circle",
-  numeric:    "ED.Config.FormulaValueTypes.numeric",
-  rank:       "ED.Config.FormulaValueTypes.rank",
-  special:    "ED.Config.FormulaValueTypes.special",
-};
-
-/**
- * Time periods that accept a numeric value.
- * @enum {string}
- */
-ED4E.scalarTimePeriods = {
-  turn:   "ED.Config.ScalarTimePeriods.turn",
-  round:  "ED.Config.ScalarTimePeriods.round",
-  minute: "ED.Config.ScalarTimePeriods.minute",
-  hour:   "ED.Config.ScalarTimePeriods.hour",
-  day:    "ED.Config.ScalarTimePeriods.day",
-  week:   "ED.Config.ScalarTimePeriods.week",
-  month:  "ED.Config.ScalarTimePeriods.month",
-  year:   "ED.Config.ScalarTimePeriods.year"
-};
-preLocalize( "scalarTimePeriods" );
-
-/**
- * Time periods for spells that don't have a defined ending.
- * @enum {string}
- */
-ED4E.permanentTimePeriods = {
-  perm: "ED.Config.PermanentTimePeriods.perm"
-};
-preLocalize( "permanentTimePeriods" );
-
-/* -------------------------------------------- */
-
-/**
- * Time periods that don't accept a numeric value.
- * @enum {string}
- */
-ED4E.specialTimePeriods = {
-  inst: "ED.Config.SpecialTimePeriods.inst",
-  spec: "ED.Config.SpecialTimePeriods.special"
-};
-preLocalize( "specialTimePeriods" );
-
-/* -------------------------------------------- */
-
-/**
- * The various lengths of time over which effects can occur.
- * @enum {string}
- */
-ED4E.timePeriods = {
-  ...ED4E.specialTimePeriods,
-  ...ED4E.permanentTimePeriods,
-  ...ED4E.scalarTimePeriods
-};
-preLocalize( "timePeriods" );
-
-/* -------------------------------------------- */
-
-/**
- * The various types of movement of moving entities.
- * @enum {string}
- */
-ED4E.movementTypes = {
-  burrow: "ED.Config.MovementTypes.burrow",
-  climb:  "ED.Config.MovementTypes.Climb",
-  fly:    "ED.Config.MovementTypes.Fly",
-  swim:   "ED.Config.MovementTypes.Swim",
-  walk:   "ED.Config.MovementTypes.Walk"
-};
-preLocalize( "movementTypes", { sort: true } );
-
-/* -------------------------------------------- */
-
-/**
- * The valid units of measure for movement distances in the game system.
- * By default, this uses the imperial units of feet and miles.
- * @enum {string}
- */
-ED4E.movementUnits = {
-  in: "ED.Config.MovementUnits.inch",
-  ft: "ED.Config.MovementUnits.feet",
-  yd: "ED.Config.MovementUnits.yard",
-  mi: "ED.Config.MovementUnits.mile",
-};
-preLocalize( "movementUnits" );
-
-/* -------------------------------------------- */
-
-/**
- * The types of range that are used for measuring actions and effects.
- * @enum {string}
- */
-ED4E.rangeTypes = {
-  self:  "ED.Config.RangeTypes.self",
-  touch: "ED.Config.RangeTypes.touch",
-  spec:  "ED.Config.RangeTypes.special",
-  any:   "ED.Config.RangeTypes.any",
-};
-preLocalize( "rangeTypes" );
-
-/* -------------------------------------------- */
-
-/**
- * The valid units of measure for the range of an action or effect. A combination of {@link ED4E.movementUnits}
- * and {@link ED4E.rangeTypes}.
- * @enum {string}
- */
-ED4E.distanceUnits = {
-  ...ED4E.movementUnits,
-  ...ED4E.rangeTypes,
-};
-preLocalize( "distanceUnits" );
-
-/* -------------------------------------------- */
-
-/**
- * Information needed to represent different area of effect target types.
- * @typedef {object} AreaTargetDefinition
- * @property {string} label        Localize(d) label for this type.
- * @property {string} template     Type of `MeasuredTemplate` create for this target type.
- * @property {string} [reference]  Reference to a rule page describing this area of effect.
- * @property {string[]} [sizes]    List of available sizes for this template. Options are chosen from the list: "angle",
- *                                 "radius", "width", "height", "length", "thickness". No more than 3 dimensions may
- *                                 be specified.
- */
-
-/**
- * Types for effects that cover an area.
- * @enum {AreaTargetDefinition}
- */
-ED4E.areaTargetDefinition = {
-  circle:   {
-    label:    "ED.Config.AreaTargets.circle",
-    template: "circle",
-    sizes:    [ "radius" ],
-  },
-  cone:     {
-    label:    "ED.Config.AreaTargets.cone",
-    template: "cone",
-    sizes:    [ "angle", "radius" ],
-  },
-  cube:     {
-    label:    "ED.Config.AreaTargets.cube",
-    template: "rect",
-    sizes:    [ "width" ],
-  },
-  cylinder: {
-    label:    "ED.Config.AreaTargets.cylinder",
-    template: "circle",
-    sizes:    [ "radius", "height" ],
-  },
-  line:     {
-    label:    "ED.Config.AreaTargets.line",
-    template: "ray",
-    sizes:    [ "length", "width" ],
-  },
-  radius:   {
-    label:    "ED.Config.AreaTargets.radius",
-    template: "circle",
-  },
-  sphere:   {
-    label:    "ED.Config.AreaTargets.sphere",
-    template: "circle",
-    sizes:    [ "radius" ],
-  },
-  square:   {
-    label:    "ED.Config.AreaTargets.square",
-    template: "rect",
-    sizes:    [ "width" ],
-  },
-  wall:     {
-    label:    "ED.Config.AreaTargets.wall",
-    template: "ray",
-    sizes:    [ "length", "thickness", "height" ],
-  },
-};
-preLocalize( "areaTargetDefinition", { key: "label", sort: true } );
-
-ED4E.spellEnhancementUnits = {
-  ...ED4E.movementUnits,
-  ...ED4E.scalarTimePeriods,
-};
-preLocalize( "spellEnhancementUnits" );
-
-/* -------------------------------------------- */
-/*  Chat Commands                               */
-/* -------------------------------------------- */
-
-/**
- * The available chat commands with their corresponding help text.
- * @enum {string}
- */
-ED4E.chatCommands = {
-  char:     "X.chatCommandCharHelp no parameters, trigger char gen",
-  coin:     "X.chatCommandCoinHelp number plus coinage, pass out coins",
-  group:    "X.chatCommandGroupHelp no parameters?, calc CR for group",
-  h:        "X.chatCommandHelp optional param 'chatCommand', show general help or for given command",
-  help:     "X.chatCommandHelp optional param 'chatCommand', show general help or for given command",
-  lp:       "X.chatCommandLpHelp number, award LP points",
-  s:        "X.chatCommandSHelp any number of steps separated by whitespace or +, roll the given steps",
-};
-preLocalize( "chatCommands" );
 
 
 /* -------------------------------------------- */

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -859,23 +859,123 @@ preLocalize( "eaeChangeKeysActor", { keys: [ "label", "group" ] } );
  * @type {FormSelectOption[]}
  */
 ED4E.eaeChangeKeysItem = [
+  // Rollable
+  {
+    value:    "system.rollType",
+    label:    "ED.Data.General.Labels.Rollable.type",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.rollable",
+  },
+  // Action
+  {
+    value:    "system.action",
+    label:    "ED.Data.Item.Labels.Action.action",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.action",
+  },
+  {
+    value:    "system.strain",
+    label:    "ED.Data.Item.Labels.Action.strain",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.action",
+  },
+  // Targeting
+  {
+    value:    "system.difficulty.target",
+    label:    "ED.Data.General.Labels.Target.target",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.targeting",
+  },
+  {
+    value:    "system.difficulty.group",
+    label:    "ED.Data.General.Labels.Target.group",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.targeting",
+  },
+  {
+    value:    "system.difficulty.fixed",
+    label:    "ED.Data.General.Labels.Target.fixed",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.targeting",
+  },
+  // Ability
   {
     value:    "system.attribute",
-    label:    "ED.Data.Item.Ability.attribute",
-    group:    "",
+    label:    "ED.Data.Item.Labels.Ability.attribute",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.ability",
+  },
+  {
+    value:    "system.tier",
+    label:    "ED.Data.Item.Labels.Ability.tier",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.ability",
   },
   {
     value:    "system.level",
-    label:    "ED.Data.Item.Ability.rank",
-    group:    "",
+    label:    "ED.Data.Item.Labels.Ability.rank",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.ability",
   },
-  ...Object.entries( ED4E.attributes ).map( ( [ key, { label } ] )  => {
-    return {
-      value:    `system.attribute.${key}`,
-      label:    label,
-      group:    "ED.ActiveEffect.ChangeKeys.Groups.attribute",
-    };
-  } ),
+  // Armor
+  {
+    value:    "system.physical",
+    label:    "ED.Data.Item.Labels.Armor.physicalArmor",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
+  },
+  {
+    value:    "system.mystical",
+    label:    "ED.Data.Item.Labels.Armor.mysticalArmor",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
+  },
+  {
+    value:    "system.initiativePenalty",
+    label:    "ED.Data.Item.Labels.Armor.initiativePenalty",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
+  },
+  // Shield
+  {
+    value:    "system.defenseBonus.physical",
+    label:    "ED.Data.Item.Labels.Shields.defenseBonusPhysical",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.shield",
+  },
+  {
+    value:    "system.defenseBonus.mystical",
+    label:    "ED.Data.Item.Labels.Shields.defenseBonusMystical",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.shield",
+  },
+  {
+    value:    "system.initiativePenalty",
+    label:    "ED.Data.Item.Labels.Shields.initiativePenalty",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.shield",
+  },
+  {
+    value:    "system.shatterThreshold",
+    label:    "ED.Data.Item.Labels.Shields.shatterThreshold",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.shield",
+  },
+  // Weapon
+  {
+    value:    "system.damage",
+    label:    "ED.Data.Item.Labels.Weapons.damageBaseStep",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weapon",
+  },
+  {
+    value:    "system.forgeBonus",
+    label:    "ED.Data.Item.Labels.Weapons.forgeBonus",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weapon",
+  },
+  {
+    value:    "system.range.shortMin",
+    label:    "ED.Data.Item.Labels.Weapons.rangeShortMin",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weaponRange",
+  },
+  {
+    value:    "system.range.shortMax",
+    label:    "ED.Data.Item.Labels.Weapons.rangeShortMax",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weaponRange",
+  },
+  {
+    value:    "system.range.longMin",
+    label:    "ED.Data.Item.Labels.Weapons.rangeLongMin",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weaponRange",
+  },
+  {
+    value:    "system.range.longMax",
+    label:    "ED.Data.Item.Labels.Weapons.rangeLongMax",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weaponRange",
+  },
 ];
 preLocalize( "eaeChangeKeysItem", { keys: [ "label", "group" ] } );
 

--- a/module/config.mjs
+++ b/module/config.mjs
@@ -695,7 +695,7 @@ preLocalize( "singleBonuses", { key: "label" } );
 ED4E.eaeChangeKeysActor = [
   ...Object.entries( ED4E.globalBonuses ).map( ( [ key, { label } ] ) => {
     return {
-      value:    `system.globalBonuses.${key}`,
+      value:    `system.globalBonuses.${key}.value`,
       label:    label,
       group:    "ED.ActiveEffect.ChangeKeys.Groups.globalBonuses",
       disabled: false,
@@ -712,14 +712,14 @@ ED4E.eaeChangeKeysActor = [
   } ), */
   ...Object.entries( ED4E.attributes ).map( ( [ key, { label } ] ) => {
     return {
-      value:    `system.attribute.${key}.baseStep`,
+      value:    `system.attributes.${key}.baseStep`,
       label:    label,
       group:    "ED.ActiveEffect.ChangeKeys.Groups.attributeStep",
     };
   } ),
   ...Object.entries( ED4E.attributes ).map( ( [ key, { label } ] ) => {
     return {
-      value:     `system.attribute.${key}.baseValue`,
+      value:     `system.attributes.${key}.baseValue`,
       label:     label,
       group:     "ED.ActiveEffect.ChangeKeys.Groups.attributeValue",
     };
@@ -753,17 +753,17 @@ ED4E.eaeChangeKeysActor = [
   },
   // encumbrance
   {
-    value:    "system.characteristics.encumbrance.value",
+    value:    "system.encumbrance.value",
     label:    "ED.Data.Actor.Labels.encumbrance",
     group:    "ED.ActiveEffect.ChangeKeys.Groups.encumbrance",
   },
   {
-    value:    "system.characteristics.encumbrance.max",
+    value:    "system.encumbrance.max",
     label:    "ED.Data.Actor.Labels.encumbranceMax",
     group:    "ED.ActiveEffect.ChangeKeys.Groups.encumbrance",
   },
   {
-    value:    "system.characteristics.encumbrance.bonus",
+    value:    "system.encumbrance.bonus",
     label:    "ED.Data.Actor.Labels.encumbranceBonus",
     group:    "ED.ActiveEffect.ChangeKeys.Groups.encumbrance",
   },
@@ -910,13 +910,23 @@ ED4E.eaeChangeKeysItem = [
   },
   // Armor
   {
-    value:    "system.physical",
+    value:    "system.physical.armor",
     label:    "ED.Data.Item.Labels.Armor.physicalArmor",
     group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
   },
   {
-    value:    "system.mystical",
+    value:    "system.physical.forgeBonus",
+    label:    "ED.Data.Item.Labels.Armor.forgeBonusPhysical",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
+  },
+  {
+    value:    "system.mystical.armor",
     label:    "ED.Data.Item.Labels.Armor.mysticalArmor",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
+  },
+  {
+    value:    "system.mystical.forgeBonus",
+    label:    "ED.Data.Item.Labels.Armor.forgeBonusMystical",
     group:    "ED.ActiveEffect.ChangeKeys.Groups.armor",
   },
   {
@@ -947,8 +957,18 @@ ED4E.eaeChangeKeysItem = [
   },
   // Weapon
   {
-    value:    "system.damage",
+    value:    "system.damage.attribute",
+    label:    "ED.Data.Item.Labels.Weapons.damageAttribute",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weapon",
+  },
+  {
+    value:    "system.damage.baseStep",
     label:    "ED.Data.Item.Labels.Weapons.damageBaseStep",
+    group:    "ED.ActiveEffect.ChangeKeys.Groups.weapon",
+  },
+  {
+    value:    "system.damage.type",
+    label:    "ED.Data.Item.Labels.Weapons.damageType",
     group:    "ED.ActiveEffect.ChangeKeys.Groups.weapon",
   },
   {

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -1,5 +1,4 @@
 import { callIfExists } from "../utils.mjs";
-import { buildSelectOptionsFromModel } from "../applications/_module.mjs";
 
 /**
  * Taken from DnD5e ( https://github.com/foundryvtt/dnd5e )
@@ -21,38 +20,6 @@ import { buildSelectOptionsFromModel } from "../applications/_module.mjs";
  * via SystemDataModel.mixin.
  */
 export default class SystemDataModel extends foundry.abstract.TypeDataModel {
-
-  static {
-    /**
-     * The fields of the schema that should be excluded from the Earthdawn Active Effect keys. Given as field paths.
-     * @type {string[]}
-     */
-    this._EAE_EXCLUDE_KEYS = [];
-  }
-
-  static initEAE() {
-    for ( const cls of foundry.utils.getParentClasses( this ) ) {
-      if ( cls._EAE_EXCLUDE_KEYS ) this._EAE_EXCLUDE_KEYS.push( ...cls._EAE_EXCLUDE_KEYS );
-    }
-  }
-
-  constructor( data={}, options={} ) {
-    super( data, options );
-
-    // in constructor because I don't know how to do this in a static block/initializer, it always references this class, not the subclass
-    /**
-     * The select options for {@link EarthdawnActiveEffect}s, representing the fields of the schema.
-     * @type {FormSelectOption[]}
-     */
-    this.constructor.EAE_SELECT_OPTIONS = buildSelectOptionsFromModel(
-      this.schema.fields
-    ).filter(
-      field => !this.constructor._EAE_EXCLUDE_KEYS.some(
-        path => field.value.startsWith( path )
-      )
-    );
-
-  }
 
   /**
    * A bound version of {@link getLocalizeKey}. Used to automatically get the

--- a/module/data/actor/pc.mjs
+++ b/module/data/actor/pc.mjs
@@ -21,39 +21,6 @@ export default class PcData extends NamegiverTemplate {
   /** @inheritDoc */
   static _systemType = "character";
 
-  static {
-    this._EAE_EXCLUDE_KEYS = [
-      "system.attributes.dex.initialValue",
-      "system.attributes.str.initialValue",
-      "system.attributes.tou.initialValue",
-      "system.attributes.per.initialValue",
-      "system.attributes.wil.initialValue",
-      "system.attributes.cha.initialValue",
-      "system.attributes.dex.baseValue",
-      "system.attributes.str.baseValue",
-      "system.attributes.tou.baseValue",
-      "system.attributes.per.baseValue",
-      "system.attributes.wil.baseValue",
-      "system.attributes.cha.baseValue",
-      "system.attributes.dex.valueModifier",
-      "system.attributes.str.valueModifier",
-      "system.attributes.tou.valueModifier",
-      "system.attributes.per.valueModifier",
-      "system.attributes.wil.valueModifier",
-      "system.attributes.cha.valueModifier",
-      "system.attributes.dex.timesIncreased",
-      "system.attributes.str.timesIncreased",
-      "system.attributes.tou.timesIncreased",
-      "system.attributes.per.timesIncreased",
-      "system.attributes.wil.timesIncreased",
-      "system.attributes.cha.timesIncreased",
-      "system.lp",
-    ];
-    this.initEAE();
-  }
-
-  /* -------------------------------------------- */
-
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/actor/templates/namegiver.mjs
+++ b/module/data/actor/templates/namegiver.mjs
@@ -10,13 +10,6 @@ const futils = foundry.utils;
  */
 export default class NamegiverTemplate extends SentientTemplate {
 
-  static {
-    this._EAE_EXCLUDE_KEYS = [
-      "system.languages",
-    ];
-    this.initEAE();
-  }
-
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/actor/templates/sentient.mjs
+++ b/module/data/actor/templates/sentient.mjs
@@ -9,25 +9,6 @@ import MappingField from "../../fields/mapping-field.mjs";
  */
 export default class SentientTemplate extends CommonTemplate {
 
-  static {
-    this._EAE_EXCLUDE_KEYS = [
-      "system.healthRate",
-      "system.isMob",
-      "system.condition",
-      "system.relations",
-      "system.characteristics.defenses.baseValue",
-      "system.characteristics.armor.baseValue",
-      "system.characteristics.recoveryTestsResource.stunRecoveryAvailable",
-      "system.health.damage.total",
-      "system.devotion.value",
-      "system.karma.value",
-      "system.karma.useAlways",
-      "system.karma.freeAttributePoints",
-      "system.encumbrance.value",
-      "system.encumbrance.status",
-    ];
-    this.initEAE();
-  }
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;


### PR DESCRIPTION
Lists are move to explicit config values
Not all keys work yet, this needs a review of the data preparation pipeline and will be done in another PR