### PR TITLE
items-with-matrix-property-sheets

### DIFF
--- a/module/data/abstract.mjs
+++ b/module/data/abstract.mjs
@@ -1,4 +1,8 @@
 import { callIfExists } from "../utils.mjs";
+import { getSetting } from "../settings.mjs";
+
+
+const { TextEditor } = foundry.applications.ux;
 
 /**
  * Taken from DnD5e ( https://github.com/foundryvtt/dnd5e )
@@ -628,6 +632,23 @@ export class ItemDataModel extends SystemDataModel {
     ) ?? true;
   }
 
+  // region Life Cycle Events
+
+  /** @inheritdoc */
+  async _preCreate( data, options, user ) {
+    if ( await super._preCreate( data, options, user ) === false ) return false;
+
+    this.#prepareMatrixData( data );
+  }
+
+  /** @inheritdoc */
+  async _preUpdate( changes, options, user ) {
+    if ( await super._preUpdate( changes, options, user ) === false ) return false;
+
+    this.#prepareMatrixData( changes );
+  }
+
+  // endregion
 
   // region Rolling
 
@@ -721,6 +742,20 @@ export class ItemDataModel extends SystemDataModel {
    * @returns {Promise<void>}
    */
   async getSheetData( context ) {}
+
+  #prepareMatrixData( data ) {
+    const edidMatrix = getSetting( "edidSpellMatrix" );
+    // if this turns into an item with a matrix, set the default matrix data
+    if ( data.system?.edid === edidMatrix && this.edid !== edidMatrix ) {
+      data.system.matrix ??= { "matrixType": "standard" };
+    } else if (
+      this.edid === edidMatrix
+      && typeof data.system?.edid === "string"
+      && data.system?.edid !== edidMatrix
+    ) {
+      data.system.matrix = null;
+    }
+  }
 
 }
 

--- a/module/data/common/matrix.mjs
+++ b/module/data/common/matrix.mjs
@@ -26,7 +26,6 @@ export default class MatrixData extends SparseDataModel {
         initial:         1,
         integer:         true,
         positive:        true,
-        max:             10,
       } ),
       damage: new fields.NumberField( {
         required:        true,

--- a/module/data/common/matrix.mjs
+++ b/module/data/common/matrix.mjs
@@ -81,7 +81,8 @@ export default class MatrixData extends SparseDataModel {
     return new foundry.data.fields.EmbeddedDataField(
       this,
       {
-        required:        false,
+        nullable:        true,
+        initial:         null,
       }
     );
   }

--- a/module/data/common/matrix.mjs
+++ b/module/data/common/matrix.mjs
@@ -1,10 +1,10 @@
-import SystemDataModel from "../abstract.mjs";
+import { SparseDataModel } from "../abstract.mjs";
 import { ED4E } from "../../../earthdawn4e.mjs";
 
 
 const { fields } = foundry.data;
 
-export default class MatrixData extends SystemDataModel {
+export default class MatrixData extends SparseDataModel {
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [

--- a/module/settings.mjs
+++ b/module/settings.mjs
@@ -44,6 +44,7 @@ export function getEdIds() {
     "edidQuestorDevotion",
     "edidUnarmedCombat",
     "edidCreatureAttack",
+    "edidSpellMatrix",
   ].map( id => getSetting( id ) );
 }
 
@@ -163,6 +164,17 @@ export default function registerSystemSettings() {
     default: "creature-attack",
     type:    new EdIdField(),
   } );
+
+  // edid for items that house a spell matrix (talents or physical items)
+  game.settings.register( "ed4e", "edidSpellMatrix", {
+    name:    "ED.Settings.Edid.spellMatrix",
+    hint:    "ED.Settings.Edid.spellMatrixHint",
+    scope:   "world",
+    config:  true,
+    default: "matrix",
+    type:    new EdIdField(),
+  } );
+
 
   // region CONTROLS
 

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -124,6 +124,7 @@ export async function getSingleGlobalItemByEdid( edid, type ) {
  *                                        strings of the found documents. Empty
  *                                        if no documents are found.
  */
+// eslint-disable-next-line max-params
 export async function getAllDocuments(
   documentName,
   documentType,
@@ -232,7 +233,7 @@ export function prepareFormulaValue( model, keyPath, label, rollData ) {
  * If the attribute is not found in the provided data, display a warning on the actor.
  * @param {string} formula           The original formula within which to replace.
  * @param {object} data              The data object which provides replacements.
- * @param {object} [options]
+ * @param {object} [options]         Options for the replacement process.
  * @param {ActorEd} [options.actor]            Actor for which the value is being prepared.
  * @param {ItemEd} [options.item]              Item for which the value is being prepared.
  * @param {string|null} [options.missing]  Value to use when replacing missing references, or `null` to not replace.
@@ -738,6 +739,7 @@ export async function preloadHandlebarsTemplates() {
     "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs",
     "systems/ed4e/templates/item/item-partials/item-details/partials/roll-type.hbs",
     "systems/ed4e/templates/item/item-partials/item-details/partials/abilities.hbs",
+    "systems/ed4e/templates/item/item-partials/item-details/partials/matrix.hbs",
 
     // Item details
     "systems/ed4e/templates/item/item-partials/item-details/item-effects.hbs",

--- a/templates/item/item-partials/item-details/details/item-details-abilities.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-abilities.hbs
@@ -1,2 +1,6 @@
-{{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}
-{{> "systems/ed4e/templates/item/item-partials/item-details/partials/roll-type.hbs"}}
+{{#if system.matrix}}
+  {{> "systems/ed4e/templates/item/item-partials/item-details/partials/matrix.hbs"}}
+{{else}}
+  {{> "systems/ed4e/templates/item/item-partials/item-details/partials/targeting.hbs"}}
+  {{> "systems/ed4e/templates/item/item-partials/item-details/partials/roll-type.hbs"}}
+{{/if}}

--- a/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs
@@ -4,3 +4,7 @@
         {{!-- automatic Weight Calculation --}}
         {{> "systems/ed4e/templates/item/item-partials/item-details/partials/tailor-to-namegiver.hbs"}}
     {{/if}}
+
+    {{#if system.matrix}}
+      {{> "systems/ed4e/templates/item/item-partials/item-details/partials/matrix.hbs"}}
+    {{/if}}

--- a/templates/item/item-partials/item-details/partials/matrix.hbs
+++ b/templates/item/item-partials/item-details/partials/matrix.hbs
@@ -1,0 +1,28 @@
+<fieldset>
+  <legend>{{localize "ED.TODO.X.Matrix"}}</legend>
+  {{#each systemFields.matrix.fields}}
+    {{#unless (eq @key "threads")}}
+      {{formGroup
+        this
+        name=(concat "system.matrix." @key)
+        value=(lookup ../system.matrix @key)
+        localize=true
+        label=this.fieldPath
+      }}
+    {{/unless}}
+  {{/each}}
+  {{formGroup
+    systemFields.matrix.fields.threads.fields.hold.fields.value
+    name=(concat "system.matrix.threads.hold.value")
+    value=system.matrix.threads.hold.value
+    localize=true
+    label=systemFields.matrix.fields.threads.fields.hold.fields.value.fieldPath
+  }}
+  {{formGroup
+    systemFields.matrix.fields.threads.fields.woven
+    name=(concat "system.matrix.threads.woven")
+    value=system.matrix.threads.woven
+    localize=true
+    label=systemFields.matrix.fields.threads.fields.woven.fieldPath
+  }}
+</fieldset>


### PR DESCRIPTION
Add matrix fields to "physical item" and "talent" sheets.

To add a matrix to an item, set the edid of that item to "matrix" (or as defined in the settings).
Then the basic matrix data fields appear.

Making it nice comes later.