### PR TITLE
Add missing import to physical-item-sheet

### DIFF
--- a/module/applications/item/physical-item-sheet.mjs
+++ b/module/applications/item/physical-item-sheet.mjs
@@ -1,6 +1,8 @@
 import ED4E from "../../config/_module.mjs";
 import ItemSheetEd from "./item-sheet.mjs";
 
+const TextEditor = foundry.applications.ux.TextEditor.implementation;
+
 /**
  * Extend the basic ActorSheet with modifications
  */


### PR DESCRIPTION
The pull request includes the following changes:

- Added the missing `TextEditor` import in `physical-item-sheet`.
- Updated the code to conform to ES module usage, as global assignment is deprecated in Foundry V13.