### PR TITLE
1636-refactoring-sheet-global-class

### DIFF
--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -1,5 +1,6 @@
 export * as actor from "./actor/_module.mjs";
 export * as advancement from "./advancement/_module.mjs";
+export * as api from "./api/_module.mjs";
 export * as combat from "./combat/_module.mjs";
 export * as configs from "./configs/_module.mjs";
 export * as effect from "./effect/_module.mjs";

--- a/module/applications/actor/character-generation-prompt.mjs
+++ b/module/applications/actor/character-generation-prompt.mjs
@@ -545,7 +545,7 @@ export default class CharacterGenerationPrompt extends ApplicationEd {
   }
 
   /**
-   * @returns {void} This function returns the number of the previous step.
+   * @returns {boolean} This function returns true if there is a previous step.
    * @userFunction UF_CharacterGenerationPrompt-hasPreviousStep
    */
   _hasPreviousStep() {

--- a/module/applications/actor/character-generation-prompt.mjs
+++ b/module/applications/actor/character-generation-prompt.mjs
@@ -2,10 +2,10 @@ import { documentsToSelectChoices, filterObject, getAllDocuments } from "../../u
 import ED4E from "../../config/_module.mjs";
 import CharacterGenerationData from "../../data/other/character-generation.mjs";
 import ItemEd from "../../documents/item.mjs";
+import ApplicationEd from "../api/application.mjs";
 
-const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
-export default class CharacterGenerationPrompt extends HandlebarsApplicationMixin( ApplicationV2 ) {
+export default class CharacterGenerationPrompt extends ApplicationEd {
 
   magicType;
 
@@ -71,11 +71,10 @@ export default class CharacterGenerationPrompt extends HandlebarsApplicationMixi
    * @userFunction UF_CharacterGenerationPrompt-defaultOptions
    */
   static DEFAULT_OPTIONS = {
-    id:      "character-generation-prompt",
-    classes: [ "earthdawn4e", "character-generation" ],
-    tag:     "form",
-    window:  {
-      frame:       true,
+    id:       "character-generation-prompt-{id}",
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
+    classes:  [ "character-generation", ],
+    window:   {
       icon:        "fa-thin fa-user",
       title:       "ED.Dialogs.Title.characterGeneration",
       resizable:   true,

--- a/module/applications/actor/common-sheet.mjs
+++ b/module/applications/actor/common-sheet.mjs
@@ -7,7 +7,7 @@ const { ActorSheetV2 } = foundry.applications.sheets;
 /**
  * Extend the basic ActorSheet with modifications
  * @augments {ActorSheetV2}
- * @mixes HandlebarsApplicationMixin
+ * @mixes DocumentSheetMixinEd
  */
 export default class ActorSheetEd extends DocumentSheetMixinEd( ActorSheetV2 ) {
 

--- a/module/applications/actor/common-sheet.mjs
+++ b/module/applications/actor/common-sheet.mjs
@@ -1,5 +1,3 @@
-import ED4E from "../../config/_module.mjs";
-import { getSetting } from "../../settings.mjs";
 import DocumentSheetMixinEd from "../api/document-sheet-mixin.mjs";
 
 const { ActorSheetV2 } = foundry.applications.sheets;
@@ -16,27 +14,9 @@ export default class ActorSheetEd extends DocumentSheetMixinEd( ActorSheetV2 ) {
    * @userFunction UF_ActorSheetEd-defaultOptions
    */
   static DEFAULT_OPTIONS = {
-    classes:  [ "earthdawn4e", "sheet", "actor" ],
-    window:   {
-      frame:          true,
-      positioned:     true,
-      icon:           false,
-      minimizable:    true,
-      resizable:      true,
-    },
+    classes:  [ "actor", ],
     actions:  {
-      editImage:          ActorSheetEd._onEditImage,
-      editItem:           ActorSheetEd._onItemEdit,
-      deleteItem:         ActorSheetEd._onItemDelete,
-      displayItem:        ActorSheetEd._onDisplayItem,
       expandItem:         ActorSheetEd._onCardExpand,
-      createChild:        ActorSheetEd._onCreateChild,
-      deleteChild:        ActorSheetEd._onDeleteChild,
-      displayChildToChat: ActorSheetEd._onDisplayChildToChat,
-      editChild:          ActorSheetEd._onEditChild,
-    },
-    form: {
-      submitOnChange: true,
     },
   };
 
@@ -90,33 +70,18 @@ export default class ActorSheetEd extends DocumentSheetMixinEd( ActorSheetV2 ) {
     );
   }
 
-  /* -------------------------------------------- */
-  /*  Rendering                                   */
-  /* -------------------------------------------- */
+  // region Rendering
 
   /** 
    * @inheritdoc 
    * @userFunction UF_ActorSheetEd-prepareContext
    */
   async _prepareContext( options ) {
-    // TODO: überprüfen was davon benötigt wird
     const context = await super._prepareContext( options );
     foundry.utils.mergeObject( context, {
       actor:                  this.document,
-      system:                 this.document.system,
       items:                  this.document.items,
-      options:                this.options,
-      systemFields:           this.document.system.schema.fields,
-      config:                 ED4E,
     } );
-
-    context.enrichedDescription = await TextEditor.enrichHTML(
-      this.document.system.description.value,
-      {
-        // Only show secret blocks to owner
-        secrets:    this.document.isOwner,
-      }
-    );
 
     return context;
   }
@@ -129,68 +94,9 @@ export default class ActorSheetEd extends DocumentSheetMixinEd( ActorSheetV2 ) {
     return super._renderHTML( context, options );
   }
 
-  /* -------------------------------------------- */
-  /*  Drag and Drop                               */
-  /* -------------------------------------------- */
+  // endregion
 
-  /* -------------------------------------------- */
-  /*  Event Handlers                              */
-  /* -------------------------------------------- */
-
-  /**
-   * Changing the actor image
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<foundry.FilePicker>} - A promise that resolves when the image is changed.
-   * @userFunction UF_ActorSheetEd-onEditImage
-   */
-  static async _onEditImage( event, target ) {
-    const attr = target.dataset.edit;
-    const current = foundry.utils.getProperty( this.document, attr );
-    const { img } = this.document.constructor.getDefaultArtwork?.( this.document.toObject() ) ?? {};
-    // eslint-disable-next-line no-undef
-    const fp = new FilePicker( {
-      current,
-      type:           "image",
-      redirectToRoot: img ? [ img ] : [],
-      callback:       ( path ) => {
-        this.document.update( { [attr]: path } );
-      },
-      top:  this.position.top + 40,
-      left: this.position.left + 10,
-    } );
-    return fp.browse();
-  }
-
-  /**
-   * Editing an item
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<any>} - A promise that resolves when the item is edited.
-   * @userFunction UF_ActorSheetEd-onItemEdit
-   */
-  static async _onItemEdit( event, target ) {
-    event.preventDefault();
-    const itemId = target.parentElement.dataset.itemId;
-    const item = this.document.items.get( itemId );
-    return item.sheet?.render( true );
-  }
-
-  /**
-   * Deleting an item
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<void>} - A promise that resolves when the item is deleted.
-   * @userFunction UF_ActorSheetEd-onItemDelete
-   */
-  static async _onItemDelete( event, target ) {
-    event.preventDefault();
-    const itemId = target.parentElement.dataset.itemId;
-    const item = this.document.items.get( itemId );
-    if ( !item ) return;
-    if ( getSetting( "quickDeleteEmbeddedOnShiftClick" ) && event.shiftKey ) return item.delete();
-    else item.deleteDialog();
-  }
+  // region Event Handlers
 
   /**
    * Expanding or collapsing the item description
@@ -210,101 +116,6 @@ export default class ActorSheetEd extends DocumentSheetMixinEd( ActorSheetV2 ) {
     itemDescription.toggleClass( "card__description--toggle" );
   }
 
-  /**
-   * Display an item in the chat
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<void>} - A promise that resolves when the item is displayed in the chat.
-   * @userFunction UF_ActorSheetEd-onDisplayItem
-   */
-  static async _onDisplayItem( event, target ) {
-    ui.notifications.info( "Display Item not done yet" );
-  }
-
-  /** 
-   * Creates a new child active effect
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is created.
-   * @userFunction UF_ActorSheetEd-onCreateChild
-   */
-  static async _onCreateChild( event, target ) {
-    const type = target.dataset.type;
-
-    if ( type === "effect" ) return ActiveEffect.implementation.create( {
-      type:     "eae",
-      name:     game.i18n.localize( "ED.ActiveEffect.newEffectName" ),
-      icon:     "icons/svg/aura.svg",
-      changes:  [ {} ],
-      system:  {
-        duration: {
-          type: target.dataset.effectPermanent ? "permanent" : "combat",
-        },
-        changes: [ {} ],
-      },
-    }, {
-      parent:      this.document,
-      renderSheet: true,
-    } );
-
-    // this will make more sense when we have a common documentSheet mixin
-    /* if ( activeTab === "spells" ) return Item.implementation.create({
-      name: game.i18n.format("DOCUMENT.New", { type: game.i18n.format(CONFIG.Item.typeLabels.spell) }),
-      type: "spell",
-      img: Item.implementation.getDefaultArtwork({ type: "spell" })?.img ?? Item.implementation.DEFAULT_ICON
-    }, { parent: this.actor, renderSheet: true });
-
-    const features = ["feat", "race", "background", "class", "subclass"];
-    if ( this.actor.type === "npc" ) features.push("weapon");
-
-    let types = {
-      features,
-      inventory: ["weapon", "equipment", "consumable", "tool", "container", "loot"]
-    }[activeTab] ?? [];
-
-    types = types.filter(type => {
-      const model = CONFIG.Item.dataModels[type];
-      return !model.metadata?.singleton || !this.actor.itemTypes[type].length;
-    });
-
-    if ( types.length ) return Item.implementation.createDialog({}, {
-      parent: this.actor, pack: this.actor.pack, types
-    }); */
-  }
-
-  /** 
-   * Deletes a child active effect
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is deleted.
-   * @userFunction UF_ActorSheetEd-onDeleteChild
-   */
-  static async _onDeleteChild( event, target ) {
-    const document = await fromUuid( target.dataset.uuid );
-    if ( getSetting( "quickDeleteEmbeddedOnShiftClick" ) && event.shiftKey ) return document.delete();
-    else document.deleteDialog();
-  }
-
-  /** 
-   * Displays a child active effect in the chat
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is displayed in chat.
-   * @userFunction UF_ActorSheetEd-onDisplayChildToChat
-   */
-  static async _onDisplayChildToChat( event, target ) {
-    ChatMessage.create( { content: "Coming up: a beautiful description of the Item you just clicked to be displayed here in chat!" } );
-  }
-
-  /** 
-   * Edits a child active effect
-   * @param {Event} event - The event that triggered the form submission.
-   * @param {HTMLElement} target - The HTML element that triggered the action.
-   * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is edited.
-   * @userFunction UF_ActorSheetEd-onEditChild
-   */
-  static async _onEditChild( event, target ) {
-    ( await fromUuid( target.dataset.uuid ) ).sheet?.render( { force: true } );
-  }
+  // endregion
 
 }

--- a/module/applications/actor/common-sheet.mjs
+++ b/module/applications/actor/common-sheet.mjs
@@ -1,7 +1,7 @@
 import ED4E from "../../config/_module.mjs";
 import { getSetting } from "../../settings.mjs";
+import DocumentSheetMixinEd from "../api/document-sheet-mixin.mjs";
 
-const { HandlebarsApplicationMixin } = foundry.applications.api;
 const { ActorSheetV2 } = foundry.applications.sheets;
 
 /**
@@ -9,7 +9,7 @@ const { ActorSheetV2 } = foundry.applications.sheets;
  * @augments {ActorSheetV2}
  * @mixes HandlebarsApplicationMixin
  */
-export default class ActorSheetEd extends HandlebarsApplicationMixin( ActorSheetV2 ) {
+export default class ActorSheetEd extends DocumentSheetMixinEd( ActorSheetV2 ) {
 
   /** 
    * @inheritdoc 

--- a/module/applications/advancement/assign-legend.mjs
+++ b/module/applications/advancement/assign-legend.mjs
@@ -125,7 +125,7 @@ export default class AssignLpPrompt extends ApplicationEd {
 
   /** @inheritDoc */
   static async _processSubmitData( event, form, formData, submitOptions ) {
-    const data = super._processSubmitData( event, form, formData );
+    const data = super._processSubmitData( event, form, formData, submitOptions );
     // make array if only one actor is selected
     data.selectedActors = [].concat( data.selectedActors || [] );
     data.amount = data.amount || 0;

--- a/module/applications/advancement/class-advancement.mjs
+++ b/module/applications/advancement/class-advancement.mjs
@@ -2,11 +2,11 @@ import ClassTemplate from "../../data/item/templates/class.mjs";
 import ED4E from "../../config/_module.mjs";
 import PromptFactory from "../global/prompt-factory.mjs";
 import { getAllDocuments } from "../../utils.mjs";
+import ApplicationEd from "../api/application.mjs";
 
-const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 const { isEmpty } = foundry.utils;
 
-export default class ClassAdvancementDialog extends HandlebarsApplicationMixin( ApplicationV2 ) {
+export default class ClassAdvancementDialog extends ApplicationEd {
 
   /**
    * This is a very specific user function which is not following the pattern of the naming convention.
@@ -97,11 +97,10 @@ export default class ClassAdvancementDialog extends HandlebarsApplicationMixin( 
    * @userFunction UF_ClassAdvancementDialog-defaultOptions
    */
   static DEFAULT_OPTIONS = {
-    id:      "class-advancement-dialog",
-    classes: [ "earthdawn4e", "class-advancement-dialog" ],
-    tag:     "form",
-    window:  {
-      frame: true,
+    id:       "class-advancement-dialog-{id}",
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
+    classes:  [ "class-advancement-dialog" ],
+    window:   {
       icon:  `fa-thin ${ED4E.icons.classAdvancement}`,
       title: "ED.Dialogs.Title.classAdvancement",
     },
@@ -113,7 +112,6 @@ export default class ClassAdvancementDialog extends HandlebarsApplicationMixin( 
     form:    {
       handler:        ClassAdvancementDialog.#onFormSubmission,
       submitOnChange: true,
-      closeOnSubmit:  false,
     },
   };
 

--- a/module/applications/advancement/learn-spell.mjs
+++ b/module/applications/advancement/learn-spell.mjs
@@ -1,9 +1,9 @@
 import ED4E from "../../config/_module.mjs";
 import PromptFactory from "../global/prompt-factory.mjs";
+import ApplicationEd from "../api/application.mjs";
 
-const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
-export default class LearnSpellPrompt extends HandlebarsApplicationMixin( ApplicationV2 ) {
+export default class LearnSpellPrompt extends ApplicationEd {
 
   /**
    * @inheritDoc
@@ -88,11 +88,10 @@ export default class LearnSpellPrompt extends HandlebarsApplicationMixin( Applic
    * @userFunction                             UF_LearnSpellPrompt-defaultOptions
    */
   static DEFAULT_OPTIONS = {
-    id:      "learn-spell-prompt",
-    classes: [ "earthdawn4e", "learn-spell" ],
-    tag:     "form",
-    window:  {
-      frame: true,
+    id:       "learn-spell-prompt-{id}",
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
+    classes:  [ "learn-spell", ],
+    window:   {
       icon:  "fa-thin fa-scroll",
       title: "ED.Dialogs.Title.learnSpell",
     },
@@ -105,7 +104,6 @@ export default class LearnSpellPrompt extends HandlebarsApplicationMixin( Applic
     form:    {
       handler:        LearnSpellPrompt.#onFormSubmission,
       submitOnChange: true,
-      closeOnSubmit:  false,
     },
   };
 

--- a/module/applications/advancement/lp-history.mjs
+++ b/module/applications/advancement/lp-history.mjs
@@ -1,13 +1,13 @@
 import LpTrackingData from "../../data/advancement/lp-tracking.mjs";
 import LpEarningTransactionData from "../../data/advancement/lp-earning-transaction.mjs";
-const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+import ApplicationEd from "../api/application.mjs";
 
 /**
  * The application responsible for handling Legend Point related interactions and data.
  * @augments ApplicationV2
  * @mixes HandlebarsApplicationMixin
  */
-export default class LegendPointHistory extends HandlebarsApplicationMixin( ApplicationV2 ) {
+export default class LegendPointHistory extends ApplicationEd {
 
   /**
    * @inheritDoc
@@ -53,11 +53,10 @@ export default class LegendPointHistory extends HandlebarsApplicationMixin( Appl
    * @userFunction UF_LegendPointHistory-prepareOptions
    */
   static DEFAULT_OPTIONS = {
-    id:      "legend-point-history-prompt", 
-    classes: [ "earthdawn4e", "legend-point__history" ],
-    tag:     "form",
-    window:  {
-      frame: true,
+    id:       "legend-point-history-prompt-{id}",
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
+    classes:  [ "legend-point__history", ],
+    window:   {
       icon:  "fa-thin fa-list-timeline",
       title: "X-Localize Legend Point History",
     },
@@ -70,7 +69,6 @@ export default class LegendPointHistory extends HandlebarsApplicationMixin( Appl
     form: {
       handler:        LegendPointHistory.#onFormSubmission,
       submitOnChange: true,
-      closeOnSubmit:  false,
     },
     position: {
       width:  1000,

--- a/module/applications/api/_module.mjs
+++ b/module/applications/api/_module.mjs
@@ -1,3 +1,3 @@
-export { default as Application } from "./applicationEd.mjs";
+export { default as Application } from "./application.mjs";
 export { default as Dialog } from "./dialog.mjs";
 export { default as DocumentSheetMixin } from "./document-sheet-mixin.mjs";

--- a/module/applications/api/_module.mjs
+++ b/module/applications/api/_module.mjs
@@ -1,0 +1,3 @@
+export { default as Application } from "./application.mjs";
+export { default as Dialog } from "./dialog.mjs";
+export { default as DocumentSheetMixin } from "./document-sheet-mixin.mjs";

--- a/module/applications/api/_module.mjs
+++ b/module/applications/api/_module.mjs
@@ -1,3 +1,3 @@
-export { default as Application } from "./application.mjs";
+export { default as Application } from "./applicationEd.mjs";
 export { default as Dialog } from "./dialog.mjs";
 export { default as DocumentSheetMixin } from "./document-sheet-mixin.mjs";

--- a/module/applications/api/application.mjs
+++ b/module/applications/api/application.mjs
@@ -14,19 +14,20 @@ export default class ApplicationEd extends HandlebarsApplicationMixin( Applicati
    * Stored form data.
    * @type {object|null}
    */
-  #config = null;
+  _data = null;
 
   /**
    * Stored form data.
    * @type {object|null}
    */
-  get config() {
-    return this.#config;
+  get data() {
+    return this._data;
   }
 
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {
     classes: [ "ed4e" ],
+    tag:     "form",
     form:    {
       handler:       ApplicationEd.#onFormSubmission,
       closeOnSubmit: false,
@@ -35,8 +36,8 @@ export default class ApplicationEd extends HandlebarsApplicationMixin( Applicati
       width:  400,
       height: "auto",
     },
-    tag:    "form",
     window: {
+      frame:          true,
       contentClasses: [ "standard-form" ],
     },
   };
@@ -51,10 +52,12 @@ export default class ApplicationEd extends HandlebarsApplicationMixin( Applicati
   static async create( options ) {
     const { promise, resolve } = Promise.withResolvers();
     const application = new this( options );
-    application.addEventListener( "close", () => resolve( application.config ), { once: true } );
+    application.addEventListener( "close", () => resolve( application.data ), { once: true } );
     application.render( { force: true } );
     return promise;
   }
+
+  // region Event Handlers
 
   /**
    * Handle form submission.
@@ -64,8 +67,8 @@ export default class ApplicationEd extends HandlebarsApplicationMixin( Applicati
    * @param {FormDataExtended} formData     The form data.
    * @param {object} submitOptions         The submit options.
    */
-  static #onFormSubmission( event, form, formData, submitOptions ) {
-    this.#config = this._processSubmitData( event, form, formData, submitOptions );
+  static async #onFormSubmission( event, form, formData, submitOptions ) {
+    this._data = this._processSubmitData( event, form, formData, submitOptions );
   }
 
   /**
@@ -80,10 +83,16 @@ export default class ApplicationEd extends HandlebarsApplicationMixin( Applicati
     return foundry.utils.expandObject( formData.object );
   }
 
+  // endregion
+
+  // region Rendering
+
   /**
    * @inheritDoc
    */
   async _renderHTML( context, options ) {
     return super._renderHTML( context, options );
   }
+
+  // endregion
 }

--- a/module/applications/api/application.mjs
+++ b/module/applications/api/application.mjs
@@ -1,0 +1,89 @@
+const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
+
+
+/**
+ * A stock application meant for async behavior using templates.
+ * @augments ApplicationV2
+ * @mixes HandlebarsApplicationMixin
+ */
+export default class Application extends HandlebarsApplicationMixin( ApplicationV2 ) {
+
+  // region Properties
+
+  /**
+   * Stored form data.
+   * @type {object|null}
+   */
+  #config = null;
+
+  /**
+   * Stored form data.
+   * @type {object|null}
+   */
+  get config() {
+    return this.#config;
+  }
+
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes: [ "ed4e" ],
+    form:    {
+      handler:       Application.#onFormSubmission,
+      closeOnSubmit: false,
+    },
+    position: {
+      width:  400,
+      height: "auto",
+    },
+    tag:    "form",
+    window: {
+      contentClasses: [ "standard-form" ],
+    },
+  };
+
+  // endregion
+
+  /**
+   * Factory method for asynchronous behavior.
+   * @param {object} options              Application rendering options.
+   * @returns {Promise<object|null>}      A promise that resolves to the form data.
+   */
+  static async create( options ) {
+    const { promise, resolve } = Promise.withResolvers();
+    const application = new this( options );
+    application.addEventListener( "close", () => resolve( application.config ), { once: true } );
+    application.render( { force: true } );
+    return promise;
+  }
+
+  /**
+   * Handle form submission.
+   * @this {Application}
+   * @param {Event} event                  The submit event.
+   * @param {HTMLFormElement} form         The form element.
+   * @param {FormDataExtended} formData     The form data.
+   * @param {object} submitOptions         The submit options.
+   */
+  static #onFormSubmission( event, form, formData, submitOptions ) {
+    this.#config = this.processSubmitData( event, form, formData, submitOptions );
+  }
+
+  /**
+   * Perform processing of the submitted data. To prevent submission, throw an error.
+   * @param {Event}event                  The submit event.
+   * @param {HTMLFormElement} form        The form element.
+   * @param {FormDataExtended} formData   The form data.
+   * @param {object} submitOptions        The submit options.
+   * @returns {object}                     The data to return from this application.
+   */
+  _processSubmitData ( event, form, formData, submitOptions ) {
+    return foundry.utils.expandObject( formData.object );
+  }
+
+  /**
+   * @inheritDoc
+   */
+  async _renderHTML( context, options ) {
+    return super._renderHTML( context, options );
+  }
+}

--- a/module/applications/api/applicationEd.mjs
+++ b/module/applications/api/applicationEd.mjs
@@ -6,7 +6,7 @@ const { HandlebarsApplicationMixin, ApplicationV2 } = foundry.applications.api;
  * @augments ApplicationV2
  * @mixes HandlebarsApplicationMixin
  */
-export default class Application extends HandlebarsApplicationMixin( ApplicationV2 ) {
+export default class ApplicationEd extends HandlebarsApplicationMixin( ApplicationV2 ) {
 
   // region Properties
 
@@ -28,7 +28,7 @@ export default class Application extends HandlebarsApplicationMixin( Application
   static DEFAULT_OPTIONS = {
     classes: [ "ed4e" ],
     form:    {
-      handler:       Application.#onFormSubmission,
+      handler:       ApplicationEd.#onFormSubmission,
       closeOnSubmit: false,
     },
     position: {
@@ -58,14 +58,14 @@ export default class Application extends HandlebarsApplicationMixin( Application
 
   /**
    * Handle form submission.
-   * @this {Application}
+   * @this {ApplicationEd}
    * @param {Event} event                  The submit event.
    * @param {HTMLFormElement} form         The form element.
    * @param {FormDataExtended} formData     The form data.
    * @param {object} submitOptions         The submit options.
    */
   static #onFormSubmission( event, form, formData, submitOptions ) {
-    this.#config = this.processSubmitData( event, form, formData, submitOptions );
+    this.#config = this._processSubmitData( event, form, formData, submitOptions );
   }
 
   /**

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -1,0 +1,15 @@
+/**
+ * @augments DialogV2
+ */
+export default class Dialog extends foundry.applications.api.DialogV2 {
+
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    classes:  [ "ed4e" ],
+    position: {
+      width:  400,
+      height: "auto",
+    },
+  };
+
+}

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -1,7 +1,7 @@
 /**
  * @augments DialogV2
  */
-export default class Dialog extends foundry.applications.api.DialogV2 {
+export default class DialogEd extends foundry.applications.api.DialogV2 {
 
   /** @inheritdoc */
   static DEFAULT_OPTIONS = {

--- a/module/applications/api/document-sheet-mixin.mjs
+++ b/module/applications/api/document-sheet-mixin.mjs
@@ -1,3 +1,8 @@
+import { getSetting } from "../../settings.mjs";
+
+const { TextEditor } = foundry.applications.ux;
+
+
 /**
  * Sheet class mixin to add common functionality shared by all types of document sheets.
  * @param {*} Base              The base class.
@@ -19,7 +24,7 @@ const DocumentSheetMixinEd = Base => {
 
     /** @inheritdoc */
     static DEFAULT_OPTIONS = {
-      classes: [ "ed4e" ],
+      classes: [ "ed4e", "sheet", ],
       form:    {
         submitOnChange: true,
       },
@@ -32,7 +37,13 @@ const DocumentSheetMixinEd = Base => {
         positioned:     true,
         resizable:      true,
       },
-      actions: {},
+      actions: {
+        createChild:  DocumentSheetEd._onCreateChild,
+        deleteChild:  DocumentSheetEd._onDeleteChild,
+        displayChild: DocumentSheetEd._onDisplayChild,
+        editChild:    DocumentSheetEd._onEditChild,
+        editImage:    DocumentSheetEd._onEditImage,
+      },
     };
 
     // region Properties
@@ -48,6 +59,7 @@ const DocumentSheetMixinEd = Base => {
      * @type {boolean}
      */
     get isPlayMode() {
+      // noinspection JSPotentiallyInvalidUsageOfThis
       return this._sheetMode === this.constructor.SHEET_MODES.PLAY;
     }
 
@@ -56,6 +68,7 @@ const DocumentSheetMixinEd = Base => {
      * @type {boolean}
      */
     get isEditMode() {
+      // noinspection JSPotentiallyInvalidUsageOfThis
       return this._sheetMode === this.constructor.SHEET_MODES.EDIT;
     }
 
@@ -66,6 +79,133 @@ const DocumentSheetMixinEd = Base => {
     _expandedItems = new Set();
 
     // endregion
+
+    // region Rendering
+
+    /** @inheritdoc */
+    async _prepareContext( options ) {
+      const context = await super._prepareContext( options );
+      foundry.utils.mergeObject( context, {
+        config:       CONFIG.ED4E,
+        isGM:         game.user.isGM,
+        options:      this.options,
+        system:       this.document.system,
+        systemFields: this.document.system.schema.fields,
+      } );
+
+      context.enrichedDescription = await TextEditor.enrichHTML(
+        this.document.system.description.value,
+        {
+          // only show secret blocks to owner
+          secrets:    this.document.isOwner,
+          EdRollData: this.document.getRollData
+        }
+      );
+
+      return context;
+    }
+
+    // endregion
+
+    // region Event Handlers
+
+    /**
+     * Creates a new embedded document of the specified type.
+     * @param {Event} event - The event that triggered the form submission.
+     * @param {HTMLElement} target - The HTML element that triggered the action.
+     * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is created.
+     * @throws {Error} - If the document type is unknown.
+     * @userFunction UF_DocumentSheetMixinEd-onCreateChild
+     */
+    static async _onCreateChild( event, target ) {
+      const type = target.dataset.type;
+
+      switch ( type ) {
+        case "effect": {
+          return ActiveEffect.implementation.create( {
+            type:     "eae",
+            name:     game.i18n.localize( "ED.ActiveEffect.newEffectName" ),
+            icon:     "icons/svg/aura.svg",
+            changes:  [ {} ],
+            system:  {
+              duration: {
+                type: target.dataset.effectPermanent ? "permanent" : "combat",
+              },
+              changes: [ {} ],
+            },
+          }, {
+            parent:      this.document,
+            renderSheet: true,
+          } );
+        }
+        default: {
+          throw new Error( `Unknown document type: ${type}` );
+        }
+      }
+
+    }
+
+    /**
+     * Deletes a child document.
+     * @param {Event} event - The event that triggered the form submission.
+     * @param {HTMLElement} target - The HTML element that triggered the action.
+     * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is deleted.
+     * @userFunction UF_DocumentSheetMixinEd-onDeleteChild
+     */
+    static async _onDeleteChild( event, target ) {
+      const document = await fromUuid( target.dataset.uuid );
+      if ( getSetting( "quickDeleteEmbeddedOnShiftClick" ) && event.shiftKey ) return document.delete();
+      else document.deleteDialog();
+    }
+
+    /**
+     * Displays a child document in the chat
+     * @param {Event} event - The event that triggered the form submission.
+     * @param {HTMLElement} target - The HTML element that triggered the action.
+     * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is displayed in chat.
+     * @userFunction UF_DocumentSheetMixinEd-onDisplayChild
+     */
+    static async _onDisplayChild( event, target ) {
+      return ChatMessage.create( { content: "Coming up: a beautiful description of the Item you just clicked to be displayed here in chat!" } );
+    }
+
+    /**
+     * Open a child document's sheet in edit mode.
+     * @param {Event} event - The event that triggered the form submission.
+     * @param {HTMLElement} target - The HTML element that triggered the action.
+     * @returns {Promise<foundry.abstract.Document>} - A promise that resolves when the child is displayed in chat.
+     * @userFunction UF_DocumentSheetMixinEd-onEditChild
+     */
+    static async _onEditChild( event, target ) {
+      ( await fromUuid( target.dataset.uuid ) ).sheet?.render( { force: true } );
+    }
+
+    /**
+     * Change the document's image.
+     * @param {Event} event - The event that triggered the form submission.
+     * @param {HTMLElement} target - The HTML element that triggered the action.
+     * @returns {Promise<FilePicker>} - A promise that resolves when the image is changed.
+     * @userFunction UF_DocumentSheetMixinEd-onEditImage
+     */
+    static async _onEditImage( event, target ) {
+      const attr = target.dataset.edit;
+      const current = foundry.utils.getProperty( this.document, attr );
+      const { img } = this.document.constructor.getDefaultArtwork?.( this.document.toObject() ) ?? {};
+      const fp = new foundry.applications.apps.FilePicker( {
+        current,
+        type:           "image",
+        redirectToRoot: img ? [ img ] : [],
+        callback:       ( path ) => {
+          this.document.update( { [attr]: path } );
+        },
+        top:  this.position.top + 40,
+        left: this.position.left + 10,
+      } );
+      return fp.browse();
+    }
+
+    // endregion
+
   };
 
 };

--- a/module/applications/api/document-sheet-mixin.mjs
+++ b/module/applications/api/document-sheet-mixin.mjs
@@ -1,0 +1,73 @@
+/**
+ * Sheet class mixin to add common functionality shared by all types of document sheets.
+ * @param {*} Base              The base class.
+ * @returns {DocumentSheetEd}   Extended class.
+ * @mixin
+ */
+const DocumentSheetMixinEd = Base => {
+  const mixin = foundry.applications.api.HandlebarsApplicationMixin;
+  return class DocumentSheetEd extends mixin( Base ) {
+
+    /**
+     * Different sheet modes.
+     * @enum {number}
+     */
+    static SHEET_MODES = {
+      EDIT: 0,
+      PLAY: 1,
+    };
+
+    /** @inheritdoc */
+    static DEFAULT_OPTIONS = {
+      classes: [ "ed4e" ],
+      form:    {
+        submitOnChange: true,
+      },
+      tag:    "form",
+      window: {
+        contentClasses: [ "standard-form" ],
+        frame:          true,
+        icon:           false,
+        minimizable:    true,
+        positioned:     true,
+        resizable:      true,
+      },
+      actions: {},
+    };
+
+    // region Properties
+
+    /**
+     * The current sheet mode.
+     * @type {number}
+     */
+    _sheetMode = this.constructor.SHEET_MODES.PLAY;
+
+    /**
+     * Is the sheet currently in 'Play' mode?
+     * @type {boolean}
+     */
+    get isPlayMode() {
+      return this._sheetMode === this.constructor.SHEET_MODES.PLAY;
+    }
+
+    /**
+     * Is the sheet currently in 'Edit' mode?
+     * @type {boolean}
+     */
+    get isEditMode() {
+      return this._sheetMode === this.constructor.SHEET_MODES.EDIT;
+    }
+
+    /**
+     * A set of uuids of embedded documents whose descriptions have been expanded on this sheet.
+     * @type {Set<string>}
+     */
+    _expandedItems = new Set();
+
+    // endregion
+  };
+
+};
+
+export default DocumentSheetMixinEd;

--- a/module/applications/combat/start-round-combatant-prompt.mjs
+++ b/module/applications/combat/start-round-combatant-prompt.mjs
@@ -1,10 +1,7 @@
-const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
+import ApplicationEd from "../api/application.mjs";
 
-/**
- * @augments ApplicationV2
- * @mixes HandlebarsApplicationMixin
- */
-export default class StartRoundCombatantPrompt extends HandlebarsApplicationMixin( ApplicationV2 ) {
+
+export default class StartRoundCombatantPrompt extends ApplicationEd {
 
   /**
    * @inheritDoc
@@ -38,10 +35,8 @@ export default class StartRoundCombatantPrompt extends HandlebarsApplicationMixi
   static DEFAULT_OPTIONS = {
     id:       "start-round-combatant-prompt-{id}",
     uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
-    classes:  [ "earthdawn4e", "start-round-combatant-prompt" ],
-    tag:      "form",
+    classes:  [ "start-round-combatant-prompt", ],
     window:   {
-      frame:          true,
       positioned:     true,
       icon:           "",
       minimizable:    false,
@@ -52,9 +47,8 @@ export default class StartRoundCombatantPrompt extends HandlebarsApplicationMixi
       toggleCombatOption: StartRoundCombatantPrompt._toggleCombatOptionCheckbox,
     },
     form:    {
-      handler:        StartRoundCombatantPrompt._onFormSubmission,
+      handler:        StartRoundCombatantPrompt.#onFormSubmission,
       submitOnChange: true,
-      closeOnSubmit:  false,
     },
     position: {
       width:  "auto",
@@ -85,7 +79,7 @@ export default class StartRoundCombatantPrompt extends HandlebarsApplicationMixi
 
   // region Form Handling
 
-  static async _onFormSubmission( event, form, formData ) {
+  static async #onFormSubmission( event, form, formData ) {
     const data = foundry.utils.expandObject( formData.object );
 
     // update combatant initiative abilities and show prompt option

--- a/module/applications/configs/base-config-sheet.mjs
+++ b/module/applications/configs/base-config-sheet.mjs
@@ -1,22 +1,20 @@
 import ED4E from "../../config/_module.mjs";
+import DocumentSheetMixinEd from "../api/document-sheet-mixin.mjs";
 
-const { DocumentSheetV2, HandlebarsApplicationMixin } = foundry.applications.api;
+const { DocumentSheetV2, } = foundry.applications.api;
 
 /**
  * Base document sheet on which all document configuration sheets should be based.
  */
-export default class BaseConfigSheet extends HandlebarsApplicationMixin( DocumentSheetV2 ) {
+export default class BaseConfigSheet extends DocumentSheetMixinEd( DocumentSheetV2 ) {
 
   /** 
    * @inheritDoc 
    * @userFunction UF_BaseConfigSheet-defaultOptions
    */
   static DEFAULT_OPTIONS = {
-    classes:     [ "config-sheet" ],
+    classes:     [ "config-sheet", ],
     sheetConfig: false,
-    form:        {
-      submitOnChange: true
-    }
   };
 
   /** 

--- a/module/applications/global/document-creation.mjs
+++ b/module/applications/global/document-creation.mjs
@@ -1,9 +1,10 @@
 import PcData from "../../data/actor/pc.mjs";
+import DialogEd from "../api/dialog.mjs";
 
 const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 /**
- * Derivate of Foundry's Item.createDialog() functionality.
+ * Taken from Foundry's Item.createDialog() functionality.
  */
 export default class DocumentCreateDialog extends HandlebarsApplicationMixin( ApplicationV2 ) {
 
@@ -233,7 +234,7 @@ export default class DocumentCreateDialog extends HandlebarsApplicationMixin( Ap
   }
 
   static async _showCharGenPrompt() {
-    return foundry.applications.api.DialogV2.confirm( {
+    return DialogEd.confirm( {
       content:     "X-Do you want to use the character generation?",
       rejectClose: false,
       modal:       true

--- a/module/applications/global/document-creation.mjs
+++ b/module/applications/global/document-creation.mjs
@@ -1,12 +1,12 @@
 import PcData from "../../data/actor/pc.mjs";
 import DialogEd from "../api/dialog.mjs";
+import ApplicationEd from "../api/application.mjs";
 
-const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
 /**
  * Taken from Foundry's Item.createDialog() functionality.
  */
-export default class DocumentCreateDialog extends HandlebarsApplicationMixin( ApplicationV2 ) {
+export default class DocumentCreateDialog extends ApplicationEd {
 
   /** @inheritDoc */
   constructor( data = {}, { resolve, documentCls, pack = null, parent = null, options = {}, } = {} ) {
@@ -40,11 +40,10 @@ export default class DocumentCreateDialog extends HandlebarsApplicationMixin( Ap
   }
 
   static DEFAULT_OPTIONS = {
-    id:             "document-create-dialog",
-    classes:        [ "earthdawn4e", "create-document" ],
-    tag:            "form",
-    window:  {
-      frame:          true,
+    id:             "document-create-dialog-{id}",
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
+    classes:        [ "create-document", ],
+    window:   {
       resizable:      true,
       height:         900,
       width:          800,
@@ -53,7 +52,6 @@ export default class DocumentCreateDialog extends HandlebarsApplicationMixin( Ap
       handler:        this.#onFormSubmission,
       submitOnChange: true,
       submitOnClose:  false,
-      closeOnSubmit:  false,
     },
     position: {
       width: 1000,

--- a/module/applications/global/document-creation.mjs
+++ b/module/applications/global/document-creation.mjs
@@ -110,7 +110,7 @@ export default class DocumentCreateDialog extends ApplicationEd {
 
     const types = CONFIG.ED4E.typeGroups[this.documentType];
     const typesRadio = Object.fromEntries(
-      Object.entries( types ).map( ( [ k, v ], i ) => {
+      Object.entries( types ).map( ( [ k, v ], _ ) => {
         return [ k, v.reduce( ( a, v ) => ( { ...a, [v]: v } ), {} ) ];
       } ),
     );

--- a/module/applications/global/prompt-factory.mjs
+++ b/module/applications/global/prompt-factory.mjs
@@ -3,8 +3,10 @@ import ActorEd from "../../documents/actor.mjs";
 import ItemEd from "../../documents/item.mjs";
 import LearnableTemplate from "../../data/item/templates/learnable.mjs";
 import ED4E from "../../config/_module.mjs";
+import DialogEd from "../api/dialog.mjs";
 
-const DialogClass = foundry.applications.api.DialogV2;
+
+const DialogClass = DialogEd;
 const fields = foundry.data.fields;
 
 /**

--- a/module/applications/global/roll-prompt.mjs
+++ b/module/applications/global/roll-prompt.mjs
@@ -1,10 +1,10 @@
 import EdRoll from "../../dice/ed-roll.mjs";
 import EdRollOptions from "../../data/roll/common.mjs";
 import ED4E from "../../config/_module.mjs";
+import ApplicationEd from "../api/application.mjs";
 
-const { ApplicationV2, HandlebarsApplicationMixin } = foundry.applications.api;
 
-export default class RollPrompt extends HandlebarsApplicationMixin( ApplicationV2 ) {
+export default class RollPrompt extends ApplicationEd {
 
   constructor( edRollOptions = {}, { resolve, rollData = {}, options = {} } = {} ) {
     if ( !( edRollOptions instanceof EdRollOptions ) ) {
@@ -54,14 +54,12 @@ export default class RollPrompt extends HandlebarsApplicationMixin( ApplicationV
   static DEFAULT_OPTIONS = {
     id:       "roll-prompt-{id}",
     uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
-    classes:  [ "earthdawn4e", "roll-prompt" ],
-    tag:      "form",
+    classes:  [ "roll-prompt", ],
     position: {
       width:  "auto",
       height: "auto",
     },
     window:   {
-      frame: true,
       title: "ED.Dialogs.Title.rollPrompt",
       icon:  `fa-regular ${ED4E.icons.dice}`,
     },
@@ -71,7 +69,6 @@ export default class RollPrompt extends HandlebarsApplicationMixin( ApplicationV
     form:    {
       handler:        RollPrompt.#onFormSubmission,
       submitOnChange: true,
-      closeOnSubmit:  false,
     },
   };
 

--- a/module/applications/global/roll-prompt.mjs
+++ b/module/applications/global/roll-prompt.mjs
@@ -198,7 +198,7 @@ export default class RollPrompt extends ApplicationEd {
     return this.render( true );
   }
 
-  static async _roll( event, target ) {
+  static async _roll( event, _ ) {
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -9,6 +9,7 @@ const { ItemSheetV2 } = foundry.applications.sheets;
 /**
  * Extend the basic ActorSheet with modifications
  * @augments {ItemSheetV2}
+ * @mixes DocumentSheetMixinEd
  */
 export default class ItemSheetEd extends DocumentSheetMixinEd( ItemSheetV2 ) {
 

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -1,8 +1,8 @@
 import ED4E from "../../config/_module.mjs";
 import SpellEnhancementsConfig from "../configs/spell-enhancements-config.mjs";
 import ConstraintsConfig from "../configs/constraints-config.mjs";
+import DocumentSheetMixinEd from "../api/document-sheet-mixin.mjs";
 
-const { HandlebarsApplicationMixin } = foundry.applications.api;
 const { ItemSheetV2 } = foundry.applications.sheets;
 
 // noinspection JSClosureCompilerSyntax
@@ -10,7 +10,7 @@ const { ItemSheetV2 } = foundry.applications.sheets;
  * Extend the basic ActorSheet with modifications
  * @augments {ItemSheetV2}
  */
-export default class ItemSheetEd extends HandlebarsApplicationMixin( ItemSheetV2 ) {
+export default class ItemSheetEd extends DocumentSheetMixinEd( ItemSheetV2 ) {
 
   // region Static Properties
   static DEFAULT_OPTIONS = {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -1,9 +1,9 @@
-import ED4E from "../../config/_module.mjs";
 import SpellEnhancementsConfig from "../configs/spell-enhancements-config.mjs";
 import ConstraintsConfig from "../configs/constraints-config.mjs";
 import DocumentSheetMixinEd from "../api/document-sheet-mixin.mjs";
 
 const { ItemSheetV2 } = foundry.applications.sheets;
+const { DragDrop, TextEditor } = foundry.applications.ux;
 
 // noinspection JSClosureCompilerSyntax
 /**
@@ -17,24 +17,9 @@ export default class ItemSheetEd extends DocumentSheetMixinEd( ItemSheetV2 ) {
   static DEFAULT_OPTIONS = {
     id:       "item-sheet-{id}",
     uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
-    classes:  [ "earthdawn4e", "sheet", "item" ],
-    window:   {
-      frame:          true,
-      positioned:     true,
-      icon:           false,
-      minimizable:    true,
-      resizable:      true,
-    },
-    form: {
-      submitOnChange: true,
-    },
+    classes:  [ "item", ],
     actions:  {
       config:             ItemSheetEd._onConfig,
-      editImage:          ItemSheetEd._onEditImage,
-      createChild:        ItemSheetEd._onCreateChild,
-      deleteChild:        ItemSheetEd._onDeleteChild,
-      displayChildToChat: ItemSheetEd._onDisplayChildToChat,
-      editChild:          ItemSheetEd._onEditChild,
     },
     position: {
       top:    50,
@@ -117,20 +102,7 @@ export default class ItemSheetEd extends DocumentSheetMixinEd( ItemSheetV2 ) {
       context,
       {
         item:                   this.document,
-        system:                 this.document.system,
         options:                this.options,
-        systemFields:           this.document.system.schema.fields,
-        isGM:                   game.user.isGM,
-        config:                 ED4E,
-      }
-    );
-
-    context.enrichedDescription = await TextEditor.enrichHTML(
-      this.document.system.description.value,
-      {
-        // Only show secret blocks to owner
-        secrets:    this.document.isOwner,
-        EdRollData: this.document.getRollData
       }
     );
 
@@ -187,83 +159,6 @@ export default class ItemSheetEd extends DocumentSheetMixinEd( ItemSheetV2 ) {
     app?.render( { force: true } );
   }
 
-  static async _onEditImage( event, target ) {
-    const attr = target.dataset.edit;
-    const current = foundry.utils.getProperty( this.document, attr );
-    const { img } = this.document.constructor.getDefaultArtwork?.( this.document.toObject() ) ?? {};
-    // eslint-disable-next-line no-undef
-    const fp = new FilePicker( {
-      current,
-      type:           "image",
-      redirectToRoot: img ? [ img ] : [],
-      callback:       ( path ) => {
-        this.document.update( { [attr]: path } );
-      },
-      top:  this.position.top + 40,
-      left: this.position.left + 10,
-    } );
-    return fp.browse();
-  }
-
-  /** @inheritDoc */
-  static async _onCreateChild( event, target ) {
-    const type = target.dataset.type;
-
-    if ( type === "effect" ) return ActiveEffect.implementation.create( {
-      type:     "eae",
-      name:     game.i18n.localize( "ED.ActiveEffect.newEffectName" ),
-      icon:     "icons/svg/aura.svg",
-      changes:  [ {} ],
-      duration: {
-        permanent: !!target.dataset.effectPermanent,
-      },
-      system:  {
-        changes: [ {} ],
-      },
-    }, {
-      parent:      this.document,
-      renderSheet: true,
-    } );
-
-    // this will make more sense when we have a common documentSheet mixin
-    /* if ( activeTab === "spells" ) return Item.implementation.create({
-      name: game.i18n.format("DOCUMENT.New", { type: game.i18n.format(CONFIG.Item.typeLabels.spell) }),
-      type: "spell",
-      img: Item.implementation.getDefaultArtwork({ type: "spell" })?.img ?? Item.implementation.DEFAULT_ICON
-    }, { parent: this.actor, renderSheet: true });
-
-    const features = ["feat", "race", "background", "class", "subclass"];
-    if ( this.actor.type === "npc" ) features.push("weapon");
-
-    let types = {
-      features,
-      inventory: ["weapon", "equipment", "consumable", "tool", "container", "loot"]
-    }[activeTab] ?? [];
-
-    types = types.filter(type => {
-      const model = CONFIG.Item.dataModels[type];
-      return !model.metadata?.singleton || !this.actor.itemTypes[type].length;
-    });
-
-    if ( types.length ) return Item.implementation.createDialog({}, {
-      parent: this.actor, pack: this.actor.pack, types
-    }); */
-  }
-
-  /** @inheritDoc */
-  static async _onDeleteChild( event, target ) {
-    ( await fromUuid( target.dataset.uuid ) ).delete();
-  }
-
-  /** @inheritDoc */
-  static async _onDisplayChildToChat( event, target ) {
-    ChatMessage.create( { content: "Coming up: a beautiful description of the Item you just clicked to be displayed here in chat!" } );
-  }
-
-  /** @inheritDoc */
-  static async _onEditChild( event, target ) {
-    ( await fromUuid( target.dataset.uuid ) ).sheet?.render( { force: true } );
-  }
   // endregion
 
   // region Drag and Drop
@@ -373,7 +268,7 @@ export default class ItemSheetEd extends DocumentSheetMixinEd( ItemSheetV2 ) {
    * @protected
    */
   async _onDropItem( event, item ) {
-    if ( !this.item.isOwner ) return;
+    // do nothing
   }
 
   /**

--- a/module/data/actor/pc.mjs
+++ b/module/data/actor/pc.mjs
@@ -6,7 +6,7 @@ import ActorEd from "../../documents/actor.mjs";
 import ED4E from "../../config/_module.mjs";
 import PromptFactory from "../../applications/global/prompt-factory.mjs";
 import { getSetting } from "../../settings.mjs";
-const { DialogV2 } = foundry.applications.api;
+import DialogEd from "../../applications/api/dialog.mjs";
 
 /**
  * System data definition for PCs.
@@ -286,7 +286,7 @@ export default class PcData extends NamegiverTemplate {
     `;
 
     let spendLp = useLp;
-    spendLp ??= await DialogV2.wait( {
+    spendLp ??= await DialogEd.wait( {
       id:          "attribute-increase-prompt",
       uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "ed4e", "attribute-increase-prompt" ],

--- a/module/data/item/devotion.mjs
+++ b/module/data/item/devotion.mjs
@@ -2,7 +2,7 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import ED4E from "../../config/_module.mjs";
 import { createContentLink } from "../../utils.mjs";
 import IncreasableAbilityTemplate from "./templates/increasable-ability.mjs";
-const { DialogV2 } = foundry.applications.api;
+import DialogEd from "../../applications/api/dialog.mjs";
 
 /**
  * Data model template with information on Devotion items.
@@ -148,7 +148,7 @@ export default class DevotionData extends IncreasableAbilityTemplate.mixin(
           ${createContentLink( questorItem.uuid, questorItem.name )}
         </p>
       `;
-    const increaseQuestor = await DialogV2.confirm( {
+    const increaseQuestor = await DialogEd.confirm( {
       rejectClose: false,
       content:     await TextEditor.enrichHTML( content ),
     } );

--- a/module/data/item/path.mjs
+++ b/module/data/item/path.mjs
@@ -3,7 +3,7 @@ import ItemDescriptionTemplate from "./templates/item-description.mjs";
 import DisciplineData from "./discipline.mjs";
 import ED4E from "../../config/_module.mjs";
 import { createContentLink, getSingleGlobalItemByEdid } from "../../utils.mjs";
-const { DialogV2 } = foundry.applications.api;
+import DialogEd from "../../applications/api/dialog.mjs";
 
 /**
  * Data model template with information on path items.
@@ -138,7 +138,7 @@ export default class PathData extends ClassTemplate.mixin(
       <p>${ pathTalentLink }</p>
       `;
 
-      const learn = await DialogV2.confirm( {
+      const learn = await DialogEd.confirm( {
         rejectClose: false,
         content:     await TextEditor.enrichHTML( content ),
       } );
@@ -156,7 +156,7 @@ export default class PathData extends ClassTemplate.mixin(
       <p>${ pathKnackLink }</p>
       `;
 
-      const learn = await DialogV2.confirm( {
+      const learn = await DialogEd.confirm( {
         rejectClose: false,
         content:     await TextEditor.enrichHTML( content ),
       } );
@@ -197,7 +197,7 @@ export default class PathData extends ClassTemplate.mixin(
             ${createContentLink( pathTalent.uuid, pathTalent.name )}
           </p>
         `;
-      const increasePathTalent = await DialogV2.confirm( {
+      const increasePathTalent = await DialogEd.confirm( {
         rejectClose: false,
         content:     await TextEditor.enrichHTML( content ),
       } );

--- a/module/data/item/questor.mjs
+++ b/module/data/item/questor.mjs
@@ -4,7 +4,7 @@ import { createContentLink, getSingleGlobalItemByEdid } from "../../utils.mjs";
 import ED4E from "../../config/_module.mjs";
 import PromptFactory from "../../applications/global/prompt-factory.mjs";
 import LpSpendingTransactionData from "../advancement/lp-spending-transaction.mjs";
-const { DialogV2 } = foundry.applications.api;
+import DialogEd from "../../applications/api/dialog.mjs";
 
 /**
  * Data model template with information on the questor path items.
@@ -127,7 +127,7 @@ export default class QuestorData extends ClassTemplate.mixin(
           ${createContentLink( questorDevotion.uuid, questorDevotion.name )}
         </p>
       `;
-    const increaseDevotion = await DialogV2.confirm( {
+    const increaseDevotion = await DialogEd.confirm( {
       rejectClose: false,
       content:     await TextEditor.enrichHTML( content ),
     } );
@@ -168,7 +168,7 @@ export default class QuestorData extends ClassTemplate.mixin(
       <p>${ questorDevotionLink }</p>
       `;
 
-    const learn = await DialogV2.confirm( {
+    const learn = await DialogEd.confirm( {
       rejectClose: false,
       content:     await TextEditor.enrichHTML( content ),
     } );

--- a/system.json
+++ b/system.json
@@ -4,8 +4,8 @@
   "description": "A system for playing the 4th edition of Earthdawn in the Foundry Virtual Tabletop environment.",
   "version": "1.0.0",
   "compatibility": {
-    "minimum": "12",
-    "verified": "12"
+    "minimum": "13.340",
+    "verified": "13.340"
   },
   "url": "https://github.com/patrickmohrmann/earthdawn4eV2",
   "manifest": "this will be replaced",

--- a/templates/actor/cards/ability-card.hbs
+++ b/templates/actor/cards/ability-card.hbs
@@ -10,7 +10,7 @@
                 data-action="rollable" src="icons/svg/d20-black.svg">
             {{else}} 
             {{#if (ne this.system.strain 0)}}
-                <img class="ability-icon" src="{{img}}" data-edit="img" title="{{name}}" height="25" width="25" />
+                <img class="ability-icon" src="{{img}}"  data-edit="img" title="{{name}}" height="25" width="25" />
                 <img class="roll-icon__hover-fixed blood" src="icons/svg/blood.svg">
                 <img class="roll-icon__pointer take-strain" data-action="takeStrain" src="systems/ed4e/assets/icons/red-blood.svg" data-attribute="{{@key}}">
             {{else}}

--- a/templates/global/card-options-chat.hbs
+++ b/templates/global/card-options-chat.hbs
@@ -1,11 +1,11 @@
 <div class="itemControlGroup" data-item-id="{{_id}}">
-  <a class="item-control item-display" data-action="displayItem" title="{{localize "ED.Actor.Cards.chat"}}">
+  <a class="item-control item-display" data-action="displayChild" title="{{localize "ED.Actor.Cards.chat"}}">
     <i class="fas fa-comments"></i>
   </a>
-  <a class="item-control item-delete" data-action="deleteItem" title="{{localize "ED.Actor.Cards.delete"}}">
+  <a class="item-control item-delete" data-action="deleteChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.delete"}}">
     <i class="fas fa-trash"></i>
   </a>
-  <a class="item-control item-edit" data-action="editItem" title="{{localize "ED.Actor.Cards.edit"}}">
+  <a class="item-control item-edit" data-action="editChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.edit"}}">
     <i class="fas fa-edit"></i>
   </a>
 </div>

--- a/templates/global/card-options-class-upgrade.hbs
+++ b/templates/global/card-options-class-upgrade.hbs
@@ -2,16 +2,16 @@
   <a class="item-control item-upgrade__class" data-action="upgradeItem" title="{{localize 'earthdawn.u.upgrade'}}">
     <i class="fas fa-arrow-circle-up"></i>
   </a>
-  {{!-- <a class="item-control item-downgrade" data-action="displayItem" title="{{localize 'earthdawn.d.downgrade'}}">
+  {{!-- <a class="item-control item-downgrade" data-action="displayChild" title="{{localize 'earthdawn.d.downgrade'}}">
     <i class="fas fa-arrow-circle-down"></i>
   </a> --}}
-  <a class="item-control item-display" data-action="displayItem" title="Display Item">
+  <a class="item-control item-display" data-action="displayChild" title="Display Item">
     <i class="fas fa-comments"></i>
   </a>
-  <a class="item-control item-delete" data-action="deleteItem" title="Delete Item">
+  <a class="item-control item-delete" data-action="deleteChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.delete"}}">
     <i class="fas fa-trash"></i>
   </a>
-  <a class="item-control item-edit" data-action="editItem" title="Edit Item">
+  <a class="item-control item-edit" data-action="editChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.edit"}}">
     <i class="fas fa-edit"></i>
   </a>
 </div>

--- a/templates/global/card-options-effect.hbs
+++ b/templates/global/card-options-effect.hbs
@@ -1,5 +1,5 @@
 <div class="itemControlGroup" data-item-id="{{_id}}">
-  <a class="item-control item-display" data-action="displayChildToChat" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.chat"}}">
+  <a class="item-control item-display" data-action="displayChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.chat"}}">
     <i class="fas fa-comments"></i>
   </a>
   <a class="item-control effect-delete" data-action="deleteChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.delete"}}">

--- a/templates/global/card-options-enhance.hbs
+++ b/templates/global/card-options-enhance.hbs
@@ -5,13 +5,13 @@
   {{!-- <a class="item-control item-downgrade" title="{{localize 'earthdawn.d.downgrade'}}">
     <i class="fas fa-arrow-circle-down"></i>
   </a> --}}
-  <a class="item-control item-display" data-action="displayItem" title="Display Item">
+  <a class="item-control item-display" data-action="displayChild" title="Display Item">
     <i class="fas fa-comments"></i>
   </a>
-  <a class="item-control item-delete" data-action="deleteItem" title="Delete Item">
+  <a class="item-control item-delete" data-action="deleteChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.delete"}}">
     <i class="fas fa-trash"></i>
   </a>
-  <a class="item-control item-edit" data-action="editItem" title="Edit Item">
+  <a class="item-control item-edit" data-action="editChild" data-uuid="{{uuid}}" title="{{localize "ED.Actor.Cards.edit"}}">
     <i class="fas fa-edit"></i>
   </a>
 </div>

--- a/templates/item/item-partials/item-section-top.hbs
+++ b/templates/item/item-partials/item-section-top.hbs
@@ -1,6 +1,6 @@
 <div>
     <div class="partial__two">
-        <img src="{{item.img}}" data-edit="img" />
+        <img class="item-image" src="{{item.img}}" title="{{item.name}}" data-action="editImage" data-edit="img" />
     </div>
 
 


### PR DESCRIPTION
Closes #1636

Create common super classes and mixins for common `Application`s.
For adjustments concerning all types of a Application edit the `DEFAULT_OPTIONS` of:
- `ApplicationEd` for generic apps like the roll prompt, or lp history
- `DocumentSheetEd` for Item and Actor sheets (can be extended to other documents like Journals, etc.)
- `DialogEd` for dialogs like increase prompts, and those from the prompt factory

All applications should now have the common css class `"ed4e"`

