### PR TITLE
fix wound calculation for strain

### DIFF
--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -632,7 +632,7 @@ export default class ActorEd extends Actor {
 
     const updates = { [`system.characteristics.health.damage.${ damageType }`]: newDamage };
 
-    if ( damageTaken >= health.woundThreshold && options.isStrain !== true ) {
+    if ( damageTaken >= health.woundThreshold && !options.isStrain ) {
       switch ( damageType ) {
         case "standard":
           updates["system.characteristics.health.wounds"] = health.wounds + 1;
@@ -662,7 +662,7 @@ export default class ActorEd extends Actor {
       ChatMessage.create( messageData );
     }
 
-    const knockdownTest = !this.system.condition.knockedDown && damageTaken >= health.woundThreshold + 5 && options.isStrain !== true;
+    const knockdownTest = !this.system.condition.knockedDown && damageTaken >= health.woundThreshold + 5 && !options.isStrain;
     if ( knockdownTest ) this.knockdownTest( damageTaken );
 
     return {

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -632,7 +632,7 @@ export default class ActorEd extends Actor {
 
     const updates = { [`system.characteristics.health.damage.${ damageType }`]: newDamage };
 
-    if ( damageTaken > health.woundThreshold ) {
+    if ( damageTaken >= health.woundThreshold && options.isStrain !== true ) {
       switch ( damageType ) {
         case "standard":
           updates["system.characteristics.health.wounds"] = health.wounds + 1;
@@ -662,7 +662,7 @@ export default class ActorEd extends Actor {
       ChatMessage.create( messageData );
     }
 
-    const knockdownTest = !this.system.condition.knockedDown && damageTaken >= health.woundThreshold + 5;
+    const knockdownTest = !this.system.condition.knockedDown && damageTaken >= health.woundThreshold + 5 && options.isStrain !== true;
     if ( knockdownTest ) this.knockdownTest( damageTaken );
 
     return {


### PR DESCRIPTION
resolves #972 

strain never causes a wound and therefore never causes knockdown

in addition, a wound from standard damage is created if the damage is **equal** or higher