### PR TITLE
solve-warnings-in-foundry-core-13.338

### DIFF
--- a/module/applications/actor/character-sheet.mjs
+++ b/module/applications/actor/character-sheet.mjs
@@ -19,7 +19,7 @@ export default class ActorSheetEdCharacter extends ActorSheetEdNamegiver {
    */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "character" ],
     actions:  {
       upgradeItem:        ActorSheetEdCharacter.upgradeItem,

--- a/module/applications/actor/creature-sheet.mjs
+++ b/module/applications/actor/creature-sheet.mjs
@@ -17,7 +17,7 @@ export default class ActorSheetEdCreature extends ActorSheetEdSentient {
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "creature" ],
     actions:  {
     },

--- a/module/applications/actor/dragon-sheet.mjs
+++ b/module/applications/actor/dragon-sheet.mjs
@@ -22,7 +22,7 @@ export default class ActorSheetEdDragon extends ActorSheetEdSentient {
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "dragon" ],
     actions:  {
     },

--- a/module/applications/actor/group-sheet.mjs
+++ b/module/applications/actor/group-sheet.mjs
@@ -17,7 +17,7 @@ export default class ActorSheetEdGroup extends ActorSheetEd {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "Group" ],
     actions:  {
     },

--- a/module/applications/actor/horror-sheet.mjs
+++ b/module/applications/actor/horror-sheet.mjs
@@ -23,7 +23,7 @@ export default class ActorSheetEdHorror extends ActorSheetEdSentient {
    */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "horror" ],
     actions:  {
     },

--- a/module/applications/actor/loot-sheet.mjs
+++ b/module/applications/actor/loot-sheet.mjs
@@ -15,7 +15,7 @@ export default class ActorSheetEdLoot extends ActorSheetEd {
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "Vehicle" ],
     actions:  {
     },

--- a/module/applications/actor/npc-sheet.mjs
+++ b/module/applications/actor/npc-sheet.mjs
@@ -16,7 +16,7 @@ export default class ActorSheetEdNpc extends ActorSheetEdNamegiver {
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "NPC" ],
     actions:  {
     },

--- a/module/applications/actor/spirit-sheet.mjs
+++ b/module/applications/actor/spirit-sheet.mjs
@@ -23,7 +23,7 @@ export default class ActorSheetEdSpirit extends ActorSheetEdSentient {
    */
   static DEFAULT_OPTIONS = {
     id:       "actor-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "spirit" ],
     actions:  {
     },

--- a/module/applications/actor/trap-sheet.mjs
+++ b/module/applications/actor/trap-sheet.mjs
@@ -15,7 +15,7 @@ export default class ActorSheetEdTrap extends ActorSheetEd {
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "Vehicle" ],
     actions:  {
     },

--- a/module/applications/actor/vehicle-sheet.mjs
+++ b/module/applications/actor/vehicle-sheet.mjs
@@ -15,7 +15,7 @@ export default class ActorSheetEdVehicle extends ActorSheetEd {
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     id:       "character-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "Vehicle" ],
     actions:  {
     },

--- a/module/applications/advancement/assign-legend.mjs
+++ b/module/applications/advancement/assign-legend.mjs
@@ -23,7 +23,7 @@ export default class AssignLpPrompt extends HandlebarsApplicationMixin( Applicat
 
   static DEFAULT_OPTIONS = {
     id:       "assign-legend-prompt-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "earthdawn4e", "assign-legend" ],
     window:   {
       frame: true,

--- a/module/applications/global/prompt-factory.mjs
+++ b/module/applications/global/prompt-factory.mjs
@@ -182,7 +182,7 @@ class ActorPromptFactory extends PromptFactory {
 
     return DialogClass.wait( {
       id:       "recovery-mode-prompt",
-      uniqueId: String( ++globalThis._appId ),
+      uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:  [ "earthdawn4e", "recovery-prompt" ],
       window:   {
         title:       "ED.Dialogs.Title.recovery",
@@ -240,7 +240,7 @@ class ActorPromptFactory extends PromptFactory {
     };
     return DialogClass.wait( {
       id:       "take-damage-prompt",
-      uniqueId: String( ++globalThis._appId ),
+      uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:  [ "earthdawn4e", "take-damage-prompt", "take-damage__dialog" ],
       // tag: "form",
       window:   {
@@ -284,7 +284,7 @@ class ActorPromptFactory extends PromptFactory {
     return DialogClass.wait( {
       rejectClose: false,
       id:          "jump-up-prompt",
-      uniqueId:    String( ++globalThis._appId ),
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "earthdawn4e", "jump-up-prompt jump-up flexcol" ],
       window:      {
         title:       "ED.Dialogs.Title.jumpUp",
@@ -305,7 +305,7 @@ class ActorPromptFactory extends PromptFactory {
     return DialogClass.wait( {
       rejectClose: false,
       id:          "knock-down-prompt",
-      uniqueId:    String( ++globalThis._appId ),
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "earthdawn4e", "knock-down-prompt knockdown flexcol" ],
       window:      {
         title:       "ED.Dialogs.Title.knockDown",
@@ -325,7 +325,7 @@ class ActorPromptFactory extends PromptFactory {
     return DialogClass.wait( {
       rejectClose: false,
       id:          "choose-discipline-prompt",
-      uniqueId:    String( ++globalThis._appId ),
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "earthdawn4e", "choose-discipline-prompt", "choose-discipline", "flexcol" ],
       window:      {
         title:       "ED.Dialogs.Title.chooseDiscipline",
@@ -345,7 +345,7 @@ class ActorPromptFactory extends PromptFactory {
     return DialogClass.wait( {
       rejectClose: false,
       id:          "draw-weapon-prompt",
-      uniqueId:    String( ++globalThis._appId ),
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "earthdawn4e", "draw-weapon-prompt", "draw-weapon", "flexcol" ],
       window:      {
         title:       "ED.Dialogs.Title.drawWeapon",
@@ -397,7 +397,7 @@ class ItemPromptFactory extends PromptFactory {
 
     return DialogClass.wait( {
       id:       "learn-ability-prompt",
-      uniqueId: String( ++globalThis._appId ),
+      uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:  [ "earthdawn4e", "learn-ability-prompt" ],
       window:   {
         title:       game.i18n.format( "ED.Dialogs.Title.learnAbility", {
@@ -441,7 +441,7 @@ class ItemPromptFactory extends PromptFactory {
 
     return DialogClass.wait( {
       id:       "lp-learn-knack-prompt",
-      uniqueId: String( ++globalThis._appId ),
+      uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:  [ "earthdawn4e", "lp-learn-knack-prompt" ],
       window:   {
         title:       game.i18n.format( "ED.Dialogs.Title.lpLearnKnack", {
@@ -476,7 +476,7 @@ class ItemPromptFactory extends PromptFactory {
     return DialogClass.wait( {
       rejectClose: false,
       id:          "choose-tier-prompt",
-      uniqueId:    String( ++globalThis._appId ),
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "earthdawn4e", "choose-tier-prompt", "flexcol" ],
       window:      {
         title:       game.i18n.format( "ED.Dialogs.Title.chooseTier", {
@@ -506,7 +506,7 @@ class ItemPromptFactory extends PromptFactory {
 
     return DialogClass.wait( {
       id:       "lp-increase-prompt",
-      uniqueId: String( ++globalThis._appId ),
+      uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:  [ "earthdawn4e", "lp-increase-prompt" ],
       window:   {
         title:       game.i18n.format( "ED.Dialogs.Title.lpIncrease", {
@@ -546,7 +546,7 @@ class ItemPromptFactory extends PromptFactory {
     return DialogClass.wait( {
       rejectClose: false,
       id:          "talent-category-prompt",
-      uniqueId:    String( ++globalThis._appId ),
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "earthdawn4e", "talent-category-prompt", "flexcol" ],
       window:      {
         title:       game.i18n.format( "ED.Dialogs.Title.talentCategory", {

--- a/module/applications/global/roll-prompt.mjs
+++ b/module/applications/global/roll-prompt.mjs
@@ -53,7 +53,7 @@ export default class RollPrompt extends HandlebarsApplicationMixin( ApplicationV
 
   static DEFAULT_OPTIONS = {
     id:       "roll-prompt-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "earthdawn4e", "roll-prompt" ],
     tag:      "form",
     position: {

--- a/module/applications/item/class-item-sheet.mjs
+++ b/module/applications/item/class-item-sheet.mjs
@@ -10,7 +10,7 @@ export default class ClassItemSheetEd extends ItemSheetEd {
   
   static DEFAULT_OPTIONS = {
     id:       "item-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "earthdawn4e", "sheet", "item" ],
     window:   {
       frame:          true,

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -15,7 +15,7 @@ export default class ItemSheetEd extends HandlebarsApplicationMixin( ItemSheetV2
   // region Static Properties
   static DEFAULT_OPTIONS = {
     id:       "item-sheet-{id}",
-    uniqueId: String( ++globalThis._appId ),
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
     classes:  [ "earthdawn4e", "sheet", "item" ],
     window:   {
       frame:          true,

--- a/module/applications/journal/journal-sheet.mjs
+++ b/module/applications/journal/journal-sheet.mjs
@@ -1,3 +1,3 @@
-export default class JournalSheetEd extends JournalSheet {
+export default class JournalSheetEd extends foundry.applications.sheets.journal.JournalEntrySheet {
 
 }

--- a/module/data/actor/pc.mjs
+++ b/module/data/actor/pc.mjs
@@ -281,7 +281,7 @@ export default class PcData extends NamegiverTemplate {
     let spendLp = useLp;
     spendLp ??= await DialogV2.wait( {
       id:          "attribute-increase-prompt",
-      uniqueId:    String( ++globalThis._appId ),
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "ed4e", "attribute-increase-prompt" ],
       window:      {
         title:       "ED.Dialogs.Title.attributeIncrease",

--- a/module/dice/ed-roll.mjs
+++ b/module/dice/ed-roll.mjs
@@ -2,6 +2,9 @@ import getDice from "./step-tables.mjs";
 import { sum } from "../utils.mjs";
 import ED4E from "../config/_module.mjs";
 
+const { renderTemplate } = foundry.applications.handlebars;
+
+
 /**
  * EdRollOptions for creating an EdRoll instance.
  * @property { object } step Ever information related to the step of the action, Mods, Boni, Mali etc.

--- a/module/hooks/init.mjs
+++ b/module/hooks/init.mjs
@@ -14,6 +14,7 @@ import * as utils from "../utils.mjs";
 
 const { DocumentSheetConfig } = foundry.applications.apps;
 const { ActiveEffectConfig } = foundry.applications.sheets;
+const { Actors, Items, Journal } = foundry.documents.collections;
 
 /**
  *
@@ -53,7 +54,7 @@ export default function () {
     CONFIG.Item.dataModels = data.item.config;
 
     // Register sheet application classes
-    Actors.unregisterSheet( "core", ActorSheet );
+    Actors.unregisterSheet( "core", foundry.appv1.sheets.ActorSheet );
     Actors.registerSheet( "earthdawn4e", applications.actor.ActorSheetEd, {
       makeDefault: true
     } );
@@ -116,7 +117,7 @@ export default function () {
       { makeDefault: true },
     );
 
-    Items.unregisterSheet( "core", ItemSheet );
+    Items.unregisterSheet( "core", foundry.appv1.sheets.ItemSheet );
     Items.registerSheet( "earthdawn4e", applications.item.ItemSheetEd, {
       makeDefault: true
     } );
@@ -128,7 +129,7 @@ export default function () {
       types:       [ "armor", "equipment", "shield", "weapon" ],
       makeDefault: true 
     } );
-    Journal.unregisterSheet( "core", JournalSheet );
+    Journal.unregisterSheet( "core", foundry.appv1.sheets.JournalSheet );
     Journal.registerSheet( "earthdawn4e", applications.journal.JournalSheetEd, {
       makeDefault: true
     } );

--- a/module/tours/ed-tours.mjs
+++ b/module/tours/ed-tours.mjs
@@ -1,5 +1,5 @@
 import { delay } from "../utils.mjs";
-export default class EdTour extends Tour {
+export default class EdTour extends foundry.nue.Tour {
   static tours = [
     "systems/ed4e/module/tours/lang/actor-item-creation",
     "systems/ed4e/module/tours/lang/arbitrary-roll",

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -820,5 +820,5 @@ export async function preloadHandlebarsTemplates() {
     paths[path] = path;
   }
 
-  return loadTemplates( paths );
+  return foundry.applications.handlebars.loadTemplates( paths );
 }


### PR DESCRIPTION
Adjust imports to new Foundry's new ESM structures to eliminate deprecation warnings.

# Breaking, only from Foundry Core 13.338 upwards