### PR TITLE
Move ability magic details into roll type

### DIFF
--- a/module/applications/actor/character-generation-prompt.mjs
+++ b/module/applications/actor/character-generation-prompt.mjs
@@ -7,7 +7,7 @@ import ApplicationEd from "../api/application.mjs";
 
 export default class CharacterGenerationPrompt extends ApplicationEd {
 
-  magicType;
+  castingType;
 
   // #region CONSTRUCTOR
   /**
@@ -293,7 +293,7 @@ export default class CharacterGenerationPrompt extends ApplicationEd {
     // Spells
     context.availableSpellPoints = await this.charGenData.getAvailableSpellPoints();
     context.maxSpellPoints = await this.charGenData.getMaxSpellPoints();
-    context.spells = this.spells.filter( spell => spell.system.spellcastingType === this.magicType );
+    context.spells = this.spells.filter( spell => spell.system.spellcastingType === this.castingType );
     context.spellsBifurcated = context.spells.map(
       spell => this.charGenData.spells.has( spell.uuid ) ? [ null, spell ] : [ spell, null ]
     );
@@ -490,7 +490,7 @@ export default class CharacterGenerationPrompt extends ApplicationEd {
     this.charGenData.updateSource( data );
 
     // wait for the update, so we can use the data models method
-    this.magicType = await this.charGenData.getMagicType();
+    this.castingType = await this.charGenData.getCastingType();
 
     // Re-render sheet with updated values
     this.render( true );

--- a/module/applications/advancement/class-advancement.mjs
+++ b/module/applications/advancement/class-advancement.mjs
@@ -240,8 +240,8 @@ export default class ClassAdvancementDialog extends ApplicationEd {
       "spell",
       true,
       "OBSERVER",
-      [ "system.magicType" ],
-      _ => true // x.system.magicType === this.classItem
+      [ "system.spellcastingType" ],
+      spell => spell.system?.spellcastingType === this.classItem.system.getCastingType()
     ) ).filter(
       spell => !this.actor.itemTypes.spell.map( s => s.uuid ).includes( spell )
     ) : [];

--- a/module/data/actor/templates/namegiver.mjs
+++ b/module/data/actor/templates/namegiver.mjs
@@ -55,12 +55,13 @@ export default class NamegiverTemplate extends SentientTemplate {
 
   /**
    * Gets the type of magic of the first thread weaving talent encountered.
-   * @type {string} The type of thread weaving magic as defined in {@link ED4E.spellcastingTypes},
-   * or an empty string if there is no corresponding talent.
+   * @type {string}
+   * @see ED4E.spellcastingTypes
    */
-  get magicType() {
-    const threadWeavingTalents = this.parent.items.filter( item => item.system?.magic?.threadWeaving );
-    return threadWeavingTalents[0]?.system.magic.magicType ?? "";
+  get castingType() {
+    return this.parent.items.find(
+      item => item.system?.rollType === "threadWeaving"
+    ).system.castingType;
   }
 
   /* -------------------------------------------- */

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -38,7 +38,7 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
           new fields.DocumentUUIDField( {
             required:        true,
             nullable:        false,
-            validate:        ( value, options ) => {
+            validate:        ( value, _ ) => {
               if ( !fromUuidSync( value, {strict: false} )?.system?.hasMixin( KnackTemplate ) ) return false;
               return undefined; // undefined means do further validation
             },
@@ -58,7 +58,7 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
           new fields.DocumentUUIDField( {
             required:        true,
             nullable:        false,
-            validate:        ( value, options ) => {
+            validate:        ( value, _ ) => {
               if ( !fromUuidSync( value, {strict: false} )?.system?.hasMixin( KnackTemplate ) ) return false;
               return undefined; // undefined means do further validation
             },
@@ -235,7 +235,7 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
   static async learn( actor, item, createData = {} ) {
     const learnedItem = await super.learn( actor, item, createData );
 
-    let category = null;
+    let category;
 
     // assign the talent category
     const promptFactoryItem = PromptFactory.fromDocument( learnedItem );

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -33,36 +33,6 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
         hint:     this.hintKey( "Ability.talentCategory" )
       } ),
       matrix: MatrixData.asEmbeddedDataField(),
-      magic:  new fields.SchemaField( {
-        threadWeaving: new fields.BooleanField( {
-          required: true,
-          nullable: false,
-          initial:  false,
-          label:    this.labelKey( "Ability.Magic.threadWeaving" ),
-          hint:     this.hintKey( "Ability.Magic.threadWeaving" )
-        } ),
-        spellcasting: new fields.BooleanField( {
-          required: true,
-          nullable: false,
-          initial:  false,
-          label:    this.labelKey( "Ability.Magic.spellcasting" ),
-          hint:     this.hintKey( "Ability.Magic.spellcasting" )
-        } ),
-        magicType: new fields.StringField( {
-          required: true,
-          nullable: true,
-          blank:    true,
-          trim:     true,
-          choices:  ED4E.spellcastingTypes,
-          label:    this.labelKey( "Ability.Magic.magicType" ),
-          hint:     this.hintKey( "Ability.Magic.magicType" )
-        } ),
-      }, {
-        required: true,
-        nullable: false,
-        label:    this.labelKey( "Ability.Magic.magic" ),
-        hint:     this.hintKey( "Ability.Magic.magic" )
-      } ),
       knacks: new fields.SchemaField( {
         available: new fields.SetField(
           new fields.DocumentUUIDField( {

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -122,8 +122,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
             blank:    false,
             trim:     true,
             choices:  ED4E.spellcastingTypes,
-            label:    this.labelKey( "Ability.Magic.magicType" ),
-            hint:     this.hintKey( "Ability.Magic.magicType" )
           } ),
         }, {} ),
       }, {

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -93,7 +93,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
             hint:     this.hintKey( "Ability.RollTypeDetails.Attack.weaponType" )
           } ),
         }, {
-          required: false,
           label:    this.labelKey( "Ability.RollTypeDetails.attack" ),
           hint:     this.hintKey( "Ability.RollTypeDetails.attack" )
         } ),
@@ -111,15 +110,23 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
             hint:     this.hintKey( "Ability.RollTypeDetails.Reaction.defenseType" )
           } ),
         }, {
-          required: false,
           label:    this.labelKey( "Ability.RollTypeDetails.reaction" ),
           hint:     this.hintKey( "Ability.RollTypeDetails.reaction" ),
         } ),
         recovery:      new fields.SchemaField( {}, {} ),
         spellcasting:  new fields.SchemaField( {}, {} ),
-        threadWeaving: new fields.SchemaField( {}, {} ),
+        threadWeaving: new fields.SchemaField( {
+          castingType: new fields.StringField( {
+            required: false,
+            nullable: true,
+            blank:    false,
+            trim:     true,
+            choices:  ED4E.spellcastingTypes,
+            label:    this.labelKey( "Ability.Magic.magicType" ),
+            hint:     this.hintKey( "Ability.Magic.magicType" )
+          } ),
+        }, {} ),
       }, {
-        required: false,
         label:    this.labelKey( "Ability.rollTypeDetails" ),
         hint:     this.hintKey( "Ability.rollTypeDetails" )
       } ),
@@ -159,6 +166,16 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     };
 
     return new AbilityRollOptions( abilityRollOptions );
+  }
+
+  /**
+   * The type of spellcasting magic of this ability, if it is of type thread weaving.
+   * Null if thread weaving of a non spellcasting discipline.
+   * @type {string|null|undefined}
+   * @see ED4E.spellcastingTypes
+   */
+  get castingType() {
+    return this.rollType === "threadWeaving" ? this.rollTypeDetails.threadWeaving.castingType : undefined;
   }
 
   /**
@@ -240,6 +257,7 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
     );
     return this.containingActor.processRoll( roll );
   }
+
   async rollAttack() {
     if ( !this.isActorEmbedded ) return;
 

--- a/module/data/item/templates/class.mjs
+++ b/module/data/item/templates/class.mjs
@@ -103,6 +103,26 @@ export default class ClassTemplate extends ItemDataModel.mixin(
 
   /* -------------------------------------------- */
 
+  getAllAbilityUuids() {
+    return this.advancement.levels
+      .flatMap( level => Array.from( level.abilities.class ) )
+      .concat( this.advancement.levels.flatMap( level => Array.from( level.abilities.free ) ) )
+      .concat( this.advancement.levels.flatMap( level => Array.from( level.abilities.special ) ) )
+      .concat( Object.values( this.advancement.abilityOptions ).flatMap( pool => Array.from( pool ) ) );
+  }
+
+  /**
+   * Get the casting type of the class, if it has a thread weaving ability for spellcasting.
+   * @returns {typeof AbilityTemplate.castingType} The casting type of the class, see {@link AbilityTemplate.castingType}.
+   */
+  getCastingType() {
+    return this
+      .getAllAbilityUuids()
+      .map( uuid => fromUuidSync( uuid ) )
+      .find( ability => ability?.system?.castingType )
+      ?.system?.castingType;
+  }
+
   /** @inheritDoc */
   // eslint-disable-next-line complexity
   async increase() {

--- a/module/data/other/character-generation.mjs
+++ b/module/data/other/character-generation.mjs
@@ -386,11 +386,11 @@ export default class CharacterGenerationData extends SparseDataModel {
     return ( await this.getMaxSpellPoints() ) - sum( currentSpellLevels );
   }
 
-  async getMagicType() {
+  async getCastingType() {
     for ( const abilityUuid of Object.keys( this.abilities.class ) ) {
       let ability = await fromUuid( abilityUuid );
 
-      if ( ability?.system.magic?.threadWeaving ) return ability.system.magic.magicType;
+      if ( ability?.system.rollType === "threadWeaving" ) return ability.system.castingType;
     }
     return undefined;
   }

--- a/module/packs/tour-items/talent_Artefaktgeschichte_dhini7gGvVSPwLY3.json
+++ b/module/packs/tour-items/talent_Artefaktgeschichte_dhini7gGvVSPwLY3.json
@@ -38,11 +38,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Beeindrucken_Hz3qxCcQtl8Ze4Nq.json
+++ b/module/packs/tour-items/talent_Beeindrucken_Hz3qxCcQtl8Ze4Nq.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Erster_Eindruck_aRLtHFmr1hfrpS4K.json
+++ b/module/packs/tour-items/talent_Erster_Eindruck_aRLtHFmr1hfrpS4K.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Fadenweben_h5hNZuAPIVlaVxBD.json
+++ b/module/packs/tour-items/talent_Fadenweben_h5hNZuAPIVlaVxBD.json
@@ -38,11 +38,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Feilschen_ARB2Ld2ZLlLGEgSX.json
+++ b/module/packs/tour-items/talent_Feilschen_ARB2Ld2ZLlLGEgSX.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Fremdsprachen_QdaMwao77qyLldxy.json
+++ b/module/packs/tour-items/talent_Fremdsprachen_QdaMwao77qyLldxy.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Gef_hlsmelodie_cfApFKn4MeOBuIss.json
+++ b/module/packs/tour-items/talent_Gef_hlsmelodie_cfApFKn4MeOBuIss.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Gewinnendes_L_cheln_7SODC2KaKrE1PGiW.json
+++ b/module/packs/tour-items/talent_Gewinnendes_L_cheln_7SODC2KaKrE1PGiW.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Herzliches_Lachen_giGnZQPW2Oy9Wa1l.json
+++ b/module/packs/tour-items/talent_Herzliches_Lachen_giGnZQPW2Oy9Wa1l.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Hieb_Ausweichen_Z2IhYwBjKfGTld6Q.json
+++ b/module/packs/tour-items/talent_Hieb_Ausweichen_Z2IhYwBjKfGTld6Q.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Konversation_XHzKVTNuVbC1UDfm.json
+++ b/module/packs/tour-items/talent_Konversation_XHzKVTNuVbC1UDfm.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Lesen_Schreiben_HLXG6scpImEg35b1.json
+++ b/module/packs/tour-items/talent_Lesen_Schreiben_HLXG6scpImEg35b1.json
@@ -38,11 +38,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Nahkampfwaffen_nXGNz0vAznkNPf9I.json
+++ b/module/packs/tour-items/talent_Nahkampfwaffen_nXGNz0vAznkNPf9I.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Unterhalten_h9wUXkZ9LTsd6EP4.json
+++ b/module/packs/tour-items/talent_Unterhalten_h9wUXkZ9LTsd6EP4.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Verspotten_10wJAcvY00T5yU7y.json
+++ b/module/packs/tour-items/talent_Verspotten_10wJAcvY00T5yU7y.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/module/packs/tour-items/talent_Wurfwaffen_RSu48Yl3Hq8umJyA.json
+++ b/module/packs/tour-items/talent_Wurfwaffen_RSu48Yl3Hq8umJyA.json
@@ -39,11 +39,6 @@
       "threadWeaving": {}
     },
     "talentCategory": null,
-    "magic": {
-      "threadWeaving": false,
-      "spellcasting": false,
-      "magicType": ""
-    },
     "knacks": {
       "available": [],
       "learned": []

--- a/templates/item/item-partials/item-details/details/item-details-talent.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-talent.hbs
@@ -11,15 +11,6 @@
   {{formField systemFields.source.fields.atLevel name="system.source.atLevel" value=item.system.source.atLevel localize=true}}
 </fieldset>
 
-{{! -- Magic Type -- }}
-<fieldset>
-  <legend>{{localize "ED.Item.Header.magic"}}</legend>
-
-  {{formField systemFields.magic.fields.spellcasting name="system.magic.spellcasting" value=item.system.magic.spellcasting localize=true}}
-  {{formField systemFields.magic.fields.threadWeaving name="system.magic.threadWeaving" value=item.system.magic.threadWeaving localize=true}}
-  {{formField systemFields.magic.fields.magicType name="system.magic.magicType" value=item.system.magic.magicType required=false localize=true}}
-</fieldset>
-
 {{! -- Knacks -- }}
 {{#if (or (ed-hasItems item.system.knacks.learned) (ed-hasItems item.system.knacks.available))}}
   <fieldset>


### PR DESCRIPTION
Since "thread weaving" and "spellcasting" roll types are now part of abilities, the information in the magic field can be moved there. The castingType is a roll type detail for "thread weaving". Naming is getting confusing, but that's just the nature of spellcasting (which is one talent) vs. thread weaving (multiple talents), but only casting disciplines are different.

This also includes getting a potential casting type from a class item. May be relevant to PR #1519