### PR TITLE
Refactor language JSON consolidation logic

### DIFF
--- a/utils/consolidate-lang-json.mjs
+++ b/utils/consolidate-lang-json.mjs
@@ -55,25 +55,28 @@ export function flattenObject( obj, _d=0 ) {
 
 /**
  * Consolidate localization JSON files by ensuring all keys are present in each file.
+ * @param {string} langFile The JSON file name to use as the lead. Required.
  * @param {string} [langDir] The directory containing the JSON files. Defaults to "lang".
- * @param {[string]} [langFiles] An array of JSON file names. If not provided, all JSON files in the directory will be used.
- * @throws {TypeError} If langFiles is not an array.
+ * @throws {TypeError} If langFile is not a string.
  */
-export default function consolidateLangJson( langDir, langFiles ) {
+export default function consolidateLangJson( langFile, langDir ) {
 
+  if ( !langFile ) throw new TypeError( "langFile is required" );
+  if ( typeof langFile !== "string" ) throw new TypeError( "langFile must be a string" );
   // eslint-disable-next-line no-param-reassign
   langDir ??= path.resolve( "lang" );
-  // eslint-disable-next-line no-param-reassign
-  langFiles ??= fs.readdirSync( langDir ).filter(
-    file => file.endsWith( ".json" )
-  );
-  if ( !Array.isArray( langFiles ) ) throw new TypeError( "langFiles must be an array" );
 
   const localizationPlaceholder = "TODO: Add translation";
 
+  // Get all language files (including the lead file)
+  const allLangFiles = fs.readdirSync( langDir ).filter(
+    file => file.endsWith( ".json" )
+  );
+
   const langData = {};
 
-  langFiles.forEach( file => {
+  // Load all language files
+  allLangFiles.forEach( file => {
     const fullPath = path.join( langDir, file );
     const raw = fs.readFileSync( fullPath, "utf8" );
     langData[file] = {
@@ -102,12 +105,12 @@ export default function consolidateLangJson( langDir, langFiles ) {
     resolvedLangs[file] = {};
 
     for ( const key of allKeys ) {
-      const deValue = flattenedLangs["de.json"][key];
+      const leadValue = flattenedLangs[langFile][key];
       const currentValue = flattenedLangs[file][key];
 
-      if ( file === "de.json" ) {
-        // Keep DE values as-is
-        resolvedLangs[file][key] = deValue ?? localizationPlaceholder;
+      if ( file === langFile ) {
+        // Keep lead values as-is
+        resolvedLangs[file][key] = leadValue ?? localizationPlaceholder;
       } else if ( currentValue ) {
         // Keep existing non-empty value
         resolvedLangs[file][key] = currentValue;

--- a/utils/lint-json.mjs
+++ b/utils/lint-json.mjs
@@ -2,7 +2,7 @@ import alignLangJson from "./format-lang-json.mjs";
 import consolidateLangJson from "./consolidate-lang-json.mjs";
 import fs from "fs";
 import path from "path";
-
+import process from "process";
 
 /**
  * Validate a JSON file.
@@ -18,15 +18,55 @@ function validateJson( jsonFile ) {
   }
 }
 
-// Main script
+/**
+ * Validates if a filename follows ISO 639-1 code format (2-letter code + .json)
+ * @param {string} filename The filename to validate
+ * @returns {boolean} True if the filename follows ISO 639-1 format
+ */
+function isValidLanguageFile( filename ) {
+  // ISO 639-1 codes are 2 letters followed by .json
+  return /^[a-z]{2}\.json$/i.test( filename );
+}
+
+// Get files from command line arguments if any (for lint-staged integration)
+const inputFiles = process.argv.slice( 2 ).filter( file => file.endsWith( ".json" ) );
+
+// If called from lint-staged with files, ensure there's only one lang file
+if ( inputFiles.length > 1 ) {
+  console.error( "So nicht, Freundchen! Only one language file can be staged at a time." );
+  process.exit( 1 );
+}
+
 const LANG_DIR = path.resolve( "lang" );
 const files = fs.readdirSync( LANG_DIR ).filter(
   file => file.endsWith( ".json" )
 );
 const filePaths = files.map( file => path.join( LANG_DIR, file ) );
 
+// Determine and validate the lead file
+let leadFile;
+if ( inputFiles.length === 1 ) {
+  // Extract just the filename from the full path
+  leadFile = path.basename( inputFiles[0] );
+
+  // Validate that the lead file follows ISO 639-1 format
+  if ( !isValidLanguageFile( leadFile ) ) {
+    console.error( `Error: Language file "${leadFile}" does not follow ISO 639-1 format (2-letter code + .json)` );
+    process.exit( 1 );
+  }
+
+  // Ensure the file exists in the lang directory
+  if ( !files.includes( leadFile ) ) {
+    console.error( `Error: Language file "${leadFile}" not found in ${LANG_DIR}` );
+    process.exit( 1 );
+  }
+} else {
+  // No file provided, throw an error
+  console.error( "Error: No language file provided. Please specify a valid ISO 639-1 language file (.json)" );
+  process.exit( 1 );
+}
 
 filePaths.forEach( file => validateJson( file ) );
-consolidateLangJson( LANG_DIR, files );
+consolidateLangJson( leadFile, LANG_DIR );
 alignLangJson( filePaths );
 filePaths.forEach( file => validateJson( file ) );

--- a/utils/lint-json.mjs
+++ b/utils/lint-json.mjs
@@ -48,13 +48,13 @@ let leadFile;
 if ( inputFiles.length === 1 ) {
   // Extract just the filename from the full path
   leadFile = path.basename( inputFiles[0] );
-
+  
   // Validate that the lead file follows ISO 639-1 format
   if ( !isValidLanguageFile( leadFile ) ) {
     console.error( `Error: Language file "${leadFile}" does not follow ISO 639-1 format (2-letter code + .json)` );
     process.exit( 1 );
   }
-
+  
   // Ensure the file exists in the lang directory
   if ( !files.includes( leadFile ) ) {
     console.error( `Error: Language file "${leadFile}" not found in ${LANG_DIR}` );


### PR DESCRIPTION
### Summary

This pull request improves the handling of language file consolidation by:

- Refactoring `consolidateLangJson` to use a lead language file parameter.
- Streamlining processing logic to rely on the lead file for key handling.
- Enhancing `lint-json` validation logic for lead file and ISO 639-1 compliance.
- Improving code maintainability with clear comments and unused variable removal.

# CAVE

This version of the lang linting requires a particular process of working with localization files. Only one localization file can be committed at a time, which will be taken as the lead file. On the basis of the lead file, all other language files are updated, deleting keys not in the lead file and adding those missing in other files.

This means that possible discrepancies between files at the moment need to be resolved if they are to be conserved. Otherwise, the first run of the linting will consolidate all lang files according to the committed lead file.