### PR TITLE
Add localization JSON consolidation and linting utilities

### DIFF
--- a/.lintstagedrc.yaml
+++ b/.lintstagedrc.yaml
@@ -1,8 +1,14 @@
 # lint and fix modules
-"module/**/*.mjs": "eslint --fix --config eslint.config.mjs"
 
-# format and check language files
-"lang/**/*.json": "npm run format:lang"
+"{module,utils}/**/*.mjs":
+  # fixable rules
+  - "eslint --fix --config eslint.config.mjs"
+  ## non-fixable checks
+  - "eslint --config eslint.config.mjs --max-warnings 0"
+
+
+# consolidate, format and check language files
+"lang/**/*.json": "npm run lint:lang"
 
 # activate when clear what the *.md format is
 # if Github docs, there is an extra module for it: https://github.com/github/markdownlint-github

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "gulp buildAll",
     "build:css": "gulp buildCSS",
     "build:watch": "gulp",
-    "format:lang": "node ./utils/format-lang-json.mjs",
+    "lint:lang": "node ./utils/lint-json.mjs",
     "lint": "gulp lint",
     "lint:fix": "gulp lint --fix",
     "pushLDBtoJSON": "node ./tools/pushLDBtoJSON.mjs",

--- a/utils/consolidate-lang-json.mjs
+++ b/utils/consolidate-lang-json.mjs
@@ -1,0 +1,125 @@
+import path from "path";
+import fs from "fs";
+
+
+/**
+ * Expand a flat object with dot notation keys into a nested object.
+ * @param {object} flatObj The object to expand
+ * @returns {object} The expanded object
+ */
+export function expandObject( flatObj ) {
+  const result = {};
+
+  // eslint-disable-next-line guard-for-in
+  for ( const flatKey in flatObj ) {
+    const parts = flatKey.split( "." );
+    let current = result;
+
+    parts.forEach( ( part, idx ) => {
+      if ( idx === parts.length - 1 ) {
+        current[part] = flatObj[flatKey];
+      } else {
+        if ( !current[part] ) current[part] = {};
+        current = current[part];
+      }
+    } );
+  }
+
+  return result;
+}
+
+/**
+ * Flatten a possibly multidimensional object to a one-dimensional one by converting all nested keys to dot notation
+ * @param {object} obj        The object to flatten
+ * @param {number} [_d]     Track the recursion depth to prevent overflow
+ * @returns {object}          A flattened object
+ */
+export function flattenObject( obj, _d=0 ) {
+  const flat = {};
+  if ( _d > 100 ) {
+    throw new Error( "Maximum depth exceeded" );
+  }
+  for ( const [ k, v ] of Object.entries( obj ) ) {
+    if ( typeof v === "object" ) {
+      if ( !Object.keys( v ).length ) flat[k] = v;
+      const inner = flattenObject( v, _d+1 );
+      for ( const [ ik, iv ] of Object.entries( inner ) ) {
+        flat[`${k}.${ik}`] = iv;
+      }
+    }
+    else flat[k] = v;
+  }
+  return flat;
+}
+
+
+/**
+ * Consolidate localization JSON files by ensuring all keys are present in each file.
+ * @param {string} [langDir] The directory containing the JSON files. Defaults to "lang".
+ * @param {[string]} [langFiles] An array of JSON file names. If not provided, all JSON files in the directory will be used.
+ * @throws {TypeError} If langFiles is not an array.
+ */
+export default function consolidateLangJson( langDir, langFiles ) {
+
+  // eslint-disable-next-line no-param-reassign
+  langDir ??= path.resolve( "lang" );
+  // eslint-disable-next-line no-param-reassign
+  langFiles ??= fs.readdirSync( langDir ).filter(
+    file => file.endsWith( ".json" )
+  );
+  if ( !Array.isArray( langFiles ) ) throw new TypeError( "langFiles must be an array" );
+
+  const localizationPlaceholder = "TODO: Add translation";
+
+  const langData = {};
+
+  langFiles.forEach( file => {
+    const fullPath = path.join( langDir, file );
+    const raw = fs.readFileSync( fullPath, "utf8" );
+    langData[file] = {
+      path:    fullPath,
+      content: JSON.parse( raw )
+    };
+  } );
+
+  const flattenedLangs = {};
+
+  for ( const [ file, { content } ] of Object.entries( langData ) ) {
+    flattenedLangs[file] = flattenObject( content );
+  }
+
+  const allKeys = new Set(
+    Object.values(
+      flattenedLangs
+    ).map(
+      langObject => Object.keys( langObject )
+    ).flat()
+  );
+
+  const resolvedLangs = {};
+
+  for ( const file of Object.keys( flattenedLangs ) ) {
+    resolvedLangs[file] = {};
+
+    for ( const key of allKeys ) {
+      const deValue = flattenedLangs["de.json"][key];
+      const currentValue = flattenedLangs[file][key];
+
+      if ( file === "de.json" ) {
+        // Keep DE values as-is
+        resolvedLangs[file][key] = deValue ?? localizationPlaceholder;
+      } else if ( currentValue ) {
+        // Keep existing non-empty value
+        resolvedLangs[file][key] = currentValue;
+      } else {
+        // Default to placeholder
+        resolvedLangs[file][key] = localizationPlaceholder;
+      }
+    }
+  }
+
+  for ( const file of Object.keys( resolvedLangs ) ) {
+    const expanded = expandObject( resolvedLangs[file] );
+    fs.writeFileSync( path.join( langDir, file ), JSON.stringify( expanded ), "utf8" );
+  }
+}

--- a/utils/format-lang-json.mjs
+++ b/utils/format-lang-json.mjs
@@ -43,10 +43,9 @@ function formatAligned( obj, indentSize = 2 ) {
   /**
    * Format entries into aligned JSON.
    * @param { [[str][str]][]} entries The entries of an object to format.
-   * @param {number} level The current indentation level.
    * @returns {string} The formatted JSON string.
    */
-  function formatEntries( entries, level = 0 ) {
+  function formatEntries( entries ) {
     const output = [];
 
     entries.forEach( ( entry, idx ) => {
@@ -97,30 +96,31 @@ function formatLangFile( filePath ) {
 }
 
 
-// Main function
-if ( process.argv.length < 3 ) {
-  console.error( "Usage: node format-json.js <file1.json> <file2.json> ..." );
-  process.exit( 1 );
-}
 
-const files = process.argv.slice( 2 );
 
-if ( files.length === 0 ) {
-  console.error( "No files provided." );
-  process.exit( 1 );
-}
-files.forEach( ( file ) => {
-  const filePath = path.resolve( file );
 
-  if ( !file.endsWith( ".json" ) ) {
-    console.error( `Invalid file type: ${ filePath }` );
-    return;
+/**
+ * Align the keys and values in JSON files.
+ * @param {string[]} files The paths to the JSON files to format.
+ */
+export default function alignLangJson( files ) {
+  if ( files.length === 0 ) {
+    console.error( "No files provided." );
+    process.exit( 1 );
   }
+  files.forEach( ( file ) => {
+    const filePath = path.resolve( file );
 
-  if ( !fs.existsSync( filePath ) ) {
-    console.error( `File not found: ${ filePath }` );
-  }
+    if ( !file.endsWith( ".json" ) ) {
+      console.error( `Invalid file type: ${ filePath }` );
+      return;
+    }
 
-  formatLangFile( filePath );
-  console.log( `Formatted ${ filePath }` );
-} );
+    if ( !fs.existsSync( filePath ) ) {
+      console.error( `File not found: ${ filePath }` );
+    }
+
+    formatLangFile( filePath );
+    console.log( `Formatted ${ filePath }` );
+  } );
+}

--- a/utils/lint-json.mjs
+++ b/utils/lint-json.mjs
@@ -1,0 +1,32 @@
+import alignLangJson from "./format-lang-json.mjs";
+import consolidateLangJson from "./consolidate-lang-json.mjs";
+import fs from "fs";
+import path from "path";
+
+
+/**
+ * Validate a JSON file.
+ * @param {string} jsonFile The path to the JSON file to validate.
+ * @throws {Error} If the JSON file is invalid.
+ */
+function validateJson( jsonFile ) {
+  try {
+    const jsonString = fs.readFileSync( jsonFile, "utf8" );
+    JSON.parse( jsonString );
+  } catch ( e ) {
+    throw new Error( `Invalid JSON file: ${ jsonFile }`, { cause: e } );
+  }
+}
+
+// Main script
+const LANG_DIR = path.resolve( "lang" );
+const files = fs.readdirSync( LANG_DIR ).filter(
+  file => file.endsWith( ".json" )
+);
+const filePaths = files.map( file => path.join( LANG_DIR, file ) );
+
+
+filePaths.forEach( file => validateJson( file ) );
+consolidateLangJson( LANG_DIR, files );
+alignLangJson( filePaths );
+filePaths.forEach( file => validateJson( file ) );


### PR DESCRIPTION
The pre-commit hook now fails if es-lint finds non-fixable issues.

JSON lang linting has been extended. When a lang file has been changed, all lang files are consolidated. This means, that all lang files are updated to have all the same keys across all files. If a key is inserted the get a default "TODO: Add translation" value.
This needs to be done once, to bring all lang files up to the same state, and from then on, changes in PRs in only one lang file are reflected in other files as well.