### PR TITLE
Add Grimoire Item Template

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -317,11 +317,12 @@
         "applyDamage":                             "Schaden zufügen",
         "applyDamageTitle":                        "Füge den Schaden den ausgewählten Zielen zu!",
         "applyEffect":                             "Effekt zufügen",
-        "applyEffectTitle":                        "Füge den Effect den ausgewählten Zielen zu!",
+        "applyEffectTitle":                        "Füge den Effekt den ausgewählten Zielen zu!",
         "rollDamage":                              "Schadenswurf",
-        "rollDamageTitle":                         "Würfel den Effect",
+        "rollDamageTitle":                         "Würfel den Effekt",
         "rollEffect":                              "Effektwurf",
-        "takeDamage":                              "Schaden nehmen"
+        "takeDamage":                              "Schaden nehmen",
+        "takeDamageTitle":                         "Füge den Schaden deinem zugewiesenen Charakter zu!"
       },
       "Flavor": {
         "actorTookDamage":                         "{dealtTo} hat Schaden erlitten.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -322,7 +322,8 @@
         "rollDamage":                              "Roll Damage",
         "rollDamageTitle":                         "Roll for Damage",
         "rollEffect":                              "Roll Effect",
-        "takeDamage":                              "Take Damage"
+        "takeDamage":                              "Take Damage",
+        "takeDamageTitle":                         "TODO: Add translation"
       },
       "Flavor": {
         "actorTookDamage":                         "TODO: Add translation",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -321,7 +321,8 @@
         "rollDamage":                              "TODO: Add translation",
         "rollDamageTitle":                         "TODO: Add translation",
         "rollEffect":                              "TODO: Add translation",
-        "takeDamage":                              "TODO: Add translation"
+        "takeDamage":                              "TODO: Add translation",
+        "takeDamageTitle":                         "TODO: Add translation"
       },
       "Flavor": {
         "actorTookDamage":                         "TODO: Add translation",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -321,7 +321,8 @@
         "rollDamage":                              "TODO: Add translation",
         "rollDamageTitle":                         "TODO: Add translation",
         "rollEffect":                              "TODO: Add translation",
-        "takeDamage":                              "TODO: Add translation"
+        "takeDamage":                              "TODO: Add translation",
+        "takeDamageTitle":                         "TODO: Add translation"
       },
       "Flavor": {
         "actorTookDamage":                         "TODO: Add translation",

--- a/module/applications/item/physical-item-sheet.mjs
+++ b/module/applications/item/physical-item-sheet.mjs
@@ -8,6 +8,8 @@ const TextEditor = foundry.applications.ux.TextEditor.implementation;
  */
 export default class PhysicalItemSheetEd extends ItemSheetEd {
 
+  // region Static Properties
+
   /** @inheritDoc */
   static DEFAULT_OPTIONS = {
     actions:  {
@@ -17,7 +19,7 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
     },
   };
 
-  // region PARTS
+  /** @inheritDoc */
   static PARTS = {
     header: {
       template: "systems/ed4e/templates/item/item-partials/item-section-name.hbs",
@@ -55,7 +57,6 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
     },
   };
 
-  // region TABS
   /** @inheritDoc */
   static TABS = {
     sheet: {
@@ -69,6 +70,10 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
       labelPrefix: "ED.Tabs.ItemSheet",
     },
   };
+
+  // endregion
+
+  // region Rendering
 
   async _preparePartContext( partId, contextInput, options ) {
     const context = await super._preparePartContext( partId, contextInput, options );
@@ -116,6 +121,27 @@ export default class PhysicalItemSheetEd extends ItemSheetEd {
 
     return context;
   }
+
+  // endregion
+
+  // region Drag and Drop
+
+
+  /** @inheritDoc */
+  async _onDropItem( event, item ) {
+    await super._onDropItem( event, item );
+
+    let changed = false;
+
+    if ( item.type === "spell" && this.item.system.isGrimoire ) {
+      // If the item is a spell and the item is a grimoire, add it to the grimoire
+      await this.item.system.addSpellToGrimoire( item );
+    }
+
+    if ( changed ) this.render();
+  }
+
+  // endregion
 
   static async addThreadLevel( event, target ) {
     event.preventDefault();

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -24,6 +24,7 @@ export const reservedEdid = {
  */
 export const defaultEdIds = {
   creatureAttack:  "creature-attack",
+  grimoire:        "grimoire",
   languageRW:      "language-rw",
   languageSpeak:   "language-speak",
   patterncraft:    "patterncraft",

--- a/module/data/item/_module.mjs
+++ b/module/data/item/_module.mjs
@@ -54,6 +54,7 @@ export {
 
 export {default as AbilityTemplate} from "./templates/ability.mjs";
 export {default as ClassTemplate} from "./templates/class.mjs";
+export {default as GrimoireTemplate} from "./templates/grimoire.mjs";
 export {default as IncreasableAbilityTemplate} from "./templates/increasable-ability.mjs";
 export {default as ItemDescriptionTemplate} from "./templates/item-description.mjs";
 export {default as KnackTemplate} from "./templates/knack-item.mjs";

--- a/module/data/item/templates/grimoire.mjs
+++ b/module/data/item/templates/grimoire.mjs
@@ -106,4 +106,43 @@ export default class GrimoireTemplate extends SystemDataModel {
 
   // endregion
 
+  // region Item Methods
+
+  /**
+   * Adds a spell to the grimoire.
+   * @param {Item} spell The spell to add to the grimoire.
+   * @returns {Promise<Item|undefined>} The updated grimoire item or undefined if the spell was not added.
+   */
+  async addSpellToGrimoire( spell ) {
+    if ( !this.isGrimoire || spell.type !== "spell" ) {
+      if ( !this.isGrimoire ) {
+        ui.notifications.error(
+          game.i18n.localize( "ED.Notifications.Error.grimoireAddNotAGrimoire" ),
+        );
+      }
+      if ( spell.type !== "spell" ) {
+        ui.notifications.error(
+          game.i18n.localize( "ED.Notifications.Error.grimoireAddNotASpell" ),
+        );
+      }
+
+      return;
+    }
+
+    // If the spell is already in the grimoire, do nothing
+    if ( this.grimoire.spells.has( spell.uuid ) ) {
+      ui.notifications.warn(
+        game.i18n.localize( "ED.Notifications.Warn.grimoireAddAlreadyInGrimoire" ),
+      );
+      return;
+    }
+
+    // Add the spell to the grimoire
+    return this.parent.update( {
+      "system.grimoire.spells": this.grimoire.spells.add( spell.uuid ),
+    } );
+  }
+
+  // endregion
+
 }

--- a/module/data/item/templates/grimoire.mjs
+++ b/module/data/item/templates/grimoire.mjs
@@ -1,0 +1,48 @@
+import SystemDataModel from "../../abstract.mjs";
+import { getSetting } from "../../../settings.mjs";
+
+const { fields } = foundry.data;
+
+export default class GrimoireTemplate extends SystemDataModel {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Item.Grimoire",
+  ];
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      grimoire: new fields.SchemaField( {
+        spells: new fields.SetField(
+          new fields.DocumentUUIDField( {
+            type:     "Item",
+            embedded: false,
+          } ), {
+            required:        true,
+            initial:         [],
+          } ),
+        owner: new fields.DocumentUUIDField( {
+          type:     "Actor",
+        } ),
+      },{
+        nullable: true,
+        initial:  null,
+      } ),
+    } );
+  }
+
+  // region Properties
+
+  get isGrimoire() {
+    return this.edid === getSetting( "edidGrimoire" );
+  }
+
+  get isOwnGrimoire() {
+    return this.grimoire?.owner === this.containingActor?.uuid;
+  }
+
+  // endregion
+
+}

--- a/module/data/item/templates/grimoire.mjs
+++ b/module/data/item/templates/grimoire.mjs
@@ -45,4 +45,65 @@ export default class GrimoireTemplate extends SystemDataModel {
 
   // endregion
 
+  // region Life Cycle Events
+
+  /**
+   * Prepares the grimoire data for creation or update.
+   * @param {object} data The data to prepare, see {@link _preCreate} and {@link _preUpdate}.
+   */
+  _prepareGrimoireData( data ) {
+    const edidGrimoire = getSetting( "edidGrimoire" );
+
+    if ( this._isBecomingGrimoire( data, edidGrimoire ) ) {
+      this._setDefaultGrimoireData( data );
+    } else if ( this._isLosingGrimoire( data, edidGrimoire ) ) {
+      this._clearGrimoireData( data );
+    }
+  }
+
+  /**
+   * Checks if the item is becoming a grimoire with creation or update.
+   * @param {object} data The data to check, see {@link _preCreate} and {@link _preUpdate}.
+   * @param {string} edidGrimoire The EDID that defines a grimoire.
+   * @returns {boolean} True if the item is becoming a matrix, false otherwise.
+   */
+  _isBecomingGrimoire( data, edidGrimoire ) {
+    return data.system?.edid === edidGrimoire && this.edid !== edidGrimoire;
+  }
+
+  /**
+   * Sets the default grimoire data for a new grimoire.
+   * @param {object} data The data to set, see {@link _preCreate} and {@link _preUpdate}.
+   */
+  _setDefaultGrimoireData( data ) {
+    data.system.grimoire ??= {
+      spells: new Set(),
+      owner:  null,
+    };
+  }
+
+  /**
+   * Checks if the item is losing its grimoire status with creation or update.
+   * @param {object} data The data to check, see {@link _preCreate} and {@link _preUpdate}.
+   * @param {string} edidGrimoire The EDID that defines a grimoire.
+   * @returns {boolean} True if the item is losing its grimoire status, false otherwise.
+   */
+  _isLosingGrimoire( data, edidGrimoire ) {
+    return (
+      this.edid === edidGrimoire
+      && typeof data.system?.edid === "string"
+      && data.system.edid !== edidGrimoire
+    );
+  }
+
+  /**
+   * Clears the grimoire data when the item is no longer a grimoire.
+   * @param {object} data The data to clear, see {@link _preCreate} and {@link _preUpdate}.
+   */
+  _clearGrimoireData( data ) {
+    data.system.grimoire = null;
+  }
+
+  // endregion
+
 }

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -146,20 +146,6 @@ export default class MatrixTemplate extends SystemDataModel {
 
   // region Life Cycle Events
 
-  /** @inheritdoc */
-  async _preCreate( data, options, user ) {
-    if ( await super._preCreate( data, options, user ) === false ) return false;
-
-    this._prepareMatrixData( data );
-  }
-
-  /** @inheritdoc */
-  async _preUpdate( changes, options, user ) {
-    if ( await super._preUpdate( changes, options, user ) === false ) return false;
-
-    this._prepareMatrixData( changes );
-  }
-
   /**
    * Prepares the matrix data for creation or update.
    * @param {object} data The data to prepare, see {@link _preCreate} and {@link _preUpdate}.

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -212,6 +212,26 @@ export default class PhysicalItemTemplate extends ItemDataModel.mixin(
     return statusOrder[ ( prevIndex < 0 ? ( statusOrder.length - 1 ) : prevIndex ) % statusOrder.length ];
   }
 
+  // region Life Cycle Events
+
+  /** @inheritdoc */
+  async _preCreate( data, options, user ) {
+    if ( await super._preCreate( data, options, user ) === false ) return false;
+
+    this._prepareGrimoireData( data );
+    this._prepareMatrixData( data );
+  }
+
+  /** @inheritdoc */
+  async _preUpdate( changed, options, user ) {
+    if ( await super._preUpdate( changed, options, user ) === false ) return false;
+
+    this._prepareGrimoireData( changed );
+    this._prepareMatrixData( changed );
+  }
+
+  // endregion
+
   /* -------------------------------------------- */
   /*  Methods                                     */
   /* -------------------------------------------- */

--- a/module/data/item/templates/physical-item.mjs
+++ b/module/data/item/templates/physical-item.mjs
@@ -3,6 +3,7 @@ import TargetTemplate from "./targeting.mjs";
 import ED4E from "../../../config/_module.mjs";
 import ThreadTemplate from "./threads.mjs";
 import MatrixTemplate from "./matrix.mjs";
+import GrimoireTemplate from "./grimoire.mjs";
 
 /**
  * Data model template with information on physical items.
@@ -19,6 +20,7 @@ import MatrixTemplate from "./matrix.mjs";
  * @property {number} usableItem.recoveryPropertyValue      recovery type value
  */
 export default class PhysicalItemTemplate extends ItemDataModel.mixin(
+  GrimoireTemplate,
   MatrixTemplate,
   TargetTemplate,
   ThreadTemplate,

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -780,6 +780,7 @@ export async function preloadHandlebarsTemplates() {
     "systems/ed4e/templates/item/item-partials/item-details/partials/roll-type.hbs",
     "systems/ed4e/templates/item/item-partials/item-details/partials/abilities.hbs",
     "systems/ed4e/templates/item/item-partials/item-details/partials/matrix.hbs",
+    "systems/ed4e/templates/item/item-partials/item-details/partials/grimoire.hbs",
 
     // Item details
     "systems/ed4e/templates/item/item-partials/item-details/item-effects.hbs",

--- a/templates/chat/chat-flavor/damage-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/damage-roll-flavor.hbs
@@ -8,13 +8,9 @@ Damage Flavor contains:
 --}}
 <div class="custom-flavor">{{ customFlavor }}</div>
 <div class="flexrow message-buttons damage-roll-buttons" data-roll-total={{ result }}>
-  <button type="button" class="apply-damage" title="{{ localize "ED.Chat.Button.applyDamageTitle" }}" data-action="apply-damage">
-    {{ localize "ED.Chat.Button.applyDamage" }}
-  </button>
+  {{> "systems/ed4e/templates/chat/chat-buttons/apply-damage.hbs"}}
   {{#if hasAssignedCharacter}}
-    <button type="button" class="take-damage" title="{{ localize "ED.Chat.Button.takeDamageTitle" }}" data-action="take-damage">
-      {{ localize "ED.Chat.Button.takeDamage" }}
-    </button>
+    {{> "systems/ed4e/templates/chat/chat-buttons/take-damage.hbs"}}
   {{/if}}
 </div>
 <div class="modifier-lists flexrow">

--- a/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-physicalItems.hbs
@@ -1,5 +1,6 @@
     {{!-- itemStatus --}}
     {{formField systemFields.itemStatus name="system.itemStatus" value=item.system.itemStatus localize=true}}
+
     {{#if item.isOwned}}
         {{!-- automatic Weight Calculation --}}
         {{> "systems/ed4e/templates/item/item-partials/item-details/partials/tailor-to-namegiver.hbs"}}
@@ -7,4 +8,8 @@
 
     {{#if system.matrix}}
       {{> "systems/ed4e/templates/item/item-partials/item-details/partials/matrix.hbs"}}
+    {{/if}}
+
+    {{#if system.grimoire}}
+      {{> "systems/ed4e/templates/item/item-partials/item-details/partials/grimoire.hbs"}}
     {{/if}}

--- a/templates/item/item-partials/item-details/partials/grimoire.hbs
+++ b/templates/item/item-partials/item-details/partials/grimoire.hbs
@@ -1,0 +1,26 @@
+<fieldset>
+  <legend>{{localize "ED.Item.Header.grimoireConfiguration"}}</legend>
+
+  {{#if system.isOwnGrimoire}}
+    <div class="grimoire-own-indicator">
+      <i class="fas fa-star"></i> <strong>{{localize "ED.Item.Grimoire.ownGrimoire"}}</strong>
+    </div>
+  {{else}}
+    <div class="grimoire-own-indicator">
+      {{localize "ED.Item.Grimoire.otherGrimoire"}}
+    </div>
+  {{/if}}
+
+  {{formGroup
+    systemFields.grimoire.fields.owner
+    name="system.grimoire.owner"
+    value=system.grimoire.owner
+    localize=true
+  }}
+
+  {{#each system.grimoire.spells}}
+    {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
+  {{else}}
+    <p class="no-spells">{{localize "ED.Item.Grimoire.noSpells"}}</p>
+  {{/each}}
+</fieldset>


### PR DESCRIPTION
This PR introduces the GrimoireTemplate class to the item data model, enabling support for grimoire items in the system.

# Features
- Schema definition for grimoire items with spell collection and owner reference
- Properties to check grimoire status and ownership
- Lifecycle methods to handle grimoire data initialization and cleanup on item creation/update
- Method to add spells to a grimoire with appropriate validation and user notifications

This update lays the groundwork for managing spell collections within grimoire items and ensures data integrity when items change type.

No breaking changes to existing item templates.