### PR TITLE
add-workflows-with-example

### DIFF
--- a/earthdawn4e.mjs
+++ b/earthdawn4e.mjs
@@ -22,6 +22,7 @@ import * as hooks from "./module/hooks/_module.mjs";
 import * as system from "./module/system/_module.mjs";
 import * as tours from "./module/tours/_module.mjs";
 import * as utils from "./module/utils.mjs";
+import * as workflows from "./module/workflows/_module.mjs";
 
 /* -------------------------------------------- */
 /*  Define Module Structure                     */
@@ -38,7 +39,8 @@ globalThis.ed4e = {
   hooks,
   system,
   tours,
-  utils
+  utils,
+  workflows,
 };
 
 /* -------------------------------------------- */
@@ -63,5 +65,6 @@ export {
   // migrations,
   system,
   utils,
+  workflows,
   ED4E
 };

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -230,6 +230,21 @@ export default class ActorEd extends Actor {
   }
 
   /**
+   * Returns an attack ability that matches the combat type and item status of the given weapon, if any.
+   * @param {ItemEd} weapon The weapon to get the attack ability for.
+   * @returns {ItemEd|undefined} The attack ability item, or undefined if none was found.
+   */
+  getAttackAbilityForWeapon( weapon ) {
+    const { wieldingType, weaponType, armorType } = weapon.system;
+    return this.itemTypes.ability.find(
+      item => item.system.rollType === "attack"
+        && item.system.rollTypeDetails?.attack?.weaponType === weaponType
+        && item.system.rollTypeDetails?.attack?.weaponItemStatus.includes( wieldingType )
+        && item.system.difficulty?.target === armorType
+    );
+  }
+
+  /**
    * Finds and returns this PC's class of the given type with the highest circle.
    * If multiple, only the first found will be returned.
    * @param {string} type The type of class to be searched for. One of discipline, path, questor.
@@ -649,7 +664,7 @@ export default class ActorEd extends Actor {
    *                                                                    - `damageTaken`: the actual amount of damage this actor has taken after armor
    *                                                                    - `knockdownTest`: whether a knockdown test should be made.
    */
-  // eslint-disable-next-line max-params
+   
 
 
   takeDamage( amount, options = {

--- a/module/workflows/_module.mjs
+++ b/module/workflows/_module.mjs
@@ -1,0 +1,2 @@
+export * as workflow from "./workflow/_module.mjs";
+export { default as WorkflowInterruptError } from "./workflow-interrupt.mjs";

--- a/module/workflows/workflow-interrupt.mjs
+++ b/module/workflows/workflow-interrupt.mjs
@@ -1,0 +1,11 @@
+export default class WorkflowInterruptError extends Error {
+
+  constructor( workflow, localizedMessage, ...params ) {
+    super( ...params );
+    this.name = "WorkflowInterruptError";
+    this.workflow = workflow;
+    this.localizedMessage = localizedMessage;
+    this.message ??= `${this.workflow.name} interrupted`;
+  }
+
+}

--- a/module/workflows/workflow/_module.mjs
+++ b/module/workflows/workflow/_module.mjs
@@ -1,0 +1,2 @@
+export { default as Workflow } from "./workflow.mjs";
+export { default as ActorWorkflow } from "./actor-workflow.mjs";

--- a/module/workflows/workflow/actor-workflow.mjs
+++ b/module/workflows/workflow/actor-workflow.mjs
@@ -1,0 +1,28 @@
+import Workflow from "./workflow.mjs";
+
+/**
+ * Base class for all workflows that are associated with an Actor.
+ * @abstract
+ */
+export default class ActorWorkflow extends Workflow {
+
+  /**
+   * The actor that this workflow is associated with.
+   * @type {foundry.documents.Actor}
+   */
+  _actor = null;
+
+  /**
+   * @override
+   * @param {foundry.documents.Actor} actor The actor that this workflow is associated with.
+   * @param {WorkflowOptions} [options] See {@link Workflow#constructor}.
+   */
+  constructor( actor, options = {} ) {
+    if ( ! ( actor instanceof foundry.documents.Actor ) )
+      throw new TypeError( "ActorWorkflow constructor expects an Actor instance." );
+
+    super( options );
+    this._actor = actor;
+  }
+
+}

--- a/module/workflows/workflow/attack-workflow.mjs
+++ b/module/workflows/workflow/attack-workflow.mjs
@@ -1,0 +1,137 @@
+import ActorWorkflow from "./actor-workflow.mjs";
+import WorkflowInterruptError from "../workflow-interrupt.mjs";
+import { getSetting } from "../../settings.mjs";
+import AttackRollOptions from "../../data/roll/attack.mjs";
+import RollPrompt from "../../applications/global/roll-prompt.mjs";
+
+/**
+ * @typedef {object} AttackWorkflowOptions
+ * @property {"tail"|"unarmed"|"weapon"} [attackType="unarmed"] The type of attack being performed.
+ */
+
+export default class AttackWorkflow extends ActorWorkflow {
+
+  /**
+   * The ability used for the attack.
+   * @type {ItemEd|undefined}
+   */
+  _ability;
+
+  /**
+   * The type of attack being performed.
+   * @type {"tail"|"unarmed"|"weapon"}
+   */
+  _attackType;
+
+  /**
+   * The roll object that is created for the attack.
+   * @type {EdRoll}
+   */
+  _roll;
+
+  /**
+   * The options that are passed to the roll object.
+   * @type {EdRollOptions}
+   */
+  _rollOptions;
+
+  /**
+   * The weapon being used for the attack.
+   * @type {ItemEd|undefined}
+   */
+  _weapon;
+
+  /**
+   * @param {foundry.documents.Actor} attacker - The actor that is performing the attack.
+   * @param {WorkflowOptions&AttackWorkflowOptions} options - The options for the attack workflow.
+   */
+  constructor( attacker, options = {} ) {
+    super( attacker, options );
+    this._attackType = options.attackType ?? "unarmed";
+
+    if ( this._attackType !== "unarmed" ) this._steps.push( this.#setWeapon.bind( this ) );
+    this._steps.push(
+      this.#setAbility.bind( this ),
+      this.#createRollOptions.bind( this ),
+      this.#createAttackRoll.bind( this ),
+      this.#rollAttack.bind( this ),
+    );
+  }
+
+  async #setWeapon() {
+    const weaponStatus = this._attackType === "tail"
+      ? [ "tail" ]
+      : [ "mainHand", "offHand", "twoHands" ];
+    let weapon = this._actor.itemTypes.weapon.find( item => weaponStatus.includes( item.system.itemStatus ) );
+
+    if ( !weapon && this._attackType !== "tail" ) weapon = this.actor.drawWeapon();
+    if ( !weapon ) throw new WorkflowInterruptError(
+      this,
+      game.i18n.localize( "ED.Notifications.Warn.Workflow.AttackNoWeaponFound" ),
+    );
+
+    this._weapon = weapon;
+  }
+
+  async #setAbility() {
+    if ( [ "tail", "unarmed" ].includes( this._attackType ) ) {
+      this._ability = this._actor.getSingleItemByEdid( getSetting( "edidUnarmedCombat" ) );
+    } else if ( this._weapon ) {
+      this._ability = this._actor.getAttackAbilityForWeapon( this._weapon );
+    }
+  }
+
+  async #createRollOptions() {
+    this._rollOptions = AttackRollOptions.fromActor(
+      {
+        ...this.getCommonAttackRollData(),
+        weaponType: this._weapon?.system.weaponType ?? "unarmed",
+        weaponUuid: this._weapon?.uuid ?? null,
+        chatFlavor: game.i18n.format( `TODO.ED.Chat.Flavor.${this._attackType}Attack`, {} )
+      },
+      this._actor,
+    );
+  }
+
+  async #createAttackRoll() {
+    this._roll = await RollPrompt.waitPrompt(
+      this._rollOptions,
+      {
+        rollData: this._actor,
+      }
+    );
+  }
+
+  async #rollAttack() {
+    // currently used as intended, as roll processing is still part of the actor document
+    this._result = this._roll;
+  }
+
+  getCommonAttackRollData() {
+    const targetTokens = game.user.targets;
+    const maxDifficulty = Math.max( ...[ ...targetTokens ].map(
+      token => token.actor.system.characteristics.defenses.physical.value
+    ) );
+
+    return {
+      step:       {
+        base:      this._ability?.system.rankFinal ?? this._actor.system.attributes.dex.step,
+        modifiers: {},
+      },
+      extraDice:  {},
+      target:     {
+        base:      maxDifficulty,
+        modifiers: {},
+        public:    false,
+        tokens:    targetTokens.map( token => token.document.uuid ),
+      },
+      strain:     {
+        base:      0,
+        modifiers: {},
+      },
+      testType:   "action",
+      rollType:   "attack",
+    };
+  }
+
+}

--- a/module/workflows/workflow/workflow.mjs
+++ b/module/workflows/workflow/workflow.mjs
@@ -32,7 +32,7 @@ export default class Workflow {
   _options;
 
   /**
-   * The result of the workflow. Each subclass defines what this means.
+   * The result of the workflow. Must be set in the subclass during execution.
    * @type {any}
    */
   _result;
@@ -71,7 +71,7 @@ export default class Workflow {
     try {
       while ( this._currentStep < this._steps.length ) {
         const step = this._steps[this._currentStep];
-        this._result = await step();
+        await step();
         this._currentStep++;
       }
     } catch ( e ) {

--- a/module/workflows/workflow/workflow.mjs
+++ b/module/workflows/workflow/workflow.mjs
@@ -1,0 +1,89 @@
+/**
+ * @typedef {object} WorkflowOptions
+ * @property {string} [name] The name of the workflow.
+ */
+
+import WorkflowInterruptError from "../workflow-interrupt.mjs";
+
+/**
+ * Base class for all workflows. A workflow is a collection of tasks that are executed in sequence. The may depend on
+ * each other, or they may be independent. The workflow itself may have one or more targets that are affected by the
+ * tasks.
+ * @abstract
+ */
+export default class Workflow {
+
+  /**
+   * The current step in the workflow, pointing to the current task.
+   * @type {number}
+   */
+  _currentStep = 0;
+
+  /**
+   * The name of the workflow. Defaults to the name of the class.
+   * @type {string}
+   */
+  _name;
+
+  /**
+   * The options for this workflow.
+   * @type {object}
+   */
+  _options;
+
+  /**
+   * The result of the workflow. Each subclass defines what this means.
+   * @type {any}
+   */
+  _result;
+
+  /**
+   * The tasks that make up this workflow.
+   * @type {Array<function() : Promise<any>>}
+   */
+  _steps = [];
+
+  /**
+   * @param {WorkflowOptions}  [options] The options for this workflow.
+   */
+  constructor( options = {} ) {
+    if ( new.target === Workflow ) {
+      throw new TypeError( "Cannot instantiate an abstract class (Workflow) directly." );
+    }
+    this._options = options;
+    this._name = options.name || this.constructor.name;
+  }
+
+  // region Properties
+
+  get name() {
+    return this._name;
+  }
+
+  // endregion
+
+  /**
+   * Execute the workflow.
+   * @returns {Promise<any|undefined>} The result of the workflow, which is defined by the subclass, or
+   * undefined if the workflow was interrupted.
+   */
+  async execute() {
+    try {
+      while ( this._currentStep < this._steps.length ) {
+        const step = this._steps[this._currentStep];
+        this._result = await step();
+        this._currentStep++;
+      }
+    } catch ( e ) {
+      if ( e instanceof WorkflowInterruptError ) {
+        ui.notifications.warn( e.localizedMessage ?? e.message );
+        return undefined;
+      } else {
+        throw e;
+      }
+    }
+
+    return this._result;
+  }
+
+}


### PR DESCRIPTION
Introduce new module for factoring out workflows from documents. This is not functionally necessary but helps maintainability and the overall structure to relive the document class a bit (especially Actor and Item).

Add example restructure for attack workflow.

Other need extra tickets (e.g., damage workflow, recovery workflow, roll workflows attribute ability, equipment, etc)