### PR TITLE
Fix manual step modifier from roll prompt not working

### DIFF
--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -341,7 +341,7 @@ export default class EdRollOptions extends SparseDataModel {
     updates.target ??= {};
     updates.step.total = this.step.total = this.totalStep;
     updates.target.total = this.target.total = this.totalTarget;
-    return updates;
+    return super.updateSource( updates, options );
   }
 
   static initDiceForStep( parent ) {


### PR DESCRIPTION
Fixes #1479

This took sooo long to debug 😵‍💫

Main problem was a missing update of the `total` for modifiable fields (i.e. the `step.total`). This was only a dynamic getter. We do have to persist that now though. So we need to interject the update process of the data model. Basic data model however do not have things like `preUpdate` and so on. So we have to hack our own solution. 

This now needs two calls to `updateSource`, because otherwise, only the actual `source` object gets updated, not the internal `_source`. The latter is used when exporting to an object through `toObject` though. So to make sure the changes are actually persisted, we need to call `updateSource` again.
If optimization is needed: calculate `totalStep` and `totalTarget` beforehand manually and only call `updateSource` once.