### PR TITLE
active-effect-add-execution-in-combat-cycle

### DIFF
--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -19,40 +19,64 @@ export default class CombatEd extends foundry.documents.Combat {
 
   /** @inheritdoc */
   async startCombat() {
-    // maybe execute effects?
+    await this.#executeEffectsForAll( "combatStart" );
     return super.startCombat();
   }
 
   /** @inheritdoc */
   async endCombat() {
-    // maybe execute effects?
+    await this.#executeEffectsForAll( "combatEnd" );
     return super.endCombat();
   }
 
   /** @inheritdoc */
   async _onStartRound( context ) {
     // ask for changing stances
-    // maybe execute effects?
+    await this.#executeEffectsForAll( "roundStart" );
     return super._onStartRound( context );
   }
 
   /** @inheritdoc */
   async _onEndRound( context ) {
-    // maybe execute effects?
+    await this.#executeEffectsForAll( "roundEnd" );
     return super._onEndRound( context );
   }
 
   /** @inheritdoc */
   async _onStartTurn( combatant, context ) {
+    await this.#executeEffectsForAll( "turnStart" );
     return super._onStartTurn( combatant, context );
   }
 
   /** @inheritdoc */
   async _onEndTurn( combatant, context ) {
     // add expire measured templates
+    await this.#executeEffectsForAll( "turnEnd" );
     return super._onEndTurn( combatant, context );
   }
 
   // endregion
+
+  /**
+   * Execute ActiveEffects that are triggered by the given execution time.
+   * @param {keyof eaeExecutionTime} executionTime The instant in the combat when the effect should be executed.
+   * @param {CombatantEd} combatant                The combatant to execute the effects for.
+   * @returns {Promise<void>}
+   */
+  async #executeEffects( executionTime, combatant ) {
+    const effects = combatant.effects.filter( effect => effect.system?.executeOn === executionTime );
+
+    for ( const effect of effects ) {
+      if ( !effect.disabled ) await effect.execute();
+    }
+  }
+
+  async #executeEffectsForAll( executionTime ) {
+    const combatants = new Set( this.combatants.map( c => c.actor ) );
+
+    for ( const combatant of combatants ) {
+      await this.#executeEffects( executionTime, combatant );
+    }
+  }
 
 }

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -18,9 +18,33 @@ export default class CombatEd extends foundry.documents.Combat {
   }
 
   /** @inheritdoc */
-  _onStartRound( context ) {
+  async startCombat() {
+    // maybe execute effects?
+    return super.startCombat();
+  }
+
+  /** @inheritdoc */
+  async endCombat() {
+    // maybe execute effects?
+    return super.endCombat();
+  }
+
+  /** @inheritdoc */
+  async _onStartRound( context ) {
     // ask for changing stances
     // maybe execute effects?
+    return super._onStartRound( context );
+  }
+
+  /** @inheritdoc */
+  async _onEndRound( context ) {
+    // maybe execute effects?
+    return super._onEndRound( context );
+  }
+
+  /** @inheritdoc */
+  async _onStartTurn( combatant, context ) {
+    return super._onStartTurn( combatant, context );
   }
 
   /** @inheritdoc */

--- a/module/documents/combat.mjs
+++ b/module/documents/combat.mjs
@@ -67,7 +67,7 @@ export default class CombatEd extends foundry.documents.Combat {
     const effects = combatant.effects.filter( effect => effect.system?.executeOn === executionTime );
 
     for ( const effect of effects ) {
-      if ( !effect.disabled ) await effect.execute();
+      if ( !effect.disabled ) await effect.system.execute();
     }
   }
 


### PR DESCRIPTION
Execute executable ActiveEffects (:P) on automatically during combat events (combat, round, turn -> start/end)