### PR TITLE
attuning-spell-matrix

### DIFF
--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -8,6 +8,7 @@ export * as global from "./global/_module.mjs";
 export * as hud from "./hud/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as journal from "./journal/_module.mjs";
+export * as workflow from "./workflow/_module.mjs";
 
 
 /**

--- a/module/applications/actor/common-sheet.mjs
+++ b/module/applications/actor/common-sheet.mjs
@@ -1,4 +1,5 @@
 import DocumentSheetMixinEd from "../api/document-sheet-mixin.mjs";
+import { ED4E } from "../../../earthdawn4e.mjs";
 
 const { ActorSheetV2 } = foundry.applications.sheets;
 
@@ -81,6 +82,7 @@ export default class ActorSheetEd extends DocumentSheetMixinEd( ActorSheetV2 ) {
     foundry.utils.mergeObject( context, {
       actor:                  this.document,
       items:                  this.document.items,
+      icons:                  ED4E.icons,
     } );
 
     return context;

--- a/module/applications/actor/sentient-sheet.mjs
+++ b/module/applications/actor/sentient-sheet.mjs
@@ -69,6 +69,7 @@ export default class ActorSheetEdSentient extends ActorSheetEd {
       case "spells":
         foundry.utils.mergeObject( context, {
           tabsSpells: this._getSpellTabs(),
+          matrices:   this.document.getMatrices(),
         } );
         break;
       case "equipment":

--- a/module/applications/actor/sentient-sheet.mjs
+++ b/module/applications/actor/sentient-sheet.mjs
@@ -142,12 +142,16 @@ export default class ActorSheetEdSentient extends ActorSheetEd {
    */
   static async _onAttuneMatrix( event, target ) {
     event.preventDefault();
-    // const li = target.closest( ".item-id" );
-    // const matrix = await fromUuid( li.dataset.uuid );
+    const matrices = this.document.getMatrices();
+    const spells = this.document.itemTypes.spell;
+
+    const li = target.closest( ".item-id" );
+    const firstMatrix = matrices.findSplice( matrix => matrix.uuid === li?.dataset?.uuid );
 
     const attuneData = await AttuneMatrixPrompt.waitPrompt( {
-      matrices: this.document.getMatrices(),
-      spells:   this.document.itemTypes.spell,
+      matrices,
+      spells,
+      firstMatrix,
     } );
 
     if ( !attuneData ) return;

--- a/module/applications/api/application.mjs
+++ b/module/applications/api/application.mjs
@@ -41,8 +41,9 @@ export default class ApplicationEd extends HandlebarsApplicationMixin( Applicati
     classes: [ "ed4e" ],
     tag:     "form",
     form:    {
-      handler:       ApplicationEd.#onFormSubmission,
-      closeOnSubmit: false,
+      handler:        ApplicationEd.#onFormSubmission,
+      submitOnChange: false,
+      closeOnSubmit:  false,
     },
     actions: {
       cancel:   ApplicationEd._cancel,

--- a/module/applications/api/application.mjs
+++ b/module/applications/api/application.mjs
@@ -87,9 +87,15 @@ export default class ApplicationEd extends HandlebarsApplicationMixin( Applicati
 
   // region Rendering
 
-  /**
-   * @inheritDoc
-   */
+  /** @inheritDoc */
+  async _prepareContext( options ) {
+    const context = await super._prepareContext( options );
+    context.data = this._data;
+
+    return context;
+  }
+
+  /** @inheritDoc */
   async _renderHTML( context, options ) {
     return super._renderHTML( context, options );
   }

--- a/module/applications/workflow/_module.mjs
+++ b/module/applications/workflow/_module.mjs
@@ -1,0 +1,1 @@
+export { default as AttuneMatrixPrompt } from "./attune-matrix-prompt.mjs";

--- a/module/applications/workflow/attune-matrix-prompt.mjs
+++ b/module/applications/workflow/attune-matrix-prompt.mjs
@@ -1,7 +1,75 @@
 import ApplicationEd from "../api/application.mjs";
+import { ED4E } from "../../../earthdawn4e.mjs";
 
 export default class AttuneMatrixPrompt extends ApplicationEd {
 
-  static DEFAULT_OPTIONS = {};
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    id:       "attune-matrix-prompt-{id}",
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
+    classes:  [ "attune-matrix-prompt", ],
+    window:   {
+      title: "ED.Dialogs.Title.attuneMatrix",
+    },
+  };
+
+  /** @inheritdoc */
+  static PARTS = {
+    main: {
+      template: "systems/ed4e/templates/workflow/attune-matrix.hbs",
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs",
+    },
+  };
+
+  /**
+   * The list of available matrices.
+   * @type {ItemEd[]}
+   */
+  #matrices;
+
+  /**
+   * The list of available spells.
+   * @type {ItemEd[]}
+   */
+  #spells;
+
+  constructor( { matrices = [], spells = [], options = {} } = {} ) {
+    super( options );
+    this.#matrices = matrices;
+    this.#spells = spells;
+  }
+
+  // region Rendering
+
+  /** @inheritdoc */
+  async _preparePartContext( partId, context, options ) {
+    const newContext = await super._preparePartContext( partId, context, options );
+
+    switch ( partId ) {
+      case "main": {
+        newContext.matrices = this.#matrices;
+        newContext.spells = this.#spells;
+        break;
+      }
+      case "footer": {
+        const buttonContinue = this.constructor.BUTTONS.continue;
+        buttonContinue.icon = ED4E.icons.attune;
+        buttonContinue.label = "ED.Dialogs.Buttons.attuneMatrix";
+        newContext.buttons = [
+          buttonContinue,
+        ];
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+
+    return newContext;
+  }
+
+  // endregion
 
 }

--- a/module/applications/workflow/attune-matrix-prompt.mjs
+++ b/module/applications/workflow/attune-matrix-prompt.mjs
@@ -82,12 +82,18 @@ export default class AttuneMatrixPrompt extends ApplicationEd {
         break;
       }
       case "footer": {
-        const buttonContinue = this.constructor.BUTTONS.continue;
-        buttonContinue.icon = ED4E.icons.attune;
-        buttonContinue.label = "ED.Dialogs.Buttons.attuneMatrix";
-        newContext.buttons = [
-          buttonContinue,
-        ];
+        if ( this.#matrices.length > 0 ) {
+          const buttonContinue = this.constructor.BUTTONS.continue;
+          buttonContinue.icon = ED4E.icons.attune;
+          buttonContinue.label = "ED.Dialogs.Buttons.attuneMatrix";
+          newContext.buttons = [
+            buttonContinue
+          ];
+        } else {
+          newContext.buttons = [
+            this.constructor.BUTTONS.cancel,
+          ];
+        }
         break;
       }
       default: {

--- a/module/applications/workflow/attune-matrix-prompt.mjs
+++ b/module/applications/workflow/attune-matrix-prompt.mjs
@@ -121,16 +121,18 @@ export default class AttuneMatrixPrompt extends ApplicationEd {
   }
 
   #getSpellChoicesConfig( matrix ) {
-    return this.#spells.map( spell => {
-      return {
+    return this.#spells.reduce( ( choices, spell ) => {
+      if ( spell.system.level > matrix.system.level ) return choices;
+      choices.push( {
         valueAttr: "value",
         value:     spell.uuid,
         label:     spell.name,
         group:     ED4E.spellcastingTypes[ spell.system.spellcastingType ],
         disabled:  matrix.system.isSpellAttuned( spell.uuid ),
         selected:  matrix.system.isSpellAttuned( spell.uuid ),
-      };
-    } );
+      } );
+      return choices;
+    }, [] );
   }
 
 }

--- a/module/applications/workflow/attune-matrix-prompt.mjs
+++ b/module/applications/workflow/attune-matrix-prompt.mjs
@@ -1,0 +1,7 @@
+import ApplicationEd from "../api/application.mjs";
+
+export default class AttuneMatrixPrompt extends ApplicationEd {
+
+  static DEFAULT_OPTIONS = {};
+
+}

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -63,6 +63,7 @@ export const icons = {
   nextCharGen:      "fa-thin fa-arrow-right",
   resetPoints:      "fa-arrows-rotate",
   undo:             "fa-arrow-rotate-left",
+  unknown:          "fa-question",
   Tabs:             {
   },
 };

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -42,6 +42,7 @@ export const icons = {
   ability:          "fa-bolt",
   attack:           "fa-crosshairs",
   attribute:        "fa-dice-d20",
+  attune:           "fa-thin fa-chart-network",
   cancel:           "fa-times",
   classAdvancement: "fa-arrow-trend-up",
   configure:        "fa-cogs",

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -88,16 +88,16 @@ export default class MatrixTemplate extends SystemDataModel {
    * Is this matrix broken and therefore cannot be used?
    * @type {boolean}
    */
-  get broken() {
-    return this.damage >= this.deathRating;
+  get matrixBroken() {
+    return this.matrix?.damage >= this.matrix?.deathRating;
   }
 
   /**
    * Can the matrix hold threads?
    * @type {boolean}
    */
-  get canHoldThread() {
-    return this.threads.maxHold > 0;
+  get matrixCanHoldThread() {
+    return this.matrix?.threads?.hold?.max > 0;
   }
 
   /**
@@ -112,20 +112,26 @@ export default class MatrixTemplate extends SystemDataModel {
    * The amount of damage that is prevented when attacked.
    * @type {number}
    */
-  get mysticArmor() {
+  get matrixMysticArmor() {
     let armorValue = this.containingActor?.system.characteristics.armor.mystical.value || 0;
-    if ( this.matrixType === "armored" ) armorValue += this.level;
+    if ( this.matrix?.matrixType === "armored" ) armorValue += this.matrix?.level;
     return armorValue;
   }
 
   /**
-   * The currently attuned spell, or the first one if there are multiple. Undefined if none are attuned.
-   * @type {undefined | Document | object | null}
+   * Is this matrix a shared matrix?
+   * @type {boolean}
    */
-  get spell() {
-    const spellUuid = this.spells.first();
-    if ( !spellUuid ) return undefined;
-    return fromUuidSync( spellUuid );
+  get matrixShared() {
+    return this.matrix?.matrixType === "shared";
+  }
+
+  /**
+   * The currently attuned spell, or the first one if there are multiple. Null if none are attuned.
+   * @type { ItemEd | null }
+   */
+  get matrixSpell() {
+    return fromUuidSync( this.matrix?.spells?.first() );
   }
 
   // endregion
@@ -179,11 +185,11 @@ export default class MatrixTemplate extends SystemDataModel {
   _setDefaultMatrixData( data ) {
     data.system.matrix ??= {
       matrixType:  "standard",
-      deathRating: this._lookupDeathRating(),
+      deathRating: this._lookupMatrixDeathRating(),
       threads:     {
         hold: {
-          value: this._lookupMaxHoldThread(),
-          max:   this._lookupMaxHoldThread(),
+          value: this._lookupMatrixMaxHoldThread(),
+          max:   this._lookupMatrixMaxHoldThread(),
         },
       },
     };
@@ -218,7 +224,7 @@ export default class MatrixTemplate extends SystemDataModel {
    */
   _isMatrixTypeChanging( data ) {
     return (
-      String( data.system?.matrix?.matrixType ) !== String( this.matrixType ) &&
+      String( data.system?.matrix?.matrixType ) !== String( this.matrix?.matrixType ) &&
       data.system?.matrix?.matrixType in ED4E.matrixTypes
     );
   }
@@ -229,9 +235,9 @@ export default class MatrixTemplate extends SystemDataModel {
    */
   _updateMatrixTypeData( data ) {
     const matrixType = data.system?.matrix?.matrixType;
-    data.system.matrix.deathRating = this._lookupDeathRating( matrixType );
-    data.system.matrix.threads.hold.value = this._lookupMaxHoldThread( matrixType );
-    data.system.matrix.threads.hold.max = this._lookupMaxHoldThread( matrixType );
+    data.system.matrix.deathRating = this._lookupMatrixDeathRating( matrixType );
+    data.system.matrix.threads.hold.value = this._lookupMatrixMaxHoldThread( matrixType );
+    data.system.matrix.threads.hold.max = this._lookupMatrixMaxHoldThread( matrixType );
   }
 
   // endregion
@@ -241,7 +247,7 @@ export default class MatrixTemplate extends SystemDataModel {
    * @param {string} matrixType The type of the matrix to look up, as defined in {@link ED4E.matrixTypes}.
    * @returns {number|undefined} The death rating of the matrix, or undefined if not found.
    */
-  _lookupDeathRating( matrixType = "standard" ) {
+  _lookupMatrixDeathRating( matrixType = "standard" ) {
     return ED4E.matrixTypes[ matrixType ].deathRating;
   }
 
@@ -250,7 +256,7 @@ export default class MatrixTemplate extends SystemDataModel {
    * @param {string} matrixType The type of the matrix to look up, as defined in {@link ED4E.matrixTypes}.
    * @returns {number|undefined} The maximum thread hold of the matrix, or undefined if not found.
    */
-  _lookupMaxHoldThread( matrixType = "standard" ) {
+  _lookupMatrixMaxHoldThread( matrixType = "standard" ) {
     return ED4E.matrixTypes[ matrixType ].maxHoldThread;
   }
 

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -134,6 +134,14 @@ export default class MatrixTemplate extends SystemDataModel {
     return fromUuidSync( this.matrix?.spells?.first() );
   }
 
+  /**
+   * The UUID of the currently attuned spell, or the first one if there are multiple. Null if none are attuned.
+   * @type {string | null}
+   */
+  get matrixSpellUuid() {
+    return this.matrix?.spells?.first() || null;
+  }
+
   // endregion
 
   // region Life Cycle Events

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -251,6 +251,19 @@ export default class MatrixTemplate extends SystemDataModel {
   // endregion
 
   /**
+   * Checks if the matrix is attuned to a specific spell.
+   * @param {string} spellUuid The UUID of the spell to check.
+   * @returns {boolean} True if the matrix is attuned to the spell, false otherwise.
+   */
+  isSpellAttuned( spellUuid ) {
+    if ( this.matrixShared ) {
+      return this.matrix?.spells?.has( spellUuid );
+    } else {
+      return this.matrixSpellUuid === spellUuid;
+    }
+  }
+
+  /**
    * Looks up the death rating of the matrix based on its type.
    * @param {string} matrixType The type of the matrix to look up, as defined in {@link ED4E.matrixTypes}.
    * @returns {number|undefined} The death rating of the matrix, or undefined if not found.

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -101,6 +101,14 @@ export default class MatrixTemplate extends SystemDataModel {
   }
 
   /**
+   * Whether this item has a matrix.
+   * @type {boolean}
+   */
+  get hasMatrix() {
+    return this.edid === getSetting( "edidSpellMatrix" );
+  }
+
+  /**
    * The amount of damage that is prevented when attacked.
    * @type {number}
    */

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -286,6 +286,14 @@ export default class ActorEd extends Actor {
   }
 
   /**
+   * Find all items that have a matrix.
+   * @returns {ItemEd[]} An array of items that have a matrix.
+   */
+  getMatrices() {
+    return this.items.filter( item => item.system?.hasMatrix );
+  }
+
+  /**
    * Taken from the ({@link https://gitlab.com/peginc/swade/-/wikis/Savage-Worlds-ID|SWADE system}).
    * Fetch an item that matches a given EDID and optionally an item type.
    * @param {string} edid         The EDID of the item(s) which you want to retrieve

--- a/module/workflows/attune-matrix-workflow.mjs
+++ b/module/workflows/attune-matrix-workflow.mjs
@@ -1,0 +1,34 @@
+import ActorWorkflow from "./workflow/actor-workflow.mjs";
+
+/**
+ * @typedef {object} AttuneMatrixWorkflowOptions
+ * @property {ItemEd[]} matrices The matrices that are available to the actor.
+ * @property {ItemEd[]} spells All available spells.
+ */
+
+export default class AttuneMatrixWorkflow extends ActorWorkflow {
+
+  /**
+   * The matrices that are available to the actor.
+   * @type {ItemEd[]}
+   */
+  _matrices = [];
+
+  /**
+   * The spells that are available to the actor.
+   * @type {ItemEd[]}
+   */
+  _spells = [];
+
+  /**
+   * @param {ActorEd} attuningActor - The actor that is reattuning the matrices.
+   * @param {WorkflowOptions&AttuneMatrixWorkflowOptions} options - The options for the attuning workflow.
+   */
+  constructor( attuningActor, options ) {
+    super( attuningActor, options );
+
+    this._matrices = options.matrices;
+    this._spells = options.spells;
+  }
+
+}

--- a/module/workflows/workflow/actor-workflow.mjs
+++ b/module/workflows/workflow/actor-workflow.mjs
@@ -1,4 +1,5 @@
 import Workflow from "./workflow.mjs";
+import ActorEd from "../../documents/actor.mjs";
 
 /**
  * Base class for all workflows that are associated with an Actor.
@@ -8,17 +9,17 @@ export default class ActorWorkflow extends Workflow {
 
   /**
    * The actor that this workflow is associated with.
-   * @type {foundry.documents.Actor}
+   * @type {ActorEd}
    */
   _actor = null;
 
   /**
    * @override
-   * @param {foundry.documents.Actor} actor The actor that this workflow is associated with.
+   * @param {ActorEd} actor The actor that this workflow is associated with.
    * @param {WorkflowOptions} [options] See {@link Workflow#constructor}.
    */
   constructor( actor, options = {} ) {
-    if ( ! ( actor instanceof foundry.documents.Actor ) )
+    if ( ! ( actor instanceof ActorEd ) )
       throw new TypeError( "ActorWorkflow constructor expects an Actor instance." );
 
     super( options );

--- a/module/workflows/workflow/item-workflow.mjs
+++ b/module/workflows/workflow/item-workflow.mjs
@@ -1,0 +1,29 @@
+import Workflow from "./workflow.mjs";
+import ItemEd from "../../documents/item.mjs";
+
+/**
+ * Base class for all workflows that are associated with an Item.
+ * @abstract
+ */
+export default class ItemWorkflow extends Workflow {
+
+  /**
+   * The item that this workflow is associated with.
+   * @type {ItemEd}
+   */
+  _item = null;
+
+  /**
+   * @override
+   * @param {ItemEd} item The item that this workflow is associated with.
+   * @param {WorkflowOptions} [options] See {@link Workflow#constructor}.
+   */
+  constructor( item, options = {} ) {
+    if ( !( item instanceof ItemEd ) )
+      throw new TypeError( "ItemWorkflow constructor expects an Item instance." );
+
+    super( options );
+    this._item = item;
+  }
+
+}

--- a/templates/actor/actor-tabs/spells.hbs
+++ b/templates/actor/actor-tabs/spells.hbs
@@ -15,9 +15,28 @@
 
         <!-- matrices -->
         <div class="tab {{tabsSpells.matrix.cssClass}}" data-group="spellsContent" data-tab="matrix">
-          <div class="undefined">
-            <p>matrizen</p>
-            <p>zeige alle Matrizen und Matrix items und funktionen für aktunement etc.</p>
+          <div class="flexrow">
+            <button class="button" data-action="attuneMatrix">
+              <i class="fas {{icons.attune}}"></i>
+              {{localize "ED.TODO.X.Dialogs.SpellMatrix.attune"}}
+            </button>
+          </div>
+          <div class="flexrow" style="flex-wrap: wrap;">
+          {{#each matrices}}
+            <div class="item-id item-name__card flexrow" data-uuid="{{this.uuid}}" data-action="attuneMatrix">
+              <img src="{{this.img}}" alt="{{this.name}}" class="item-id item-name__card" data-uuid="{{this.uuid}}"
+                      data-action="attuneMatrix" width="52" />
+              <figcaption class="item-id item-name__card" data-uuid="{{this.uuid}}"
+                          data-action="attuneMatrix" >
+                {{this.name}}
+              </figcaption>
+              <span>
+                {{#each this.system.matrix.spells}}
+                  {{{ed-linkForUuid this}}}
+                {{/each}}
+              </span>
+            </div>
+          {{/each}}
           </div>
         </div>
 

--- a/templates/actor/actor-tabs/spells.hbs
+++ b/templates/actor/actor-tabs/spells.hbs
@@ -23,7 +23,7 @@
           </div>
           <div class="flexrow" style="flex-wrap: wrap;gap: 1rem;justify-content: space-around;">
             {{#each matrices}}
-              <div class="item-id item-name__card" style="flex: 1 1 calc(25% - 1rem);max-width: 200px;box-sizing: border-box;" data-uuid="{{this.uuid}}" data-action="attuneMatrix">
+              <div class="item-id item-name__card" style="cursor:pointer;flex: 1 1 calc(25% - 1rem);max-width: 200px;box-sizing: border-box;" data-uuid="{{this.uuid}}" data-action="attuneMatrix">
                 <div class="flexrow">
                   <img src="{{this.img}}" alt="{{this.name}}" class="item-id item-name__card" data-uuid="{{this.uuid}}"
                        data-action="attuneMatrix" height="52" width="52" />

--- a/templates/actor/actor-tabs/spells.hbs
+++ b/templates/actor/actor-tabs/spells.hbs
@@ -21,22 +21,24 @@
               {{localize "ED.TODO.X.Dialogs.SpellMatrix.attune"}}
             </button>
           </div>
-          <div class="flexrow" style="flex-wrap: wrap;">
-          {{#each matrices}}
-            <div class="item-id item-name__card flexrow" data-uuid="{{this.uuid}}" data-action="attuneMatrix">
-              <img src="{{this.img}}" alt="{{this.name}}" class="item-id item-name__card" data-uuid="{{this.uuid}}"
-                      data-action="attuneMatrix" width="52" />
-              <figcaption class="item-id item-name__card" data-uuid="{{this.uuid}}"
-                          data-action="attuneMatrix" >
-                {{this.name}}
-              </figcaption>
-              <span>
-                {{#each this.system.matrix.spells}}
-                  {{{ed-linkForUuid this}}}
-                {{/each}}
-              </span>
-            </div>
-          {{/each}}
+          <div class="flexrow" style="flex-wrap: wrap;gap: 1rem;justify-content: space-around;">
+            {{#each matrices}}
+              <div class="item-id item-name__card" style="flex: 1 1 calc(25% - 1rem);max-width: 200px;box-sizing: border-box;" data-uuid="{{this.uuid}}" data-action="attuneMatrix">
+                <div class="flexrow">
+                  <img src="{{this.img}}" alt="{{this.name}}" class="item-id item-name__card" data-uuid="{{this.uuid}}"
+                       data-action="attuneMatrix" height="52" width="52" />
+                  <figcaption class="item-id item-name__card" data-uuid="{{this.uuid}}"
+                              data-action="attuneMatrix" >
+                    {{this.name}}
+                  </figcaption>
+                </div>
+                <span>
+                  {{#each this.system.matrix.spells}}
+                    {{{ed-linkForUuid this}}}
+                  {{/each}}
+                </span>
+              </div>
+            {{/each}}
           </div>
         </div>
 

--- a/templates/workflow/attune-matrix.hbs
+++ b/templates/workflow/attune-matrix.hbs
@@ -1,6 +1,7 @@
+<!--TODO: Put it in summary tag if particular Matrix was selected-->
 <div>
 {{#each spellSelectionFields }}
-  {{formGroup this.field name=this.matrix.uuid value=this.selected}}
+  {{formGroup this.field name=this.matrix.id value=this.selected options=this.field.choices valueAttr="value"}}
 {{else}}
   <em>{{localize "ED.Dialogs.TODO.X.No matrices available"}}</em>
 {{/each}}

--- a/templates/workflow/attune-matrix.hbs
+++ b/templates/workflow/attune-matrix.hbs
@@ -1,5 +1,7 @@
+<div>
 {{#each spellSelectionFields }}
-  {{formGroup this.field name=(this.matrix.uuid) value=(this.selected)}}
+  {{formGroup this.field name=this.matrix.uuid value=this.selected}}
 {{else}}
   <em>{{localize "ED.Dialogs.TODO.X.No matrices available"}}</em>
 {{/each}}
+</div>

--- a/templates/workflow/attune-matrix.hbs
+++ b/templates/workflow/attune-matrix.hbs
@@ -1,5 +1,5 @@
-{{#each matrices as | matrix |}}
-  <i>{{matrix.name}}</i>
+{{#each spellSelectionFields }}
+  {{formGroup this.field name=(this.matrix.uuid) value=(this.selected)}}
 {{else}}
   <em>{{localize "ED.Dialogs.TODO.X.No matrices available"}}</em>
 {{/each}}

--- a/templates/workflow/attune-matrix.hbs
+++ b/templates/workflow/attune-matrix.hbs
@@ -1,0 +1,5 @@
+{{#each matrices as | matrix |}}
+  <i>{{matrix.name}}</i>
+{{else}}
+  <em>{{localize "ED.Dialogs.TODO.X.No matrices available"}}</em>
+{{/each}}

--- a/templates/workflow/attune-matrix.hbs
+++ b/templates/workflow/attune-matrix.hbs
@@ -1,8 +1,17 @@
-<!--TODO: Put it in summary tag if particular Matrix was selected-->
 <div>
-{{#each spellSelectionFields }}
-  {{formGroup this.field name=this.matrix.id value=this.selected options=this.field.choices valueAttr="value"}}
-{{else}}
-  <em>{{localize "ED.Dialogs.TODO.X.No matrices available"}}</em>
-{{/each}}
+  {{#if firstField}}
+    {{#with firstField }}
+      {{formGroup this.field name=this.matrix.id value=this.selected options=this.field.choices valueAttr="value"}}
+    {{/with}}
+    <details>
+    <summary>{{localize "ED.X.TODO.otherMatrices"}}</summary>
+  {{/if}}
+  {{#each spellSelectionFields }}
+    {{formGroup this.field name=this.matrix.id value=this.selected options=this.field.choices valueAttr="value"}}
+  {{else}}
+    <em>{{localize "ED.Dialogs.TODO.X.No matrices available"}}</em>
+  {{/each}}
+  {{#if firstField}}
+    </details>
+  {{/if}}
 </div>


### PR DESCRIPTION
Add basic UI for attuning spell matrices.

- add listing matrices in actor's "spells" tab
- add button to attune all
- click matrix in "spells" tab to focus in clicked matrix
- add temporary inline styling


NOT ADDRESSED (create new issues for that?)
- spells that can share a matrix that is not of type "shared" (e.g., resist element versions, otter swim/gills)
- attune on the fly

(otherwise this PR got too big)