### PR TITLE
add-basis-for-executing-active-effects

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -591,6 +591,8 @@
           "documentOriginType":                         "Der Typ des Dokuments aus dem dieser Effekt stammt. Leer, wenn direkt durch User erstellt.",
           "documentOriginUuid":                         "Die UUID des Dokuments aus dem dieser Effekt stammt. Leer, wenn direkt durch User erstellt.",
           "duration":                                   "Die Dauer des Effekts",
+          "executable":                                 "Hat dieser EAE einen eigens implementierten Effekt?",
+          "executionScript":                            "Das Script das ausgeführt wird wenn dieser Effekt aktiviert wird",
           "source":                                     "Woher kommt dieser Effekt und wie ist er zustande gekommen?",
           "transferToTarget":                           "Wird dieser Effekt nach Ausführung der Fähigkeit auf das Ziel übertragen?"
         },
@@ -601,6 +603,8 @@
           "documentOriginType":                         "Dokumenttyp Ursprung",
           "documentOriginUuid":                         "Dokument Ursprung",
           "duration":                                   "Dauer",
+          "executable":                                 "Ausführbar",
+          "executionScript":                            "Script",
           "source":                                     "Ursprung",
           "transferToTarget":                           "Übertrage auf Ziel"
         }
@@ -1921,7 +1925,18 @@
       "researchCheck":                                    "Würfle Forschen um die Geheimnisse des Fadengegenstandes zu erforschen."
     }
   },
+  "EFFECT": {
+    "TABS": {
+      "changes": "Änderungen",
+      "details": "Details",
+      "duration": "Dauer",
+      "execution": "Ausführung"
+    }
+  },
   "TYPES": {
+    "ActiveEffect": {
+      "eae": "EAE"
+    },
     "Actor": {
       "character": "Charakter",
       "creature": "Kreatur",

--- a/lang/de.json
+++ b/lang/de.json
@@ -411,6 +411,19 @@
           "permanent":                                              "Permanent",
           "realTime":                                               "Zeit",
           "uses":                                                   "Anwendungen"
+        },
+        "ExecutionTime": {
+          "Groups": {
+            "combat": "Kampf",
+            "round": "Runde",
+            "turn": "Zug"
+          },
+          "combatStart": "Kampfbeginn",
+          "combatEnd": "Kampfende",
+          "roundStart": "Rundenbeginn",
+          "roundEnd": "Rundenende",
+          "turnStart": "Zugbeginn",
+          "turnEnd": "Zugende"
         }
       },
       "Elements": {
@@ -592,6 +605,7 @@
           "documentOriginUuid":                         "Die UUID des Dokuments aus dem dieser Effekt stammt. Leer, wenn direkt durch User erstellt.",
           "duration":                                   "Die Dauer des Effekts",
           "executable":                                 "Hat dieser EAE einen eigens implementierten Effekt?",
+          "executeOn":                                  "Wann wird dieses Effekt-Script ausgeführt?",
           "executionScript":                            "Das Script das ausgeführt wird wenn dieser Effekt aktiviert wird",
           "source":                                     "Woher kommt dieser Effekt und wie ist er zustande gekommen?",
           "transferToTarget":                           "Wird dieser Effekt nach Ausführung der Fähigkeit auf das Ziel übertragen?"
@@ -604,6 +618,7 @@
           "documentOriginUuid":                         "Dokument Ursprung",
           "duration":                                   "Dauer",
           "executable":                                 "Ausführbar",
+          "executeOn":                                  "Ausführungszeitpunkt",
           "executionScript":                            "Script",
           "source":                                     "Ursprung",
           "transferToTarget":                           "Übertrage auf Ziel"

--- a/module/applications/effect/eae-sheet.mjs
+++ b/module/applications/effect/eae-sheet.mjs
@@ -25,9 +25,22 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
   /** @inheritDoc */
   static PARTS = {
     ...ActiveEffectConfig.PARTS,
-    details:  { template: "systems/ed4e/templates/effect/details.hbs" },
-    duration: { template: "systems/ed4e/templates/effect/duration.hbs" },
-    changes:  { template: "systems/ed4e/templates/effect/changes.hbs" },
+    details:   { template: "systems/ed4e/templates/effect/details.hbs" },
+    duration:  { template: "systems/ed4e/templates/effect/duration.hbs" },
+    changes:   { template: "systems/ed4e/templates/effect/changes.hbs" },
+    execution: { template: "systems/ed4e/templates/effect/execution.hbs" },
+  };
+
+  /** @inheritDoc */
+  static TABS = {
+    ...ActiveEffectConfig.TABS,
+    sheet: {
+      ...ActiveEffectConfig.TABS.sheet,
+      tabs: [
+        ...ActiveEffectConfig.TABS.sheet.tabs,
+        { id: "execution", icon: ED4E.icons.effectExecution },
+      ],
+    },
   };
 
   // region Properties
@@ -126,9 +139,25 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
         partContext.keyOptions = this.keyOptions;
         partContext.edids = getEdIds();
         break;
+      case "execution":
+        break;
     }
 
     return partContext;
+  }
+
+  /** @inheritDoc */
+  _prepareTabs( group ) {
+    // returns a new object, so can be modified without changing TABS
+    const tabs = super._prepareTabs( group );
+    const execInTabs = "execution" in tabs;
+    const executable = this.document.system.executable;
+
+    // remove execution tab if not executable
+    // no need to check opposite, as the tab is always added in ApplicationV2
+    if ( !executable && execInTabs ) delete tabs.execution;
+
+    return tabs;
   }
 
   // endregion

--- a/module/applications/effect/eae-sheet.mjs
+++ b/module/applications/effect/eae-sheet.mjs
@@ -19,6 +19,7 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
     actions: {
       addChange:     this.#onAddChange,
       deleteChange:  this.#onDeleteChange,
+      execute:       this.#onExecute,
     },
   };
 
@@ -189,6 +190,15 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
     const index = Number( row.dataset.index ) || 0;
     changes.splice( index, 1 );
     return this.submit( { updateData: { system: { changes } } } );
+  }
+
+  /**
+   * Execute the effect script, if available.
+   * @this {ActiveEffectConfig}
+   * @type {ApplicationClickAction}
+   */
+  static async #onExecute() {
+    return this.document.system.execute();
   }
 
   // endregion

--- a/module/config/_module.mjs
+++ b/module/config/_module.mjs
@@ -19,7 +19,7 @@ import * as SYSTEM from "./system.mjs";
 
 /* eslint-disable */
 // Since Foundry does not support hot reloading object notation templates...
-/* Hooks.on('hotReload', async ({ content, extension, packageId, packageType, path } = {}) => {
+Hooks.on('hotReload', async ({ content, extension, packageId, packageType, path } = {}) => {
   if (extension === 'hbs') {
     const key = Object.entries(flattenObject(templates)).find(([_, tpath]) => tpath == path)?.[0];
     if (!key) throw new Error(`Unrecognized template: ${path}`);
@@ -34,7 +34,7 @@ import * as SYSTEM from "./system.mjs";
     });
     Object.values(ui.windows).forEach(app => app.render(true));
   }
-}); */
+});
 /* eslint-enable */
 
 // Namespace Configuration Values

--- a/module/config/effects.mjs
+++ b/module/config/effects.mjs
@@ -15,6 +15,40 @@ export const eaeDurationTypes = {
 };
 preLocalize( "eaeDurationTypes" );
 
+export const eaeExecutionTime = {
+  combatStart: {
+    value: "combatStart",
+    label: "ED.Config.Eae.ExecutionTime.combatStart",
+    group: "ED.Config.Eae.ExecutionTime.Groups.combat",
+  },
+  combatEnd: {
+    value: "combatEnd",
+    label: "ED.Config.Eae.ExecutionTime.combatEnd",
+    group: "ED.Config.Eae.ExecutionTime.Groups.combat",
+  },
+  roundStart: {
+    value: "roundStart",
+    label: "ED.Config.Eae.ExecutionTime.roundStart",
+    group: "ED.Config.Eae.ExecutionTime.Groups.round",
+  },
+  roundEnd: {
+    value: "roundEnd",
+    label: "ED.Config.Eae.ExecutionTime.roundEnd",
+    group: "ED.Config.Eae.ExecutionTime.Groups.round",
+  },
+  turnStart: {
+    value: "turnStart",
+    label: "ED.Config.Eae.ExecutionTime.turnStart",
+    group: "ED.Config.Eae.ExecutionTime.Groups.turn",
+  },
+  turnEnd: {
+    value: "turnEnd",
+    label: "ED.Config.Eae.ExecutionTime.turnEnd",
+    group: "ED.Config.Eae.ExecutionTime.Groups.turn",
+  },
+};
+preLocalize( "eaeExecutionTime", { keys: [ "label", "group" ] } );
+
 /**
  * Configuration data for Global Bonuses
  * @typedef {object} GlobalBonusConfiguration

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -48,6 +48,7 @@ export const icons = {
   damage:           "fa-skull-crossbones",
   dice:             "fa-dice",
   effect:           "fa-biohazard",
+  effectExecution:  "fa-light fa-arrow-progress",
   halfmagic:        "fa-hat-wizard",
   initiative:       "fa-running",
   itemHistory:      "fa-history",

--- a/module/data/effects/eae.mjs
+++ b/module/data/effects/eae.mjs
@@ -184,7 +184,24 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
 
   // region Executable
 
-
+  /**
+   * Execute the effect's execution script.
+   * @param {{}} options - Additional options for executing the script. Currently not used.
+   * @returns {Promise} A promise that resolves once the script has been executed.
+   */
+  async execute( options = {} ) {
+    try {
+      const fn = new foundry.utils.AsyncFunction(
+        "effect",
+        "parent",
+        "options",
+        `{${ this.executionScript }\n}`,
+      );
+      await fn.call( globalThis, this.parent, this.parent.parent, options );
+    } catch ( error ) {
+      console.error( error );
+    }
+  }
 
   // endregion
 

--- a/module/data/effects/eae.mjs
+++ b/module/data/effects/eae.mjs
@@ -16,44 +16,103 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
 
     return this.mergeSchema( super.defineSchema(), {
       changes: new fields.ArrayField( new fields.EmbeddedDataField(
-        EarthdawnActiveEffectChangeData,
+        EarthdawnActiveEffectChangeData
       ), {
-        label:  this.labelKey( "changes" ),
-        hint:   this.hintKey( "changes" ),
+        label: this.labelKey( "changes" ),
+        hint:  this.hintKey( "changes" )
       } ),
       duration: new fields.EmbeddedDataField( EarthdawnActiveEffectDurationData, {
-        label:  this.labelKey( "duration" ),
-        hint:   this.hintKey( "duration" ),
+        label: this.labelKey( "duration" ),
+        hint:  this.hintKey( "duration" )
+      } ),
+      executable:       new fields.BooleanField( {
+        label:   this.labelKey( "executable" ),
+        hint:    this.hintKey( "executable" )
+      } ),
+      executionScript:  new fields.JavaScriptField( {
+        required: false,
+        label:    this.labelKey( "executionScript" ),
+        hint:     this.hintKey( "executionScript" )
       } ),
       transferToTarget: new fields.BooleanField( {
         initial: false,
         label:   this.labelKey( "transferToTarget" ),
-        hint:    this.hintKey( "transferToTarget" ),
+        hint:    this.hintKey( "transferToTarget" )
       } ),
       abilityEdid: new EdIdField( {
-        blank:    true,
-        initial:  "",
-        label:    this.labelKey( "abilityEdid" ),
-        hint:     this.hintKey( "abilityEdid" ),
+        blank:   true,
+        initial: "",
+        label:   this.labelKey( "abilityEdid" ),
+        hint:    this.hintKey( "abilityEdid" )
       } ),
       source: new fields.SchemaField(
         {
           documentOriginUuid: new fields.DocumentUUIDField( {
             label: this.labelKey( "documentOriginUuid" ),
-            hint:  this.hintKey( "documentOriginUuid" ),
+            hint:  this.hintKey( "documentOriginUuid" )
           } ),
           documentOriginType: new fields.StringField( {
             label: this.labelKey( "documentOriginType" ),
-            hint:  this.hintKey( "documentOriginType" ),
-          } ),
+            hint:  this.hintKey( "documentOriginType" )
+          } )
         },
         {
           label: this.labelKey( "source" ),
-          hint:  this.hintKey( "source" ),
+          hint:  this.hintKey( "source" )
         }
-      ),
+      )
     } );
   }
+
+
+  //  region CRUD
+
+  /** @inheritDoc */
+  async _preUpdate( changes, options, user ) {
+    if ( await super._preUpdate( changes, options, user ) === false ) return false;
+
+    if ( changes.system?.changes && !changes.changes ) {
+      changes.changes = await this._prepareChangesData( changes.system.changes );
+    }
+  }
+
+  /**
+   * Transform the system changes data into the expected format of the base data model. This includes evaluating
+   * formula fields.
+   * @param {[EarthdawnActiveEffectChangeData]} systemChanges - The system changes data
+   * @returns {Promise<EffectChangeData[]>} The prepared changes data
+   * @protected
+   */
+  async _prepareChangesData( systemChanges ) {
+    const evalData = await this._getFormulaData();
+    return systemChanges.map( change => {
+      const { key, value, mode, priority } = change;
+      try {
+        const finalValue = FormulaField.evaluate( value, evalData );
+        return {
+          key,
+          value: finalValue,
+          mode,
+          priority
+        };
+      } catch {
+        return change;
+      }
+    } );
+  }
+
+  /**
+   * Retrieve the formula data for the formula fields within this effect.
+   * @returns {Promise<object>} A promise that resolves to the roll data object of this effect's target.
+   * @protected
+   */
+  async _getFormulaData() {
+    if ( this.appliedToAbility ) return ( await fromUuid( this.abilityUuid ) )?.getRollData() ?? {};
+    return this.parent?.target?.getRollData() ?? {};
+  }
+
+  // endregion
+
 
   // region Properties
 
@@ -123,51 +182,9 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
   // endregion
 
 
-  //  region CRUD
+  // region Executable
 
-  /** @inheritDoc */
-  async _preUpdate( changes, options, user ) {
-    if ( await super._preUpdate( changes, options, user ) === false ) return false;
 
-    if ( changes.system?.changes && !changes.changes ) {
-      changes.changes = await this._prepareChangesData( changes.system.changes );
-    }
-  }
-
-  /**
-   * Transform the system changes data into the expected format of the base data model. This includes evaluating
-   * formula fields.
-   * @param {[EarthdawnActiveEffectChangeData]} systemChanges - The system changes data
-   * @returns {Promise<EffectChangeData[]>} The prepared changes data
-   * @protected
-   */
-  async _prepareChangesData( systemChanges ) {
-    const evalData = await this._getFormulaData();
-    return systemChanges.map( change => {
-      const { key, value, mode, priority } = change;
-      try {
-        const finalValue = FormulaField.evaluate( value, evalData );
-        return {
-          key,
-          value: finalValue,
-          mode,
-          priority,
-        };
-      } catch {
-        return change;
-      }
-    } );
-  }
-
-  /**
-   * Retrieve the formula data for the formula fields within this effect.
-   * @returns {Promise<object>} A promise that resolves to the roll data object of this effect's target.
-   * @protected
-   */
-  async _getFormulaData() {
-    if ( this.appliedToAbility ) return ( await fromUuid( this.abilityUuid ) )?.getRollData() ?? {};
-    return this.parent?.target?.getRollData() ?? {};
-  }
 
   // endregion
 

--- a/module/data/effects/eae.mjs
+++ b/module/data/effects/eae.mjs
@@ -3,6 +3,7 @@ import EdIdField from "../fields/edid-field.mjs";
 import EarthdawnActiveEffectChangeData from "./eae-change-data.mjs";
 import EarthdawnActiveEffectDurationData from "./eae-duration.mjs";
 import FormulaField from "../fields/formula-field.mjs";
+import ED4E from "../../config/_module.mjs";
 
 
 /**
@@ -29,8 +30,15 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
         label:   this.labelKey( "executable" ),
         hint:    this.hintKey( "executable" )
       } ),
+      executeOn:        new fields.StringField( {
+        required: false,
+        choices:  ED4E.eaeExecutionTime,
+        label:    this.labelKey( "executeOn" ),
+        hint:     this.hintKey( "executeOn" ),
+      } ),
       executionScript:  new fields.JavaScriptField( {
         required: false,
+        initial:  "/**\n* This scope has the following variables available:\n* - effect: The \`EarthdawnActiveEffect\` document instance this script lives on\n* - parent: The parent document of this effect, either an \`ActorEd\` or an \`ItemEd\`\n*/\n\n",
         label:    this.labelKey( "executionScript" ),
         hint:     this.hintKey( "executionScript" )
       } ),

--- a/templates/effect/details.hbs
+++ b/templates/effect/details.hbs
@@ -1,5 +1,12 @@
 <!-- from Foundry core's "templates/sheets/active-effect-config/details.hbs"-->
 <section class="tab{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+
+  {{#if isActorEffect}}
+    {{formGroup fields.statuses value=source.statuses options=statuses rootId=rootId classes="statuses"}}
+  {{/if}}
+
+  {{formGroup systemFields.executable value=source.system.executable rootId=rootId localize=true}}
+
   <fieldset>
     {{formGroup fields.tint value=source.tint rootId=rootId placeholder="#ffffff"}}
     {{formGroup fields.disabled value=source.disabled rootId=rootId}}
@@ -14,8 +21,5 @@
 
   </fieldset>
 
-  {{#if isActorEffect}}
-    {{formGroup fields.statuses value=source.statuses options=statuses rootId=rootId classes="statuses"}}
-  {{/if}}
   {{formGroup fields.description value=source.description rootId=rootId}}
 </section>

--- a/templates/effect/execution.hbs
+++ b/templates/effect/execution.hbs
@@ -1,0 +1,5 @@
+  <section class="tab{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+
+    {{formGroup systemFields.executionScript value=source.system.executionScript rootId=rootId localize=true}}
+
+  </section>

--- a/templates/effect/execution.hbs
+++ b/templates/effect/execution.hbs
@@ -1,5 +1,12 @@
   <section class="tab{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
 
+    {{formGroup systemFields.executeOn value=source.system.executeOn rootId=rootId localize=true}}
+
     {{formGroup systemFields.executionScript value=source.system.executionScript rootId=rootId localize=true}}
+
+    <button type="button" data-action="execute">
+      <i class="fa-regular fa-play" inert></i>
+      <!--label></label-->
+    </button>
 
   </section>


### PR DESCRIPTION
Add a field to run custom javascript from active effects.
Add selection of execution time. This is not functional yet and will be implemented when Combat is worked on.
Until then, a "Run" button is added for convenience.