### PR TITLE
move-localization-to-foundry-core-where-possible

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -802,6 +802,14 @@
         }
       },
       "Item":                         {
+        "Spell": {
+          "FIELDS": {
+            "spellcastingType": {
+              "hint": "Art der Spruchzauberei die für diesen Zauber benötigt wird",
+              "label": "Spruchzauberei Typ"
+            }
+          }
+        },
         "Hints":  {
           "Ability":       {
             "Magic":                 {

--- a/module/applications/actor/character-generation-prompt.mjs
+++ b/module/applications/actor/character-generation-prompt.mjs
@@ -233,6 +233,8 @@ export default class CharacterGenerationPrompt extends HandlebarsApplicationMixi
       active:   false,
       cssClass: ""
     },
+    initial:     "namegiver-tab",
+    labelPrefix: "ED.Sheet.Tabs",
   };
 
   /* ----------------------------------------------------------- */

--- a/module/applications/actor/common-sheet.mjs
+++ b/module/applications/actor/common-sheet.mjs
@@ -42,7 +42,7 @@ export default class ActorSheetEd extends HandlebarsApplicationMixin( ActorSheet
     sheet: {
       tabs:        [],
       initial:     "general",
-      labelPrefix: "ED.Actor.Tabs",
+      labelPrefix: "ED.Sheet.Tabs",
     },
   };
 

--- a/module/applications/advancement/lp-history.mjs
+++ b/module/applications/advancement/lp-history.mjs
@@ -128,6 +128,8 @@ export default class LegendPointHistory extends HandlebarsApplicationMixin( Appl
       active:   false,
       cssClass: ""
     },
+    initial:     "chronological-tab",
+    labelPrefix: "ED.Sheets.Tabs",
   };
 
   // put _configureRenderOptions here if needed

--- a/module/applications/effect/eae-sheet.mjs
+++ b/module/applications/effect/eae-sheet.mjs
@@ -42,6 +42,7 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
         { id: "execution", icon: ED4E.icons.effectExecution },
       ],
     },
+    labelPrefix: "ED.Sheet.Tabs",
   };
 
   // region Properties

--- a/module/applications/global/roll-prompt.mjs
+++ b/module/applications/global/roll-prompt.mjs
@@ -103,7 +103,7 @@ export default class RollPrompt extends HandlebarsApplicationMixin( ApplicationV
    */
   static TABS = {
     "base-tab": {
-      id:       "earned-tab",
+      id:       "base-tab",
       group:    "primary",
       icon:     "",
       label:    "ED.Dialogs.Tabs.rollPromptBaseTab",
@@ -118,6 +118,8 @@ export default class RollPrompt extends HandlebarsApplicationMixin( ApplicationV
       active:   false,
       cssClass: "",
     },
+    initial:     "base-tab",
+    labelPrefix: "ED.Sheet.Tabs",
   };
 
   buttons = [

--- a/module/applications/item/class-item-sheet.mjs
+++ b/module/applications/item/class-item-sheet.mjs
@@ -86,7 +86,7 @@ export default class ClassItemSheetEd extends ItemSheetEd {
         { id:    "advancement", },
       ],
       initial:     "general",
-      labelPrefix: "ED.Item.Tabs",
+      labelPrefix: "ED.Sheet.Tabs",
     },
   };
 

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -82,7 +82,7 @@ export default class ItemSheetEd extends HandlebarsApplicationMixin( ItemSheetV2
         { id:    "effects", },
       ],
       initial:     "general",
-      labelPrefix: "ED.Item.Tabs",
+      labelPrefix: "ED.Sheet.Tabs",
     },
   };
   // endregion

--- a/module/applications/item/physical-item-sheet.mjs
+++ b/module/applications/item/physical-item-sheet.mjs
@@ -64,7 +64,7 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
         { id:    "thread", },
       ],
       initial:     "general",
-      labelPrefix: "ED.Item.Tabs",
+      labelPrefix: "ED.Sheet.Tabs",
     },
   };
 

--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -21,6 +21,11 @@ import { callIfExists } from "../utils.mjs";
  */
 export default class SystemDataModel extends foundry.abstract.TypeDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    "ED.Data.General",
+  ];
+
   /**
    * A bound version of {@link getLocalizeKey}. Used to automatically get the
    * localization key of a data field label for this instances document type.
@@ -441,6 +446,12 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
  */
 export class ActorDataModel extends SystemDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor",
+  ];
+
   /** @inheritDoc */
   static labelKey = SystemDataModel.getLocalizeKey.bind( this, "Actor", false );
 
@@ -508,6 +519,12 @@ export class ActorDataModel extends SystemDataModel {
  * Variant of the SystemDataModel with support for rich item tooltips.
  */
 export class ItemDataModel extends SystemDataModel {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item",
+  ];
 
   /** @inheritDoc */
   static labelKey = SystemDataModel.getLocalizeKey.bind( this, "Item", false );
@@ -697,6 +714,12 @@ export class ItemDataModel extends SystemDataModel {
  */
 export class ActiveEffectDataModel extends SystemDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.ActiveEffect",
+  ];
+
   /** @inheritDoc */
   static labelKey = SystemDataModel.getLocalizeKey.bind( this, "ActiveEffect", false );
 
@@ -738,6 +761,11 @@ export class ActiveEffectDataModel extends SystemDataModel {
  * Data Model variant that does not export fields with an `undefined` value during `toObject( true )`.
  */
 export class SparseDataModel extends foundry.abstract.DataModel {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    "ED.Data.Other",
+  ];
 
   /**
    * A bound version of {@link getLocalizeKey}. Used to automatically get the

--- a/module/data/actor/creature.mjs
+++ b/module/data/actor/creature.mjs
@@ -6,6 +6,12 @@ import SentientTemplate from "./templates/sentient.mjs";
  */
 export default class CreatureData extends SentientTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Creature",
+  ];
+
   /** @inheritDoc */
   static _systemType = "creature";
 

--- a/module/data/actor/dragon.mjs
+++ b/module/data/actor/dragon.mjs
@@ -6,6 +6,12 @@ import SentientTemplate from "./templates/sentient.mjs";
  */
 export default class DragonData extends SentientTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Dragon",
+  ];
+
   /** @inheritDoc */
   static _systemType = "dragon";
 

--- a/module/data/actor/group.mjs
+++ b/module/data/actor/group.mjs
@@ -5,6 +5,12 @@ import CommonTemplate from "./templates/common.mjs";
  */
 export default class GroupData extends CommonTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Group",
+  ];
+
   /** @inheritDoc */
   static _systemType = "group";
 

--- a/module/data/actor/horror.mjs
+++ b/module/data/actor/horror.mjs
@@ -6,6 +6,12 @@ import SentientTemplate from "./templates/sentient.mjs";
  */
 export default class HorrorData extends SentientTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Horror",
+  ];
+
   /** @inheritDoc */
   static _systemType = "horror";
 

--- a/module/data/actor/loot.mjs
+++ b/module/data/actor/loot.mjs
@@ -5,6 +5,12 @@ import CommonTemplate from "./templates/common.mjs";
  */
 export default class LootData extends CommonTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Loot",
+  ];
+
   /** @inheritDoc */
   static _systemType = "loot";
 

--- a/module/data/actor/npc.mjs
+++ b/module/data/actor/npc.mjs
@@ -9,6 +9,12 @@ export default class NpcData extends NamegiverTemplate.mixin(
   ActorDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Npc",
+  ];
+
   /** @inheritDoc */
   static _systemType = "npc";
 

--- a/module/data/actor/pc.mjs
+++ b/module/data/actor/pc.mjs
@@ -17,6 +17,12 @@ const { DialogV2 } = foundry.applications.api;
  */
 export default class PcData extends NamegiverTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Pc",
+  ];
+
   /** @inheritDoc */
   static _systemType = "character";
 

--- a/module/data/actor/spirit.mjs
+++ b/module/data/actor/spirit.mjs
@@ -6,6 +6,12 @@ import SentientTemplate from "./templates/sentient.mjs";
  */
 export default class SpiritData extends SentientTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Spirit",
+  ];
+
   /** @inheritDoc */
   static _systemType = "spirit";
 

--- a/module/data/actor/templates/common.mjs
+++ b/module/data/actor/templates/common.mjs
@@ -10,6 +10,12 @@ export default class CommonTemplate extends ActorDataModel.mixin(
   ActorDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Common",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/actor/templates/description.mjs
+++ b/module/data/actor/templates/description.mjs
@@ -7,6 +7,12 @@ import SystemDataModel from "../../abstract.mjs";
 export default class ActorDescriptionTemplate extends SystemDataModel {
 
   /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor",
+  ];
+
+  /** @inheritdoc */
   static defineSchema() {
     const fields = foundry.data.fields;
     return {

--- a/module/data/actor/templates/namegiver.mjs
+++ b/module/data/actor/templates/namegiver.mjs
@@ -10,6 +10,12 @@ const futils = foundry.utils;
  */
 export default class NamegiverTemplate extends SentientTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Namegiver",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/actor/templates/sentient.mjs
+++ b/module/data/actor/templates/sentient.mjs
@@ -9,6 +9,12 @@ import MappingField from "../../fields/mapping-field.mjs";
  */
 export default class SentientTemplate extends CommonTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Sentient",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/actor/trap.mjs
+++ b/module/data/actor/trap.mjs
@@ -5,6 +5,12 @@ import CommonTemplate from "./templates/common.mjs";
  */
 export default class TrapData extends CommonTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Trap",
+  ];
+
   /** @inheritDoc */
   static _systemType = "trap";
 

--- a/module/data/actor/vehicle.mjs
+++ b/module/data/actor/vehicle.mjs
@@ -5,6 +5,12 @@ import CommonTemplate from "./templates/common.mjs";
  */
 export default class VehicleData extends CommonTemplate {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Actor.Vehicle",
+  ];
+
   /** @inheritDoc */
   static _systemType = "Vehicle";
 

--- a/module/data/advancement/advancement-level.mjs
+++ b/module/data/advancement/advancement-level.mjs
@@ -9,6 +9,12 @@ import IdentifierField from "../fields/identifier-field.mjs";
  */
 export default class AdvancementLevelData extends SparseDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.AdvancementLevel",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/advancement/base-advancement.mjs
+++ b/module/data/advancement/base-advancement.mjs
@@ -9,6 +9,12 @@ import MappingField from "../fields/mapping-field.mjs";
 
 export default class AdvancementData extends SparseDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.Advancement",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/advancement/lp-earning-transaction.mjs
+++ b/module/data/advancement/lp-earning-transaction.mjs
@@ -6,6 +6,12 @@ import { dateToInputString } from "../../utils.mjs";
 // UF_LpTracking-addLpTransaction
 export default class LpEarningTransactionData extends LpTransactionData {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.LpEarningTransaction",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/advancement/lp-spending-transaction.mjs
+++ b/module/data/advancement/lp-spending-transaction.mjs
@@ -4,6 +4,12 @@ import { dateToInputString } from "../../utils.mjs";
 
 export default class LpSpendingTransactionData extends LpTransactionData {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.LpSpendingTransaction",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/advancement/lp-tracking.mjs
+++ b/module/data/advancement/lp-tracking.mjs
@@ -4,6 +4,12 @@ import { sum } from "../../utils.mjs";
 
 export default class LpTrackingData extends foundry.abstract.DataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.LpTracking",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/advancement/lp-transaction.mjs
+++ b/module/data/advancement/lp-transaction.mjs
@@ -2,6 +2,12 @@ import AssignLpPrompt from "../../applications/advancement/assign-legend.mjs";
 
 export default class LpTransactionData extends foundry.abstract.DataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.LpTransaction",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/chat/attack.mjs
+++ b/module/data/chat/attack.mjs
@@ -2,6 +2,11 @@ import BaseMessageData from "./base-message.mjs";
 
 export default class AttackMessageData extends BaseMessageData {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.General.AttackMessage",
+  ];
 
   static DEFAULT_OPTIONS = {
     actions: {

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -2,6 +2,12 @@ import SystemDataModel from "../abstract.mjs";
 
 export default class BaseMessageData extends SystemDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.General.BaseMessage",
+  ];
+
   constructor( data, options ) {
     super( data, options );
 

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -2,6 +2,12 @@ import BaseMessageData from "./base-message.mjs";
 
 export default class DamageMessageData extends BaseMessageData {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.General.DamageMessage",
+  ];
+
   static DEFAULT_OPTIONS = {
     actions: {
       "apply-damage":  this._onApplyDamage,

--- a/module/data/common/metrics.mjs
+++ b/module/data/common/metrics.mjs
@@ -17,6 +17,12 @@ const fields = foundry.data.fields;
  */
 export class MetricData extends SparseDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.General.Metric",
+  ];
+
   /* -------------------------------------------- */
   /*  Properties                                  */
   /* -------------------------------------------- */

--- a/module/data/common/restrict-require.mjs
+++ b/module/data/common/restrict-require.mjs
@@ -11,6 +11,12 @@ const { fields } = foundry.data;
  */
 export class ConstraintData extends SparseDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.General.Constraint",
+  ];
+
   /* -------------------------------------------- */
   /* Properties                                   */
   /* -------------------------------------------- */

--- a/module/data/effects/eae-change-data.mjs
+++ b/module/data/effects/eae-change-data.mjs
@@ -6,6 +6,12 @@ import FormulaField from "../fields/formula-field.mjs";
  */
 export default class EarthdawnActiveEffectChangeData extends SparseDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.ActiveEffect.Change",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/effects/eae-condition.mjs
+++ b/module/data/effects/eae-condition.mjs
@@ -11,6 +11,12 @@ const { createFormGroup, createSelectInput } = foundry.applications.fields;
  */
 export default class EarthdawnConditionEffectData extends EarthdawnActiveEffectData {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.ActiveEffect.EaeCondition",
+  ];
+
   static metadata = Object.freeze(
     foundry.utils.mergeObject( super.metadata, {
       type: "condition",

--- a/module/data/effects/eae-duration.mjs
+++ b/module/data/effects/eae-duration.mjs
@@ -7,6 +7,12 @@ import ED4E from "../../config/_module.mjs";
  */
 export default class EarthdawnActiveEffectDurationData extends SparseDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.ActiveEffect.EaeDuration",
+  ];
+
   static defineSchema() {
     const fields = foundry.data.fields;
 

--- a/module/data/effects/eae.mjs
+++ b/module/data/effects/eae.mjs
@@ -11,6 +11,12 @@ import ED4E from "../../config/_module.mjs";
  */
 export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.ActiveEffect.Eae",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/armor.mjs
+++ b/module/data/item/armor.mjs
@@ -16,6 +16,12 @@ export default class ArmorData extends PhysicalItemTemplate.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Armor",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/binding-secrets.mjs
+++ b/module/data/item/binding-secrets.mjs
@@ -8,6 +8,12 @@ export default class BindingSecretData extends SpellData.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.BindingSecret",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/curse-horror-mark.mjs
+++ b/module/data/item/curse-horror-mark.mjs
@@ -15,6 +15,12 @@ export default class CurseHorrorMarkData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.CurseHorrorMark",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/devotion.mjs
+++ b/module/data/item/devotion.mjs
@@ -11,6 +11,12 @@ export default class DevotionData extends IncreasableAbilityTemplate.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Devotion",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/discipline.mjs
+++ b/module/data/item/discipline.mjs
@@ -13,6 +13,12 @@ export default class DisciplineData extends ClassTemplate.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Discipline",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/effect.mjs
+++ b/module/data/item/effect.mjs
@@ -8,6 +8,12 @@ export default class EffectData extends SystemDataModel.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Effect",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/equipment.mjs
+++ b/module/data/item/equipment.mjs
@@ -11,6 +11,12 @@ export default class EquipmentData extends PhysicalItemTemplate.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Equipment",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/knack-ability.mjs
+++ b/module/data/item/knack-ability.mjs
@@ -16,6 +16,12 @@ export default class KnackAbilityData extends AbilityTemplate.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.KnackAbility",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/knack-karma.mjs
+++ b/module/data/item/knack-karma.mjs
@@ -10,6 +10,12 @@ export default class KnackKarmaData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.KnackKarma",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/knack-maneuver.mjs
+++ b/module/data/item/knack-maneuver.mjs
@@ -10,6 +10,12 @@ export default class KnackManeuverData extends ManeuverData.mixin(
   ItemDescriptionTemplate,
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.KnackManeuver",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/maneuver.mjs
+++ b/module/data/item/maneuver.mjs
@@ -9,6 +9,12 @@ export default class ManeuverData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Maneuver",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/mask.mjs
+++ b/module/data/item/mask.mjs
@@ -34,7 +34,13 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
 export default class MaskData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 ) {
-  // TODO to check when mask function will be done.
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Mask",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/matrices.mjs
+++ b/module/data/item/matrices.mjs
@@ -8,6 +8,12 @@ export default class MatrixData extends SystemDataModel.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Matrix",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/namegiver.mjs
+++ b/module/data/item/namegiver.mjs
@@ -23,6 +23,13 @@ import MappingField from "../fields/mapping-field.mjs";
 export default class NamegiverData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 ) {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Namegiver",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/path.mjs
+++ b/module/data/item/path.mjs
@@ -13,6 +13,12 @@ export default class PathData extends ClassTemplate.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Path",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/poison-disease.mjs
+++ b/module/data/item/poison-disease.mjs
@@ -20,6 +20,12 @@ export default class PoisonDiseaseData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.PoisonDisease",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/power.mjs
+++ b/module/data/item/power.mjs
@@ -16,6 +16,12 @@ export default class PowerData extends ActionTemplate.mixin(
   TargetTemplate,
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Power",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/questor.mjs
+++ b/module/data/item/questor.mjs
@@ -13,6 +13,12 @@ export default class QuestorData extends ClassTemplate.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Questor",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/shield.mjs
+++ b/module/data/item/shield.mjs
@@ -12,6 +12,13 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
 export default class ShieldData extends PhysicalItemTemplate.mixin(
   ItemDescriptionTemplate
 ) {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Shield",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/ship-weapon.mjs
+++ b/module/data/item/ship-weapon.mjs
@@ -13,6 +13,13 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
 export default class ShipWeaponData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 ) {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.ShipWeapon",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/skill.mjs
+++ b/module/data/item/skill.mjs
@@ -10,6 +10,12 @@ export default class SkillData extends IncreasableAbilityTemplate.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Skill",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/special-ability.mjs
+++ b/module/data/item/special-ability.mjs
@@ -8,6 +8,12 @@ export default class SpecialAbilityData extends ItemDataModel.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.SpecialAbility",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/spell-knacks.mjs
+++ b/module/data/item/spell-knacks.mjs
@@ -8,6 +8,12 @@ export default class SpellKnackData extends KnackTemplate.mixin(
   ItemDescriptionTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.SpellKnack",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -18,6 +18,12 @@ export default class SpellData extends ItemDataModel.mixin(
   TargetTemplate
 )  {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Spell",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const { ArrayField, EmbeddedDataField, NumberField, SchemaField, SetField, StringField, TypedSchemaField } = foundry.data.fields;
@@ -30,8 +36,6 @@ export default class SpellData extends ItemDataModel.mixin(
         trim:     true,
         choices:  ED4E.spellcastingTypes,
         initial:  "elementalism",
-        label:    this.labelKey( "Spell.spellcastingType" ),
-        hint:     this.hintKey( "Spell.spellcastingType" ),
       } ),
       level: new NumberField( {
         required: true,
@@ -40,8 +44,6 @@ export default class SpellData extends ItemDataModel.mixin(
         initial:  1,
         integer:  true,
         positive: true,
-        label:    this.labelKey( "Spell.level" ),
-        hint:     this.hintKey( "Spell.level" ),
       } ),
       spellDifficulty:    new SchemaField( {
         reattune: new NumberField( {
@@ -50,8 +52,6 @@ export default class SpellData extends ItemDataModel.mixin(
           min:      ED4E.minDifficulty,
           initial:  ( data ) => { return data.weaving + 5 || ED4E.minDifficulty; },
           integer:  true,
-          label:    this.labelKey( "Spell.reattuneDifficulty" ),
-          hint:     this.hintKey( "Spell.reattuneDifficulty" ),
         } ),
         weaving: new NumberField( {
           required: true,
@@ -59,8 +59,6 @@ export default class SpellData extends ItemDataModel.mixin(
           min:      ED4E.minDifficulty,
           initial:  ( _ ) => { return this.parent?.parent?.fields?.level?.initial + 4 || ED4E.minDifficulty; },
           integer:  true,
-          label:    this.labelKey( "Spell.weavingDifficulty" ),
-          hint:     this.hintKey( "Spell.weavingDifficulty" ),
         } ),
       } ),
       threads: new SchemaField( {
@@ -70,8 +68,6 @@ export default class SpellData extends ItemDataModel.mixin(
           min:      0,
           initial:  0,
           integer:  true,
-          label:    this.labelKey( "Spell.spellThreadsRequired" ),
-          hint:     this.hintKey( "Spell.spellThreadsRequired" ),
         } ),
         woven: new NumberField( {
           required: true,
@@ -79,8 +75,6 @@ export default class SpellData extends ItemDataModel.mixin(
           min:      0,
           initial:  0,
           integer:  true,
-          label:    this.labelKey( "Spell.spellThreadsWoven" ),
-          hint:     this.hintKey( "Spell.spellThreadsWoven" ),
         } ),
         extra: new NumberField( {} ),
       } ),
@@ -88,8 +82,6 @@ export default class SpellData extends ItemDataModel.mixin(
         required: true,
         blank:    true,
         initial:  "",
-        label:    this.labelKey( "Spell.effect" ),
-        hint:     this.hintKey( "Spell.effect" ),
       } ),
       keywords: new SetField( new StringField( {
         required: true,
@@ -97,14 +89,10 @@ export default class SpellData extends ItemDataModel.mixin(
         blank:    false,
         trim:     true,
         choices:  ED4E.spellKeywords,
-        label:    this.labelKey( "Spell.keyword" ),
-        hint:     this.hintKey( "Spell.keyword" ),
       } ), {
         required: true,
         nullable: false,
         initial:  [],
-        label:    this.labelKey( "Spell.keywords" ),
-        hint:     this.hintKey( "Spell.keywords" ),
       } ),
       element: new SchemaField( {
         type: new StringField( {
@@ -113,8 +101,6 @@ export default class SpellData extends ItemDataModel.mixin(
           blank:    false,
           trim:     true,
           choices:  ED4E.elements,
-          label:    this.labelKey( "Spell.spellElementType" ),
-          hint:     this.hintKey( "Spell.spellElementType" ),
         } ),
         subtype: new StringField( {
           required: true,
@@ -126,50 +112,32 @@ export default class SpellData extends ItemDataModel.mixin(
           ).map(
             subtypes => Object.keys( subtypes )
           ).flat(),
-          label:    this.labelKey( "Spell.spellElementSubtype" ),
-          hint:     this.hintKey( "Spell.spellElementSubtype" ),
         } )
       },
       {
         required: true,
         nullable: true,
-        label:    this.labelKey( "Spell.spellElement" ),
-        hint:     this.hintKey( "Spell.spellElement" ),
       } ),
       duration: new EmbeddedDataField( DurationMetricData, {
-        label: this.labelKey( "Spell.duration" ),
-        hint:  this.hintKey( "Spell.duration" ),
       } ),
       range:    new EmbeddedDataField( RangeMetricData, {
-        label: this.labelKey( "Spell.range" ),
-        hint:  this.hintKey( "Spell.range" ),
       } ),
       area: new EmbeddedDataField( AreaMetricData, {
-        label: this.labelKey( "Spell.area" ),
-        hint:  this.hintKey( "Spell.area" ),
       } ),
       extraSuccess: new ArrayField( new TypedSchemaField( MetricData.TYPES, {
-        label:    this.labelKey( "Spell.extraSuccess" ),
-        hint:     this.hintKey( "Spell.extraSuccess" ),
       } ),
       {
         required: true,
         nullable: true,
         initial:  [],
         max:      1,
-        label:    this.labelKey( "Spell.extraSuccesses" ),
-        hint:     this.hintKey( "Spell.extraSuccesses" ),
       } ),
       extraThreads: new ArrayField( new TypedSchemaField( MetricData.TYPES, {
-        label: this.labelKey( "Spell.extraThreadOption" ),
-        hint:  this.hintKey( "Spell.extraThreadOption" ),
       } ),
       {
         required: true,
         nullable: true,
         initial:  [],
-        label:    this.labelKey( "Spell.extraThreads" ),
-        hint:     this.hintKey( "Spell.extraThreads" ),
       } ),
     } );
   }

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -12,6 +12,12 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
   ItemDescriptionTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Talent",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -21,6 +21,13 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
   LearnableTemplate,
   TargetTemplate
 ) {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Ability",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/templates/action.mjs
+++ b/module/data/item/templates/action.mjs
@@ -11,6 +11,12 @@ export default class ActionTemplate extends ItemDataModel.mixin(
   RollableTemplate,
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Action",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/templates/class.mjs
+++ b/module/data/item/templates/class.mjs
@@ -20,6 +20,12 @@ export default class ClassTemplate extends ItemDataModel.mixin(
   LpIncreaseTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Class",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/templates/increasable-ability.mjs
+++ b/module/data/item/templates/increasable-ability.mjs
@@ -12,6 +12,13 @@ const isEmpty = foundry.utils.isEmpty;
 export default class IncreasableAbilityTemplate extends AbilityTemplate.mixin(
   LpIncreaseTemplate,
 ) {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.IncreasableAbility",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/templates/item-description.mjs
+++ b/module/data/item/templates/item-description.mjs
@@ -8,6 +8,12 @@ import EdIdField from "../../fields/edid-field.mjs";
 export default class ItemDescriptionTemplate extends SystemDataModel {
 
   /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Description",
+  ];
+
+  /** @inheritdoc */
   static defineSchema() {
     const fields = foundry.data.fields;
     return {

--- a/module/data/item/templates/knack-item.mjs
+++ b/module/data/item/templates/knack-item.mjs
@@ -13,6 +13,12 @@ export default class KnackTemplate extends SystemDataModel.mixin(
   TargetTemplate,
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Knack",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/templates/learnable.mjs
+++ b/module/data/item/templates/learnable.mjs
@@ -7,6 +7,12 @@ import SystemDataModel from "../../abstract.mjs";
  */
 export default class LearnableTemplate extends SystemDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Learnable",
+  ];
+
   /**
    * @description Whether the entity fulfills all requirements to be learned.
    * @type {boolean}

--- a/module/data/item/templates/lp-increase.mjs
+++ b/module/data/item/templates/lp-increase.mjs
@@ -9,6 +9,12 @@ import SystemDataModel from "../../abstract.mjs";
  */
 export default class LpIncreaseTemplate extends SystemDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.LpIncrease",
+  ];
+
   /**
    * @description Whether the entity fulfills all requirements to be increased.
    * @type {boolean}

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -22,6 +22,12 @@ export default class PhysicalItemTemplate extends ItemDataModel.mixin(
   ThreadTemplate
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.PhysicalItem",
+  ];
+
   /**
    * The order in which this items status is cycled. Represents the default order.
    * Should be defined in the extending class, if different.

--- a/module/data/item/templates/rollable.mjs
+++ b/module/data/item/templates/rollable.mjs
@@ -7,6 +7,12 @@ const { fields } = foundry.data;
 
 export default class RollableTemplate extends SystemDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Rollable",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/templates/targeting.mjs
+++ b/module/data/item/templates/targeting.mjs
@@ -11,6 +11,13 @@ import ED4E from "../../../config/_module.mjs";
  * @mixin
  */
 export default class TargetTemplate extends SystemDataModel {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Target",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/item/templates/threads.mjs
+++ b/module/data/item/templates/threads.mjs
@@ -9,6 +9,12 @@ import ThreadBaseData from "../../thread/thread-base.mjs";
  */
 export default class ThreadTemplate extends ItemDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Thread",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -25,6 +25,12 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
   RollableTemplate,
 ) {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Weapon",
+  ];
+
   static _itemStatusOrder = [ "owned", "carried", "mainHand", "offHand", "twoHands", "tail" ];
 
   /** @inheritDoc */

--- a/module/data/other/character-generation.mjs
+++ b/module/data/other/character-generation.mjs
@@ -29,6 +29,12 @@ import MappingField from "../fields/mapping-field.mjs";
  */
 export default class CharacterGenerationData extends SparseDataModel {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.CharacterGeneration",
+  ];
+
   static minAttributeModifier = -2;
   static maxAttributeModifier = 8;
 

--- a/module/data/roll/ability.mjs
+++ b/module/data/roll/ability.mjs
@@ -2,6 +2,12 @@ import EdRollOptions from "./common.mjs";
 
 export default class AbilityRollOptions extends EdRollOptions {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.AbilityRollOptions",
+  ];
+
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/roll/attack.mjs
+++ b/module/data/roll/attack.mjs
@@ -3,6 +3,12 @@ import EdRollOptions from "./common.mjs";
 
 export default class AttackRollOptions extends EdRollOptions {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.AttackRollOptions",
+  ];
+
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -60,6 +60,13 @@ import { SparseDataModel } from "../abstract.mjs";
  *                               etc. TODO: complete list
  */
 export default class EdRollOptions extends SparseDataModel {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.RollOptions",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/roll/damage.mjs
+++ b/module/data/roll/damage.mjs
@@ -3,6 +3,12 @@ import ED4E from "../../config/_module.mjs";
 
 export default class DamageRollOptions extends EdRollOptions {
 
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.DamageRollOptions",
+  ];
+
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {

--- a/module/data/thread/thread-base.mjs
+++ b/module/data/thread/thread-base.mjs
@@ -3,6 +3,13 @@ import { SparseDataModel } from "../abstract.mjs";
 import ThreadLevelData from "./thread-level.mjs";
 
 export default class ThreadBaseData extends SparseDataModel {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.ThreadBase",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;

--- a/module/data/thread/thread-level.mjs
+++ b/module/data/thread/thread-level.mjs
@@ -1,7 +1,13 @@
 import { SparseDataModel } from "../abstract.mjs";
 
 export default class ThreadLevelData extends SparseDataModel {
-  /** @inheritDoc */
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.ThreadLevel",
+  ];
+
   /** @inheritDoc */
   static defineSchema() {
     const fields = foundry.data.fields;


### PR DESCRIPTION
Add code for foundry core localization of data models and appV2 tab labels.

!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
The lang file has not been updated yet!!!
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!

When updating lang files, the label and hint properties in data model fields need to be removed!