### PR TITLE
Implement Spell Threadweaving Basics and Data Model Enhancements

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -315,14 +315,16 @@
     "Chat": {
       "Button": {
         "applyDamage":                             "Schaden zufügen",
-        "applyDamageTitle":                        "Füge den Schaden den ausgewählten Zielen zu!",
+        "applyDamageTitle":                        "Füge den Schaden den ausgewählten Zielen zu",
         "applyEffect":                             "Effekt zufügen",
-        "applyEffectTitle":                        "Füge den Effekt den ausgewählten Zielen zu!",
+        "applyEffectTitle":                        "Füge den Effekt den ausgewählten Zielen zu",
+        "castSpell":                               "Zauber wirken",
+        "castSpellTitle":                          "Alle Fäden gewoben, wirke den Zauber auf die ausgewählten Ziele",
         "rollDamage":                              "Schadenswurf",
         "rollDamageTitle":                         "Würfel den Effekt",
         "rollEffect":                              "Effektwurf",
         "takeDamage":                              "Schaden nehmen",
-        "takeDamageTitle":                         "Füge den Schaden deinem zugewiesenen Charakter zu!"
+        "takeDamageTitle":                         "Füge den Schaden deinem zugewiesenen Charakter zu"
       },
       "Flavor": {
         "actorTookDamage":                         "{dealtTo} hat Schaden erlitten.",
@@ -336,13 +338,17 @@
         "rollUnarmedDamage":                       "{sourceActor} würfelt waffenlosen Schaden",
         "takeDamage":                              "Schaden nehmen",
         "takeStrainDamage":                        "{actor} nimmt {amount} Überanstrengungsschaden durch {ability}.",
+        "threadWeaving":                           "{sourceActor} webt Fäden für \"{spell}\" ({step})",
         "undoDamage":                              "Setzte den Schaden zurück"
       },
       "Header": {
         "arbitraryTest":                           "Willkürlicher Test",
         "attackManeuvers":                         "Manöver",
         "attackReactions":                         "Reaktionen",
-        "attackTargets":                           "Ziele"
+        "attackTargets":                           "Ziele",
+        "extraThreads":                            "Zusätzliche Fäden",
+        "numThreadsJustWoven":                     "Gerade gewebte Fäden",
+        "numThreadsWovenTotal":                    "Gesamt gewebte Fäden"
       }
     },
     "Conditions": {
@@ -1541,6 +1547,7 @@
         "activeUser":                              "Charaktere von aktiven Spieler",
         "actorsNoUserConfigured":                  "Charaktere ohne Spieler",
         "attuneOnTheFly":                          "Neu abstimmen während des Spiels",
+        "fieldsetExtraThreads":                    "Zusätzliche Fäden",
         "inactiveUser":                            "Charaktere von inaktiven Spieler",
         "update":                                  "System Update Neuigkeiten"
       },
@@ -1635,6 +1642,9 @@
         "step":                                    "Stufe",
         "strain":                                  "Überanstrengung"
       },
+      "SelectExtraThreads": {
+        "selectedXofYthreads":                     "{numSelected} von maximal {maxExtraThreads} Fäden ausgewählt"
+      },
       "Sorting": {
         "item":                                    "Item",
         "sortBy":                                  "Sortiere nach",
@@ -1645,6 +1655,7 @@
         "assignLp":                                "Legendenpunkte zuweisen",
         "attributeIncrease":                       "Attribut steigern",
         "attuneMatrix":                            "Matrix neu abstimmen",
+        "buttonSelect":                            "Wähle eine Option",
         "characterGeneration":                     "Charaktererschaffung",
         "chooseDiscipline":                        "Wähle eine Disziplin",
         "chooseTier":                              "Wähle einen Kreis",
@@ -1658,6 +1669,7 @@
         "lpLearnKnack":                            "Lerne Kniff",
         "recovery":                                "Erholung",
         "rollPrompt":                              "Würfel Dialog",
+        "selectExtraThreads":                      "Wähle zusätzliche Fäden",
         "startRoundCombatantPrompt":               "Rundenstart: Kampfbeteiligte",
         "takeDamage":                              "Schaden nehmen",
         "talentCategory":                          "Talent Kategorie"
@@ -1811,6 +1823,8 @@
         "firstDisciplineViaCharGen":               "Erste Disziplin kann nur während der Charaktererstellung erlernt werden",
         "grimoireAddAlreadyInGrimoire":            "Der Zauber ist bereits im Grimoire enthalten.",
         "livingArmorOnly":                         "Es kann nur nur lebendige Rüstung getragen werden.",
+        "matrixBrokenCannotWeave":                 "Die Matrix ist beschädigt und kann nicht benutzt werden.",
+        "noActiveSpellSelected":                   "Die Matrix hat keinen aktiven Zauber ausgewählt.",
         "noMoreClassLevelsToIncrease":             "Es gibt keine weiteren Ränge/Kreise, die erhöht werden können.",
         "noSourceTalent":                          "Kein Talent mit ED-ID {talentSourceEdid} gefunden",
         "noWeaponToAttackWith":                    "Keine Waffe zum Angreifen verfügbar :(",

--- a/lang/en.json
+++ b/lang/en.json
@@ -319,6 +319,8 @@
         "applyDamageTitle":                        "Assign the Damage to the Targets!",
         "applyEffect":                             "Assign Effect",
         "applyEffectTitle":                        "Assign the Effect to the Targets!",
+        "castSpell":                               "TODO: Add translation",
+        "castSpellTitle":                          "TODO: Add translation",
         "rollDamage":                              "Roll Damage",
         "rollDamageTitle":                         "Roll for Damage",
         "rollEffect":                              "Roll Effect",
@@ -337,13 +339,17 @@
         "rollUnarmedDamage":                       "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "takeStrainDamage":                        "TODO: Add translation",
+        "threadWeaving":                           "TODO: Add translation",
         "undoDamage":                              "TODO: Add translation"
       },
       "Header": {
         "arbitraryTest":                           "arbitrary Test",
         "attackManeuvers":                         "TODO: Add translation",
         "attackReactions":                         "TODO: Add translation",
-        "attackTargets":                           "TODO: Add translation"
+        "attackTargets":                           "TODO: Add translation",
+        "extraThreads":                            "TODO: Add translation",
+        "numThreadsJustWoven":                     "TODO: Add translation",
+        "numThreadsWovenTotal":                    "TODO: Add translation"
       }
     },
     "Conditions": {
@@ -1492,6 +1498,7 @@
         "activeUser":                              "Active User",
         "actorsNoUserConfigured":                  "Not Configured, Owned Actors",
         "attuneOnTheFly":                          "TODO: Add translation",
+        "fieldsetExtraThreads":                    "TODO: Add translation",
         "inactiveUser":                            "Inactive User",
         "update":                                  "TODO: Add translation"
       },
@@ -1586,6 +1593,9 @@
         "step":                                    "Step",
         "strain":                                  "Strain"
       },
+      "SelectExtraThreads": {
+        "selectedXofYthreads":                     "TODO: Add translation"
+      },
       "Sorting": {
         "item":                                    "TODO: Add translation",
         "sortBy":                                  "TODO: Add translation",
@@ -1596,6 +1606,7 @@
         "assignLp":                                "TODO: Add translation",
         "attributeIncrease":                       "TODO: Add translation",
         "attuneMatrix":                            "TODO: Add translation",
+        "buttonSelect":                            "TODO: Add translation",
         "characterGeneration":                     "TODO: Add translation",
         "chooseDiscipline":                        "TODO: Add translation",
         "chooseTier":                              "TODO: Add translation",
@@ -1609,6 +1620,7 @@
         "lpLearnKnack":                            "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
+        "selectExtraThreads":                      "TODO: Add translation",
         "startRoundCombatantPrompt":               "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation"
@@ -1762,6 +1774,8 @@
         "firstDisciplineViaCharGen":               "TODO: Add translation",
         "grimoireAddAlreadyInGrimoire":            "TODO: Add translation",
         "livingArmorOnly":                         "This namegiver can only wear living armor.",
+        "matrixBrokenCannotWeave":                 "TODO: Add translation",
+        "noActiveSpellSelected":                   "TODO: Add translation",
         "noMoreClassLevelsToIncrease":             "TODO: Add translation",
         "noSourceTalent":                          "TODO: Add translation",
         "noWeaponToAttackWith":                    "TODO: Add translation",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -318,6 +318,8 @@
         "applyDamageTitle":                        "TODO: Add translation",
         "applyEffect":                             "TODO: Add translation",
         "applyEffectTitle":                        "TODO: Add translation",
+        "castSpell":                               "TODO: Add translation",
+        "castSpellTitle":                          "TODO: Add translation",
         "rollDamage":                              "TODO: Add translation",
         "rollDamageTitle":                         "TODO: Add translation",
         "rollEffect":                              "TODO: Add translation",
@@ -336,13 +338,17 @@
         "rollUnarmedDamage":                       "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "takeStrainDamage":                        "TODO: Add translation",
+        "threadWeaving":                           "TODO: Add translation",
         "undoDamage":                              "TODO: Add translation"
       },
       "Header": {
         "arbitraryTest":                           "TODO: Add translation",
         "attackManeuvers":                         "TODO: Add translation",
         "attackReactions":                         "TODO: Add translation",
-        "attackTargets":                           "TODO: Add translation"
+        "attackTargets":                           "TODO: Add translation",
+        "extraThreads":                            "TODO: Add translation",
+        "numThreadsJustWoven":                     "TODO: Add translation",
+        "numThreadsWovenTotal":                    "TODO: Add translation"
       }
     },
     "Conditions": {
@@ -1491,6 +1497,7 @@
         "activeUser":                              "TODO: Add translation",
         "actorsNoUserConfigured":                  "TODO: Add translation",
         "attuneOnTheFly":                          "TODO: Add translation",
+        "fieldsetExtraThreads":                    "TODO: Add translation",
         "inactiveUser":                            "TODO: Add translation",
         "update":                                  "TODO: Add translation"
       },
@@ -1585,6 +1592,9 @@
         "step":                                    "TODO: Add translation",
         "strain":                                  "TODO: Add translation"
       },
+      "SelectExtraThreads": {
+        "selectedXofYthreads":                     "TODO: Add translation"
+      },
       "Sorting": {
         "item":                                    "TODO: Add translation",
         "sortBy":                                  "TODO: Add translation",
@@ -1595,6 +1605,7 @@
         "assignLp":                                "TODO: Add translation",
         "attributeIncrease":                       "TODO: Add translation",
         "attuneMatrix":                            "TODO: Add translation",
+        "buttonSelect":                            "TODO: Add translation",
         "characterGeneration":                     "TODO: Add translation",
         "chooseDiscipline":                        "TODO: Add translation",
         "chooseTier":                              "TODO: Add translation",
@@ -1608,6 +1619,7 @@
         "lpLearnKnack":                            "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
+        "selectExtraThreads":                      "TODO: Add translation",
         "startRoundCombatantPrompt":               "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation"
@@ -1761,6 +1773,8 @@
         "firstDisciplineViaCharGen":               "TODO: Add translation",
         "grimoireAddAlreadyInGrimoire":            "TODO: Add translation",
         "livingArmorOnly":                         "TODO: Add translation",
+        "matrixBrokenCannotWeave":                 "TODO: Add translation",
+        "noActiveSpellSelected":                   "TODO: Add translation",
         "noMoreClassLevelsToIncrease":             "TODO: Add translation",
         "noSourceTalent":                          "TODO: Add translation",
         "noWeaponToAttackWith":                    "TODO: Add translation",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -318,6 +318,8 @@
         "applyDamageTitle":                        "TODO: Add translation",
         "applyEffect":                             "TODO: Add translation",
         "applyEffectTitle":                        "TODO: Add translation",
+        "castSpell":                               "TODO: Add translation",
+        "castSpellTitle":                          "TODO: Add translation",
         "rollDamage":                              "TODO: Add translation",
         "rollDamageTitle":                         "TODO: Add translation",
         "rollEffect":                              "TODO: Add translation",
@@ -336,13 +338,17 @@
         "rollUnarmedDamage":                       "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "takeStrainDamage":                        "TODO: Add translation",
+        "threadWeaving":                           "TODO: Add translation",
         "undoDamage":                              "TODO: Add translation"
       },
       "Header": {
         "arbitraryTest":                           "TODO: Add translation",
         "attackManeuvers":                         "TODO: Add translation",
         "attackReactions":                         "TODO: Add translation",
-        "attackTargets":                           "TODO: Add translation"
+        "attackTargets":                           "TODO: Add translation",
+        "extraThreads":                            "TODO: Add translation",
+        "numThreadsJustWoven":                     "TODO: Add translation",
+        "numThreadsWovenTotal":                    "TODO: Add translation"
       }
     },
     "Conditions": {
@@ -1491,6 +1497,7 @@
         "activeUser":                              "TODO: Add translation",
         "actorsNoUserConfigured":                  "TODO: Add translation",
         "attuneOnTheFly":                          "TODO: Add translation",
+        "fieldsetExtraThreads":                    "TODO: Add translation",
         "inactiveUser":                            "TODO: Add translation",
         "update":                                  "TODO: Add translation"
       },
@@ -1585,6 +1592,9 @@
         "step":                                    "TODO: Add translation",
         "strain":                                  "TODO: Add translation"
       },
+      "SelectExtraThreads": {
+        "selectedXofYthreads":                     "TODO: Add translation"
+      },
       "Sorting": {
         "item":                                    "TODO: Add translation",
         "sortBy":                                  "TODO: Add translation",
@@ -1595,6 +1605,7 @@
         "assignLp":                                "TODO: Add translation",
         "attributeIncrease":                       "TODO: Add translation",
         "attuneMatrix":                            "TODO: Add translation",
+        "buttonSelect":                            "TODO: Add translation",
         "characterGeneration":                     "TODO: Add translation",
         "chooseDiscipline":                        "TODO: Add translation",
         "chooseTier":                              "TODO: Add translation",
@@ -1608,6 +1619,7 @@
         "lpLearnKnack":                            "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
+        "selectExtraThreads":                      "TODO: Add translation",
         "startRoundCombatantPrompt":               "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation"
@@ -1761,6 +1773,8 @@
         "firstDisciplineViaCharGen":               "TODO: Add translation",
         "grimoireAddAlreadyInGrimoire":            "TODO: Add translation",
         "livingArmorOnly":                         "TODO: Add translation",
+        "matrixBrokenCannotWeave":                 "TODO: Add translation",
+        "noActiveSpellSelected":                   "TODO: Add translation",
         "noMoreClassLevelsToIncrease":             "TODO: Add translation",
         "noSourceTalent":                          "TODO: Add translation",
         "noWeaponToAttackWith":                    "TODO: Add translation",

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -24,7 +24,7 @@ export default class DialogEd extends foundry.applications.api.DialogV2 {
   static async waitButtonSelect( items, buttonClass, config = {} ) {
     return this.wait( {
       rejectClose: false,
-      id:          "ed-button-select",
+      id:          "ed-button-select-{id}",
       uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
       classes:     [ "ed-button-select" ],
       window:      {

--- a/module/applications/api/dialog.mjs
+++ b/module/applications/api/dialog.mjs
@@ -1,3 +1,5 @@
+
+
 /**
  * @augments DialogV2
  */
@@ -11,5 +13,47 @@ export default class DialogEd extends foundry.applications.api.DialogV2 {
       height: "auto",
     },
   };
+
+  /**
+   * Create a simple dialog for choosing from a list of options, represented as buttons.
+   * @param {ItemEd[]|string[]} items The items to choose from, either as ItemEd instances or a list of their UUIDs.
+   * @param {string} [buttonClass] The class to apply to the buttons.
+   * @param {Partial<ApplicationConfiguration & DialogV2Configuration & DialogV2WaitOptions>} [config] Configuration options for the dialog.
+   * @returns {Promise<any>} Resolves to the UUID of the selected item. If the dialog was dismissed, and rejectClose is false, the Promise resolves to null.
+   */
+  static async waitButtonSelect( items, buttonClass, config = {} ) {
+    return this.wait( {
+      rejectClose: false,
+      id:          "ed-button-select",
+      uniqueId:    String( ++foundry.applications.api.ApplicationV2._appId ),
+      classes:     [ "ed-button-select" ],
+      window:      {
+        title:       game.i18n.localize( "ED.Dialogs.Title.buttonSelect" ),
+        minimizable: false,
+      },
+      modal:       false,
+      buttons:     this.createItemButtons( items, buttonClass ),
+      ...config,
+    } );
+  }
+
+  /**
+   * Create buttons for a list of items, typically used in item selection dialogs.
+   * @param {ItemEd[]|string[]} items The items to choose from, either as ItemEd instances or a list of their UUIDs.
+   * @param {string} buttonClass - The class to use for the buttons.
+   * @returns {DialogV2Button[]} An array of button objects. The action is the item's UUID.
+   */
+  static createItemButtons( items, buttonClass = "ed-button" ) {
+    const itemsList = items?.[0]?.system ? items : items.map( uuid => fromUuidSync( uuid ) );
+    return itemsList.map( item => {
+      return {
+        action:  item.uuid,
+        label:   item.name,
+        icon:    item.img,
+        class:   `button-${ item.system[ buttonClass ] } ${ item.name }`,
+        default: false,
+      };
+    } );
+  }
 
 }

--- a/module/applications/workflow/_module.mjs
+++ b/module/applications/workflow/_module.mjs
@@ -1,1 +1,2 @@
 export { default as AttuneMatrixPrompt } from "./attune-matrix-prompt.mjs";
+export { default as SelectExtraThreadsPrompt } from "./select-extra-threads-prompt.mjs";

--- a/module/applications/workflow/select-extra-threads-prompt.mjs
+++ b/module/applications/workflow/select-extra-threads-prompt.mjs
@@ -1,0 +1,186 @@
+import ApplicationEd from "../api/application.mjs";
+import { ED4E } from "../../../earthdawn4e.mjs";
+
+export default class SelectExtraThreadsPrompt extends ApplicationEd {
+
+  /** @inheritdoc */
+  static DEFAULT_OPTIONS = {
+    id:       "select-extra-threads-prompt-{id}",
+    uniqueId: String( ++foundry.applications.api.ApplicationV2._appId ),
+    classes:  [ "select-extra-threads-prompt", ],
+    form:     {
+      closeOnSubmit:  false,
+      submitOnChange: true,
+    },
+    actions:  {
+      continue: SelectExtraThreadsPrompt._continue,
+    },
+    window:   {
+      title: "ED.Dialogs.Title.selectExtraThreads",
+    },
+  };
+
+  /** @inheritdoc */
+  static PARTS = {
+    main: {
+      template: "systems/ed4e/templates/workflow/select-extra-threads.hbs",
+    },
+    footer: {
+      template: "templates/generic/form-footer.hbs",
+    },
+  };
+
+  // region Properties
+
+  /**
+   * The spell to which extra threads are being added.
+   * @type {ItemEd}
+   */
+  #spell;
+
+  /**
+   * The actor casting the spell.
+   * @type {ActorEd}
+   */
+  #caster;
+
+  /**
+   * The discipline of the actor for the spell being cast.
+   */
+  #discipline;
+
+  /**
+   * The maximum number of extra threads that can be selected.
+   * @type {number}
+   */
+  #maxExtraThreads;
+
+  /**
+   * The data fields for the options of extra threads to select from.
+   * @type {DataField[]}
+   */
+  #optionsDataFields = [];
+
+  /**
+   * The number of extra threads that have been chosen.
+   * @type {number}
+   */
+  get #numSelectedThreads() {
+    return this._data.extraThreads.length;
+  }
+
+  // endregion
+
+  constructor( { spell, caster, ...options } ) {
+    super( options );
+
+    this.#spell = spell;
+    this.#caster = caster;
+    this.#discipline = this.#caster.getDisciplineForSpellcastingType( this.#spell.system.spellcastingType );
+    this.#maxExtraThreads = this.#getMaxExtraThreads();
+    this.#optionsDataFields = this.#createOptionsDataFields();
+
+    this._data.extraThreads = [];
+  }
+
+  /**
+   * Creates new data fields to be used for form inputs. They represent the options of
+   * extra threads that can be selected.
+   * @returns {DataField[]} An array of data fields representing the options for extra threads.
+   */
+  #createOptionsDataFields() {
+    const fields = foundry.data.fields;
+
+    const choices = Object.fromEntries(
+      this.#spell.system.extraThreads.map( ( ( enhancement, index ) => [
+        index,
+        enhancement.summaryString,
+      ] )
+      ) );
+
+    const options = [];
+    for ( let i = 1; i <= this.#maxExtraThreads; i++ ) {
+      const optionField = new fields.StringField(
+        {
+          // don't need a label here, as we expect to only use it as form input
+          required: true,
+          nullable: true,
+          initial:  null,
+          blank:    false,
+          trim:     true,
+          choices:  choices,
+        }, {
+          name:     `extraThreads.${i - 1}`,
+        } );
+      options.push( optionField );
+    }
+
+    return options;
+  }
+
+  /**
+   * Gets the maximum number of extra threads that can be selected. This is based
+   * on the caster's circle in the discipline of the spell being cast.
+   * @returns {number} The maximum number of extra threads that can be selected.
+   */
+  #getMaxExtraThreads() {
+    return ED4E.extraThreadsByCircle[ this.#discipline?.system?.level || 0 ] || 0;
+  }
+
+  // region Rendering
+
+  /** @inheritdoc */
+  async _preparePartContext( partId, context, options ) {
+    const newContext = await super._preparePartContext( partId, context, options );
+
+    switch ( partId ) {
+      case "main": {
+        newContext.spell = this.#spell;
+        newContext.caster = this.#caster;
+        newContext.discipline = this.#discipline;
+        newContext.maxExtraThreads = this.#maxExtraThreads;
+        newContext.numSelected = this.#numSelectedThreads;
+        newContext.optionFields = this.#optionsDataFields;
+        break;
+      }
+      case "footer": {
+        newContext.buttons = [
+          this.constructor.BUTTONS.continue,
+        ];
+        break;
+      }
+      default: {
+        break;
+      }
+    }
+
+    return newContext;
+  }
+
+  // endregion
+
+  // region Form Handling
+
+  /** @inheritdoc */
+  _processSubmitData( event, form, formData, submitOptions ) {
+    const { extraThreads } = super._processSubmitData( event, form, formData, submitOptions );
+    return {
+      extraThreads: Object.values( extraThreads ).filter( e => !!e ).map( index => Number( index ) ),
+    };
+  }
+
+  // endregion
+
+  // region Event Handlers
+
+  /** @inheritdoc */
+  static async _continue( event, target ) {
+    this.submit();
+    this.resolve?.(
+      this.data.extraThreads.map( index => this.#spell.system.extraThreads[ index ] )
+    );
+    return this.close();
+  }
+
+  // endregion
+}

--- a/module/config/magic.mjs
+++ b/module/config/magic.mjs
@@ -53,6 +53,28 @@ preLocalize(
   { keys: [ "air", "earth", "fire", "water", "wood" ] }
 );
 
+/**
+ * The number of extra threads that can be added to a spell based on the circle of its corresponding discipline.
+ * @type {{ [circle: number]: number }}
+ */
+export const extraThreadsByCircle = {
+  1:  1,
+  2:  1,
+  3:  1,
+  4:  1,
+  5:  2,
+  6:  2,
+  7:  2,
+  8:  2,
+  9:  3,
+  10: 3,
+  11: 3,
+  12: 3,
+  13: 4,
+  14: 4,
+  15: 4,
+};
+
 export const matrixTypes = {
   "standard": {
     label:         "ED.Config.MatrixTypes.standard",

--- a/module/config/rolls.mjs
+++ b/module/config/rolls.mjs
@@ -103,7 +103,7 @@ export const rollTypes = {
   },
   threadWeaving: {
     label:            "ED.Config.RollTypes.threadWeaving",
-    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/threadWeaving-roll-flavor.hbs",
+    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/thread-weaving-roll-flavor.hbs",
   },
   jumpUp: {
     label:            "ED.Config.RollTypes.jumpUp",

--- a/module/data/common/metrics.mjs
+++ b/module/data/common/metrics.mjs
@@ -85,10 +85,6 @@ export class MetricData extends SparseDataModel {
     return this.unit === this.specialUnitKey;
   }
 
-  get hint() {
-    return this.constructor.hintKey( `MetricData.${this.constructor.TYPE}` );
-  }
-
   get scalarConfig() {
     return {};
   }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -366,7 +366,14 @@ export default class SpellData extends ItemDataModel.mixin(
           modifiers: {},
           public:    true,
         },
-        chatFlavor: game.i18n.format( "ED.Chat.Flavor.threadWeaving", { to: system.parent.name } ),
+        chatFlavor: game.i18n.format(
+          "ED.Chat.Flavor.threadWeaving",
+          {
+            sourceActor: await fromUuid( abilityRollOptions.rollingActorUuid ),
+            spell:       system.parent.name,
+            step:        abilityRollOptions.totalStep,
+          }
+        ),
         rollType:   "threadWeaving",
         spellUuid:  system.parent.uuid,
         threads:    {

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -7,6 +7,7 @@ import TargetTemplate from "./templates/targeting.mjs";
 import { AreaMetricData, DurationMetricData, MetricData, RangeMetricData } from "../common/metrics.mjs";
 
 
+const { fields } = foundry.data;
 
 /**
  * Data model template with information on Spell items.
@@ -26,10 +27,8 @@ export default class SpellData extends ItemDataModel.mixin(
 
   /** @inheritDoc */
   static defineSchema() {
-    const { ArrayField, EmbeddedDataField, NumberField, SchemaField, SetField, StringField, TypedSchemaField } = foundry.data.fields;
-
     return this.mergeSchema( super.defineSchema(), {
-      spellcastingType: new StringField( {
+      spellcastingType: new fields.StringField( {
         required: true,
         nullable: false,
         blank:    false,
@@ -37,7 +36,7 @@ export default class SpellData extends ItemDataModel.mixin(
         choices:  ED4E.spellcastingTypes,
         initial:  "elementalism",
       } ),
-      level: new NumberField( {
+      level: new fields.NumberField( {
         required: true,
         nullable: false,
         min:      1,
@@ -45,15 +44,15 @@ export default class SpellData extends ItemDataModel.mixin(
         integer:  true,
         positive: true,
       } ),
-      spellDifficulty:    new SchemaField( {
-        reattune: new NumberField( {
+      spellDifficulty:    new fields.SchemaField( {
+        reattune: new fields.NumberField( {
           required: true,
           nullable: false,
           min:      ED4E.minDifficulty,
           initial:  ( data ) => { return data.weaving + 5 || ED4E.minDifficulty; },
           integer:  true,
         } ),
-        weaving: new NumberField( {
+        weaving: new fields.NumberField( {
           required: true,
           nullable: false,
           min:      ED4E.minDifficulty,
@@ -61,22 +60,22 @@ export default class SpellData extends ItemDataModel.mixin(
           integer:  true,
         } ),
       } ),
-      threads: new SchemaField( {
-        required: new NumberField( {
+      threads: new fields.SchemaField( {
+        required: new fields.NumberField( {
           required: true,
           nullable: false,
           min:      0,
           initial:  0,
           integer:  true,
         } ),
-        woven: new NumberField( {
+        woven: new fields.NumberField( {
           required: true,
           nullable: false,
           min:      0,
           initial:  0,
           integer:  true,
         } ),
-        extra: new NumberField( {
+        extra: new fields.NumberField( {
           required: true,
           nullable: true,
           min:      0,
@@ -84,12 +83,12 @@ export default class SpellData extends ItemDataModel.mixin(
           integer:  true,
         } ),
       } ),
-      effect: new StringField( {
+      effect: new fields.StringField( {
         required: true,
         blank:    true,
         initial:  "",
       } ),
-      keywords: new SetField( new StringField( {
+      keywords: new fields.SetField( new fields.StringField( {
         required: true,
         nullable: false,
         blank:    false,
@@ -100,15 +99,15 @@ export default class SpellData extends ItemDataModel.mixin(
         nullable: false,
         initial:  [],
       } ),
-      element: new SchemaField( {
-        type: new StringField( {
+      element: new fields.SchemaField( {
+        type: new fields.StringField( {
           required: true,
           nullable: true,
           blank:    false,
           trim:     true,
           choices:  ED4E.elements,
         } ),
-        subtype: new StringField( {
+        subtype: new fields.StringField( {
           required: true,
           nullable: true,
           blank:    false,
@@ -124,13 +123,13 @@ export default class SpellData extends ItemDataModel.mixin(
         required: true,
         nullable: true,
       } ),
-      duration: new EmbeddedDataField( DurationMetricData, {
+      duration: new fields.EmbeddedDataField( DurationMetricData, {
       } ),
-      range:    new EmbeddedDataField( RangeMetricData, {
+      range:    new fields.EmbeddedDataField( RangeMetricData, {
       } ),
-      area: new EmbeddedDataField( AreaMetricData, {
+      area: new fields.EmbeddedDataField( AreaMetricData, {
       } ),
-      extraSuccess: new ArrayField( new TypedSchemaField( MetricData.TYPES, {
+      extraSuccess: new fields.ArrayField( new fields.TypedSchemaField( MetricData.TYPES, {
       } ),
       {
         required: true,
@@ -138,12 +137,17 @@ export default class SpellData extends ItemDataModel.mixin(
         initial:  [],
         max:      1,
       } ),
-      extraThreads: new ArrayField( new TypedSchemaField( MetricData.TYPES, {
+      extraThreads: new fields.ArrayField( new fields.TypedSchemaField( MetricData.TYPES, {
       } ),
       {
         required: true,
         nullable: true,
         initial:  [],
+      } ),
+      isWeaving: new fields.BooleanField( {
+        required: true,
+        nullable: false,
+        initial:  false,
       } ),
     } );
   }
@@ -168,9 +172,7 @@ export default class SpellData extends ItemDataModel.mixin(
     return undefined;
   }
 
-  /* -------------------------------------------- */
-  /*  Properties                                  */
-  /* -------------------------------------------- */
+  // region Properties
 
   /**
    * @description Whether this spell is an illusion and therefore can be sensed.
@@ -195,6 +197,12 @@ export default class SpellData extends ItemDataModel.mixin(
   get sensingDifficulty() {
     return this.isIllusion ? this.level + 15 : undefined;
   }
+
+  get totalRequiredThreads() {
+    return this.threads.required + ( this.threads.extra || 0 );
+  }
+
+  // endregion
 
   /* -------------------------------------------- */
   /*  LP Tracking                                 */

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -76,7 +76,13 @@ export default class SpellData extends ItemDataModel.mixin(
           initial:  0,
           integer:  true,
         } ),
-        extra: new NumberField( {} ),
+        extra: new NumberField( {
+          required: true,
+          nullable: true,
+          min:      0,
+          initial:  null,
+          integer:  true,
+        } ),
       } ),
       effect: new StringField( {
         required: true,

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -47,7 +47,6 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
       source: new fields.SchemaField( {
         class:   new fields.DocumentUUIDField( {
           type:     "Item",
-          embedded: true,
         } ),
         atLevel: new fields.NumberField( {
           required: false,

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -1,4 +1,3 @@
-import ClassTemplate from "./class.mjs";
 import TargetTemplate from "./targeting.mjs";
 import ActionTemplate from "./action.mjs";
 import ED4E from "../../../config/_module.mjs";
@@ -46,7 +45,10 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
         initial:  "",
       } ),
       source: new fields.SchemaField( {
-        class:   new fields.DocumentUUIDField( ClassTemplate ),
+        class:   new fields.DocumentUUIDField( {
+          type:     "Item",
+          embedded: true,
+        } ),
         atLevel: new fields.NumberField( {
           required: false,
           nullable: true,

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -164,6 +164,12 @@ export default class MatrixTemplate extends SystemDataModel {
   _prepareMatrixData( data ) {
     const edidMatrix = getSetting( "edidSpellMatrix" );
 
+    if ( !this.matrixHasMultipleSpells && this.matrixSpellUuid && !this.matrix.activeSpell ) {
+      // If the matrix has only one spell attuned, only that one
+      data.system.matrix ??= {};
+      data.system.matrix.activeSpell = this.matrixSpellUuid;
+    }
+
     if ( this._isBecomingMatrix( data, edidMatrix ) ) {
       this._setDefaultMatrixData( data );
     } else if ( this._isLosingMatrix( data, edidMatrix ) ) {

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -1,6 +1,8 @@
 import SystemDataModel from "../../abstract.mjs";
 import { ED4E } from "../../../../earthdawn4e.mjs";
 import { getSetting } from "../../../settings.mjs";
+import DialogEd from "../../../applications/api/dialog.mjs";
+import AttuneWorkflow from "../../../workflows/workflow/attune-workflow.mjs";
 
 
 const { fields } = foundry.data;
@@ -66,14 +68,15 @@ export default class MatrixTemplate extends SystemDataModel {
           }, {
             required:        true,
           } ),
-          woven: new fields.NumberField( {
-            required:        true,
-            initial:         0,
-            integer:         true,
-            min:             0,
-          } ),
         }, {
           required:        true,
+        } ),
+        activeSpell: new fields.DocumentUUIDField( {
+          type:     "Item",
+          embedded: true,
+          required: true,
+          nullable: true,
+          initial:  null,
         } ),
       }, {
         nullable:        true,
@@ -83,6 +86,14 @@ export default class MatrixTemplate extends SystemDataModel {
   }
 
   // region Properties
+
+  /**
+   * Whether this item has a matrix.
+   * @type {boolean}
+   */
+  get hasMatrix() {
+    return this.edid === getSetting( "edidSpellMatrix" );
+  }
 
   /**
    * Is this matrix broken and therefore cannot be used?
@@ -101,11 +112,11 @@ export default class MatrixTemplate extends SystemDataModel {
   }
 
   /**
-   * Whether this item has a matrix.
+   * Whether the matrix has a more than one spell attuned.
    * @type {boolean}
    */
-  get hasMatrix() {
-    return this.edid === getSetting( "edidSpellMatrix" );
+  get matrixHasMultipleSpells() {
+    return this.matrix?.spells?.size > 1;
   }
 
   /**
@@ -236,6 +247,8 @@ export default class MatrixTemplate extends SystemDataModel {
 
   // endregion
 
+  // region Methods
+
   /**
    * Checks if the matrix is attuned to a specific spell.
    * @param {string} spellUuid The UUID of the spell to check.
@@ -279,5 +292,68 @@ export default class MatrixTemplate extends SystemDataModel {
   _lookupMatrixMaxHoldThread( matrixType = "standard" ) {
     return ED4E.matrixTypes[ matrixType ].maxHoldThread;
   }
+
+  // region Spellcasting
+
+  /**
+   * Checks if threads can be woven into the matrix's spell.
+   * @returns {boolean} False if the matrix is broken, true otherwise.
+   */
+  canWeave() {
+    return !this.matrixBroken;
+  }
+
+  /**
+   * Gets the currently active spell for the matrix.
+   * @returns {Promise<Document|null>} The active spell document, or null if no active spell could be set.
+   */
+  async getActiveSpell() {
+    if ( !this.matrix.activeSpell ) await this.selectActiveSpell();
+    return fromUuid( this.matrix.activeSpell );
+  }
+
+  /**
+   * Whether there are currently threads being woven into the matrix.
+   * @returns {boolean} True if the containing spell is actively being woven threads to, false otherwise.
+   */
+  matrixIsWeaving() {
+    return fromUuidSync( this.matrix?.activeSpell )?.system?.isWeaving || false;
+  }
+
+  /**
+   * Selects the active spell for the matrix.
+   * @returns {Promise<boolean>} True if the active spell was successfully selected, false otherwise.
+   */
+  async selectActiveSpell() {
+    let newActiveSpell;
+    if ( this.matrixHasMultipleSpells ) {
+      newActiveSpell = await fromUuid( await DialogEd.waitButtonSelect( this.matrix.spells ) );
+      if ( !newActiveSpell ) {
+        ui.notifications.warn( game.i18n.localize( "ED.Notifications.Warn.noActiveSpellSelected" ) );
+        return false;
+      }
+    } else if ( this.matrixSpell ) {
+      newActiveSpell = this.matrixSpell;
+    } else {
+      // Not attuned, try to attune a spell
+      const attuneWorkflow = new AttuneWorkflow(
+        this.containingActor,
+        { firstMatrix: this.uuid },
+      );
+
+      // If the attune workflow is successful, try to select the active spell again
+      return ( await attuneWorkflow.execute() ) ? this.selectActiveSpell() : false;
+    }
+
+    const updated = await this.parent?.update( {
+      "system.matrix.activeSpell": newActiveSpell
+    } );
+
+    return !!updated;
+  }
+
+  // endregion
+
+  // endregion
 
 }

--- a/module/data/roll/_module.mjs
+++ b/module/data/roll/_module.mjs
@@ -4,3 +4,4 @@ export {default as AttackRollData} from "./attack.mjs";
 export {default as AttuningRollData} from "./attuning.mjs";
 export {default as DamageRollData} from "./damage.mjs";
 export {default as InitiativeRollData} from "./initiative.mjs";
+export {default as WeavingRollData} from "./weaving.mjs";

--- a/module/data/roll/weaving.mjs
+++ b/module/data/roll/weaving.mjs
@@ -1,0 +1,58 @@
+import EdRollOptions from "./common.mjs";
+
+export default class ThreadWeavingRollOptions extends EdRollOptions {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.ThreadWeavingRollOptions",
+  ];
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return this.mergeSchema( super.defineSchema(), {
+      spellUuid: new fields.DocumentUUIDField( {
+        type:     "Item",
+        embedded: true,
+      } ),
+      threads: new fields.SchemaField( {
+        required: new fields.NumberField( {
+          required: true,
+          nullable: false,
+          min:      0,
+          initial:  0,
+          integer:  true,
+        } ),
+        extra: new fields.NumberField( {
+          required: true,
+          nullable: false,
+          min:      0,
+          initial:  0,
+          integer:  true,
+        } ),
+      } ),
+    } );
+  }
+
+  /** @inheritDoc */
+  async getFlavorTemplateData( context ) {
+    const newContext = await super.getFlavorTemplateData( context );
+
+    newContext.spell = await fromUuid( this.spellUuid );
+    newContext.threads = this.threads;
+    newContext.threads.totalRequired = this.threads.required + this.threads.extra;
+    newContext.threads.woven = {
+      now: Math.min(
+        newContext.numSuccesses,
+        newContext.spell.system.missingThreads
+      ),
+    };
+    newContext.threads.woven.total = newContext.threads.woven.now + newContext.spell.system.threads.woven;
+    newContext.doneWeaving = newContext.threads.woven.total >= newContext.threads.totalRequired;
+    newContext.rollingActor = await fromUuid( this.rollingActorUuid );
+    newContext.rollingActorTokenDocument = await context.rollingActor?.getTokenDocument();
+
+    return newContext;
+  }
+
+}

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -18,6 +18,7 @@ import { AttuneWorkflow } from "../workflows/workflow/_module.mjs";
 import { getSetting } from "../settings.mjs";
 
 const futils = foundry.utils;
+const { TextEditor } = foundry.applications.ux;
 
 /**
  * Extend the base Actor class to implement additional system-specific logic.

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -15,6 +15,7 @@ import DamageRollOptions from "../data/roll/damage.mjs";
 import { typeMigrationConfig } from "./migration/actor/old-system-V082/_module.mjs";
 import AttackWorkflow from "../workflows/workflow/attack-workflow.mjs";
 import { AttuneWorkflow } from "../workflows/workflow/_module.mjs";
+import { getSetting } from "../settings.mjs";
 
 const futils = foundry.utils;
 
@@ -244,6 +245,22 @@ export default class ActorEd extends Actor {
         && item.system.rollTypeDetails?.attack?.weaponItemStatus.has( wieldingType )
         && item.system.difficulty?.target === armorType
     );
+  }
+
+  /**
+   * Returns the discipline item that is associated with the given spell's spellcasting type.
+   * @param {keyof typeof import("../config/magic.mjs").spellcastingTypes} spellcastingType The spellcasting type key (from config.spellcastingTypes).
+   * @returns {ItemEd|null} The discipline item, or null if none was found.
+   */
+  getDisciplineForSpellcastingType( spellcastingType ) {
+    const threadWeavingTalent = this.getItemsByEdid(
+      getSetting( "edidThreadWeaving" ),
+    ).find(
+      item => spellcastingType === item.system.rollTypeDetails?.threadWeaving?.castingType
+    );
+    if ( !threadWeavingTalent ) return null;
+
+    return fromUuidSync( threadWeavingTalent.system.source?.class );
   }
 
   /**

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -846,6 +846,7 @@ export async function preloadHandlebarsTemplates() {
     // chat buttons
     "systems/ed4e/templates/chat/chat-buttons/apply-damage.hbs",
     "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs",
+    "systems/ed4e/templates/chat/chat-buttons/cast-spell.hbs",
     "systems/ed4e/templates/chat/chat-buttons/roll-damage.hbs",
     "systems/ed4e/templates/chat/chat-buttons/roll-effect.hbs",
     "systems/ed4e/templates/chat/chat-buttons/take-damage.hbs",

--- a/module/workflows/workflow/attune-workflow.mjs
+++ b/module/workflows/workflow/attune-workflow.mjs
@@ -126,7 +126,7 @@ export default class AttuneWorkflow extends ActorWorkflow {
     // Notify the user
     ui.notifications.info( game.i18n.localize( "ED.Notifications.Info.ReattuningCancelled" ) );
 
-    this._result = true;
+    this._result = false;
   }
 
   /**
@@ -207,13 +207,14 @@ export default class AttuneWorkflow extends ActorWorkflow {
       };
     } );
 
+    let updatedDocuments;
     // Apply the updates if we have any
     if ( updates.length > 0 ) {
-      await this._actor.updateEmbeddedDocuments( "Item", updates );
+      updatedDocuments = await this._actor.updateEmbeddedDocuments( "Item", updates );
     }
 
     // Set the result to true to indicate success
-    this._result = true;
+    this._result = updatedDocuments?.length > 0;
   }
 
   // endregion

--- a/templates/chat/chat-buttons/cast-spell.hbs
+++ b/templates/chat/chat-buttons/cast-spell.hbs
@@ -1,0 +1,4 @@
+<button type="button" class="cast-spell" title="{{ localize "ED.Chat.Button.castSpellTitle" }}"
+    data-action="cast-spell">
+  {{ localize "ED.Chat.Button.castSpell" }}
+</button>

--- a/templates/chat/chat-flavor/thread-weaving-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/thread-weaving-roll-flavor.hbs
@@ -1,14 +1,44 @@
 <div class="custom-flavor">{{ customFlavor }}</div>
+
+<h4>{{ localize "ED.Chat.Header.numThreadsJustWoven" }}</h4>
+<div>
+  {{threads.woven.now}}
+</div>
+
+<h4>{{ localize "ED.Chat.Header.numThreadsWovenTotal" }}</h4>
+<div>
+  {{threads.woven.total}} / {{threads.totalRequired}}
+</div>
+
+<h4>{{ localize "ED.Chat.Header.extraThreads" }}</h4>
+<div class="extra-threads-list">
+  <ul class="unlist">
+    {{#each spell.system.threads.extra as |thread|}}
+        <li>
+          {{{thread.summaryString}}}
+        </li>
+    {{/each}}
+  </ul>
+</div>
+
+{{#if doneWeaving}}
+  {{> "systems/ed4e/templates/chat/chat-buttons/cast-spell.hbs"}}
+{{/if}}
+
+<!-- Rule of One Check -->
 {{#if (eq ruleOfOne true)}}
   <div class="roll-failure">{{localize "ED.Rolls.ruleOfOne"}}</div>
 {{else}}
-{{#if (ne target.total 0)}}
-{{> "systems/ed4e/templates/chat/dice-partials/roll-successes.hbs"}}
-{{/if}}
-<div class="modifier-lists flexrow">
-  {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
-  {{#if target.public}}
-    {{> "systems/ed4e/templates/chat/dice-partials/roll-target-modifier.hbs"}}
+
+  <!-- Modifier Lists -->
+  {{#if (ne target.total 0)}}
+    {{> "systems/ed4e/templates/chat/dice-partials/roll-successes.hbs"}}
   {{/if}}
-</div>
+
+  <div class="modifier-lists flexrow">
+    {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
+    {{#if target.public}}
+      {{> "systems/ed4e/templates/chat/dice-partials/roll-target-modifier.hbs"}}
+    {{/if}}
+  </div>
 {{/if}}

--- a/templates/workflow/select-extra-threads.hbs
+++ b/templates/workflow/select-extra-threads.hbs
@@ -1,0 +1,18 @@
+<div>
+
+  <div>
+    {{localize "ED.Dialogs.SelectExtraThreads.selectedXofYthreads" numSelected maxExtraThreads}}
+  </div>
+
+  <fieldset class="extra-threads">
+    <legend>{{localize "ED.Dialogs.Header.fieldsetExtraThreads"}}</legend>
+    {{#each optionFields}}
+      {{formInput
+        this
+        name=this.name
+        value=(lookup (lookup ../data "extraThreads") @index)
+      }}
+    {{/each}}
+  </fieldset>
+
+</div>


### PR DESCRIPTION
# Description
This pull request introduces the foundational logic for spell threadweaving, including methods for weaving, resetting, and stopping threads on spells. The SpellData model is extended with additional schema fields, computed properties, and workflow methods to support threadweaving mechanics, spell learning, and related game logic.
This update also improves validation, localization, and integration with prompts and roll workflows.

# Test
A simple test would be to create a character, with a detailed spell (including extra threads choices) and a corresponding thread weaving talent (and an optional matrix, only relevant for matrix held threads).
Then call from the console:
`await spell.system.weaveThreads( threadWeavingItem, matrixItemIfAny)`
