### PR TITLE
Attune Grimoire Workflow

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -328,8 +328,8 @@
         "takeDamageTitle":                         "Füge den Schaden deinem zugewiesenen Charakter zu"
       },
       "Flavor": {
-        "AttuningRollOptions":                     "{actor} versucht ''{attuningItem}'' und benutzt dafür {attuningAbility}",
         "actorTookDamage":                         "{dealtTo} hat Schaden erlitten.",
+        "attuningRollOptions":                     "{sourceActor} versucht ''{attuningItem}'' und benutzt dafür {attuningAbility}",
         "jumpUp":                                  "{sourceActor} versucht aufzuspringen mit Stufe {step}.",
         "knockdownTest":                           "{sourceActor} macht eine Niederschlagsprobe mit Stufe {step}.",
         "rollAbility":                             "{sourceActor} würfelt {ability} ({step})",
@@ -1435,8 +1435,8 @@
               }
             },
             "edid": {
-              "hint":                              "Eindeutige ID des Items",
-              "label":                             "ID"
+              "hint":                              "Eindeutige ID die das Item im Earthdawn-System identifiziert",
+              "label":                             "ED-ID"
             },
             "summary": {
               "value": {
@@ -1503,6 +1503,10 @@
         "Grimoire": {
           "FIELDS": {
             "grimoire": {
+              "attunedSpell": {
+                "hint":                            "Zauber der in diesem Grimoire abgestimmt ist",
+                "label":                           "Abgestimmter Zauber"
+              },
               "owner": {
                 "hint":                            "Besitzer des Grimoires",
                 "label":                           "Besitzer"
@@ -2938,6 +2942,9 @@
         "lpDescription":                           "Beschreibung der Legendenprämie"
       },
       "RollPrompt": {
+        "Title": {
+          "attuneGrimoire":                        "Struktur Verstehen um Grimoire abzustimmen"
+        },
         "devotion":                                "Weihepunkt",
         "devotionStep":                            "Weihepunkt Stufe",
         "difficulty":                              "Schwierigkeit",
@@ -2975,6 +2982,8 @@
         "recovery":                                "Erholung",
         "rollPrompt":                              "Würfel Dialog",
         "selectExtraThreads":                      "Wähle zusätzliche Fäden",
+        "selectGrimoireToAttune":                  "Wähle Grimoire zum Abstimmen",
+        "selectSpellToAttuneToGrimoire":           "Wähle Zauber mit dem das Grimoire abgestimmt wird",
         "startRoundCombatantPrompt":               "Rundenstart: Kampfbeteiligte",
         "takeDamage":                              "Schaden nehmen",
         "talentCategory":                          "Talent Kategorie"
@@ -3027,8 +3036,8 @@
         "deleteLevel":                             "Lösche Stufe"
       },
       "Grimoire": {
-        "noSpells":                                "Keine Zauber verfügbar",
-        "otherGrimoire":                           "Andere Grimoire",
+        "noSpells":                                "Keine Zauber in diesem Grimoire. Ziehe Zauber hierher um sie dem Grimoire hinzuzufügen.",
+        "otherGrimoire":                           "Nicht das eigene Grimoire ",
         "ownGrimoire":                             "Eigenes Grimoire"
       },
       "Header": {
@@ -3105,12 +3114,19 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "Der Actor ist ein Singleton. Es kann nur eine Instanz dieses Actors geben.",
+        "attuneAbilityNotFound":                   "",
         "formulaMalformedError":                   "Die Formel ist fehlerhaft. Bitte überprüfe die Formel.",
         "formulaMissingReferenceWarn":             "Die Formel verweist auf eine nicht existierende Referenz {missingReferences}. Bitte überprüfe die Formel.",
         "grimoireAddNotAGrimoire":                 "Das Item ist kein Grimoire. Bitte überprüfe das Item.",
         "grimoireAddNotASpell":                    "Das Item ist kein Zauber. Bitte überprüfe das Item.",
+        "grimoireAttuneAbilityNotFound":           "Struktur Verstehen Fähigkeit nicht gefunden. Die ist notwendig um ein Grimoire abzustimmen.",
+        "grimoireSetActiveNotAGrimoire":           "Das Item ist kein Grimoire. Hier kann kein Zauber abgestimmt werden.",
+        "grimoireSetActiveNotASpell":              "Das Item ist kein Zauber. Das Grimoire kann nicht abgestimmt werden.",
+        "grimoireSetActiveNotInGrimoire":          "Der Zauber ist nicht im Grimoire enthalten. Es kann nicht abgestimmt werden.",
         "identifierError":                         "Der Identifikator ist fehlerhaft. Bitte überprüfe den Identifikator.",
         "invalidElementSubtype":                   "Der Element Untertyp ist ungültig. Bitte überprüfe den Untertyp.",
+        "noGrimoiresAvailableToAttune":            "Es sind keine Grimoire verfügbar, die abgestimmt werden können.",
+        "noSpellsAvailableToAttune":               "Das Grimoire enthält keine Zauber, die abgestimmt werden können.",
         "singleton":                               "Der Actor ist ein Singleton. Es kann nur eine Instanz dieses Actors geben."
       },
       "Info": {
@@ -3142,6 +3158,7 @@
         "notImplementedYet":                       "Diese Funktion ist noch nicht implementiert.",
         "piecemealArmorSizeExceeded":              "Maximale Menge an stückweiser Rüstung erreicht. Leg andere Teile ab um das neue Stück auszurüsten.",
         "questorItemNotUpdated":                   "Questor-Item konnte nicht aktualisiert werden",
+        "spellAlreadyAttunedInGrimoire":           "Der Zauber ist bereits im Grimoire abgestimmt.",
         "warningEffectNoActor":                    "Der Effekt hat keinen Actor zugewiesen. Bitte weise einen Actor zu."
       }
     },
@@ -3152,6 +3169,7 @@
         "effectTestRoll":                          "Effektprobe"
       },
       "Modifiers": {
+        "grimoirePenalty":                         "Fremdes Grimoire",
         "stunRecoveryWillpower":                   "Willenskraft"
       },
       "baseValue":                                 "Basis Stufe",

--- a/lang/en.json
+++ b/lang/en.json
@@ -329,8 +329,8 @@
         "takeDamageTitle":                         "TODO: Add translation"
       },
       "Flavor": {
-        "AttuningRollOptions":                     "TODO: Add translation",
         "actorTookDamage":                         "TODO: Add translation",
+        "attuningRollOptions":                     "TODO: Add translation",
         "jumpUp":                                  "TODO: Add translation",
         "knockdownTest":                           "TODO: Add translation",
         "rollAbility":                             "TODO: Add translation",
@@ -1491,6 +1491,10 @@
         "Grimoire": {
           "FIELDS": {
             "grimoire": {
+              "attunedSpell": {
+                "hint":                            "TODO: Add translation",
+                "label":                           "TODO: Add translation"
+              },
               "owner": {
                 "hint":                            "TODO: Add translation",
                 "label":                           "TODO: Add translation"
@@ -2922,6 +2926,9 @@
         "lpDescription":                           "Enter your description here"
       },
       "RollPrompt": {
+        "Title": {
+          "attuneGrimoire":                        "TODO: Add translation"
+        },
         "devotion":                                "Devotion",
         "devotionStep":                            "Devotion Step",
         "difficulty":                              "Difficulty",
@@ -2959,6 +2966,8 @@
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
         "selectExtraThreads":                      "TODO: Add translation",
+        "selectGrimoireToAttune":                  "TODO: Add translation",
+        "selectSpellToAttuneToGrimoire":           "TODO: Add translation",
         "startRoundCombatantPrompt":               "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation"
@@ -3089,12 +3098,19 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "TODO: Add translation",
+        "attuneAbilityNotFound":                   "TODO: Add translation",
         "formulaMalformedError":                   "TODO: Add translation",
         "formulaMissingReferenceWarn":             "TODO: Add translation",
         "grimoireAddNotAGrimoire":                 "TODO: Add translation",
         "grimoireAddNotASpell":                    "TODO: Add translation",
+        "grimoireAttuneAbilityNotFound":           "TODO: Add translation",
+        "grimoireSetActiveNotAGrimoire":           "TODO: Add translation",
+        "grimoireSetActiveNotASpell":              "TODO: Add translation",
+        "grimoireSetActiveNotInGrimoire":          "TODO: Add translation",
         "identifierError":                         "TODO: Add translation",
         "invalidElementSubtype":                   "TODO: Add translation",
+        "noGrimoiresAvailableToAttune":            "TODO: Add translation",
+        "noSpellsAvailableToAttune":               "TODO: Add translation",
         "singleton":                               "TODO: Add translation"
       },
       "Info": {
@@ -3126,6 +3142,7 @@
         "notImplementedYet":                       "TODO: Add translation",
         "piecemealArmorSizeExceeded":              "Maximum amount of piecemeal armor reached. Unequip other parts to equip the new piece.",
         "questorItemNotUpdated":                   "TODO: Add translation",
+        "spellAlreadyAttunedInGrimoire":           "TODO: Add translation",
         "warningEffectNoActor":                    "TODO: Add translation"
       }
     },
@@ -3136,6 +3153,7 @@
         "effectTestRoll":                          "Effect Test"
       },
       "Modifiers": {
+        "grimoirePenalty":                         "TODO: Add translation",
         "stunRecoveryWillpower":                   "TODO: Add translation"
       },
       "baseValue":                                 "Base Step",
@@ -3199,8 +3217,6 @@
         "encumbranceHint":                         "TODO: Add translation"
       },
       "GameMechanics": {
-        "checkEnoughTestsOnRecovery":              "TODO: Add translation",
-        "checkEnoughTestsOnRecoveryHint":          "TODO: Add translation",
         "languages":                               "TODO: Add translation",
         "languagesHint":                           "TODO: Add translation",
         "minimumDifficulty":                       "TODO: Add translation",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -330,6 +330,7 @@
       "Flavor": {
         "AttuningRollOptions":                     "TODO: Add translation",
         "actorTookDamage":                         "TODO: Add translation",
+        "attuningRollOptions":                     "TODO: Add translation",
         "jumpUp":                                  "TODO: Add translation",
         "knockdownTest":                           "TODO: Add translation",
         "rollAbility":                             "TODO: Add translation",
@@ -1490,6 +1491,10 @@
         "Grimoire": {
           "FIELDS": {
             "grimoire": {
+              "attunedSpell": {
+                "hint":                            "TODO: Add translation",
+                "label":                           "TODO: Add translation"
+              },
               "owner": {
                 "hint":                            "TODO: Add translation",
                 "label":                           "TODO: Add translation"
@@ -2921,6 +2926,9 @@
         "lpDescription":                           "TODO: Add translation"
       },
       "RollPrompt": {
+        "Title": {
+          "attuneGrimoire":                        "TODO: Add translation"
+        },
         "devotion":                                "TODO: Add translation",
         "devotionStep":                            "TODO: Add translation",
         "difficulty":                              "TODO: Add translation",
@@ -2958,6 +2966,8 @@
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
         "selectExtraThreads":                      "TODO: Add translation",
+        "selectGrimoireToAttune":                  "TODO: Add translation",
+        "selectSpellToAttuneToGrimoire":           "TODO: Add translation",
         "startRoundCombatantPrompt":               "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation"
@@ -3088,12 +3098,19 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "TODO: Add translation",
+        "attuneAbilityNotFound":                   "TODO: Add translation",
         "formulaMalformedError":                   "TODO: Add translation",
         "formulaMissingReferenceWarn":             "TODO: Add translation",
         "grimoireAddNotAGrimoire":                 "TODO: Add translation",
         "grimoireAddNotASpell":                    "TODO: Add translation",
+        "grimoireAttuneAbilityNotFound":           "TODO: Add translation",
+        "grimoireSetActiveNotAGrimoire":           "TODO: Add translation",
+        "grimoireSetActiveNotASpell":              "TODO: Add translation",
+        "grimoireSetActiveNotInGrimoire":          "TODO: Add translation",
         "identifierError":                         "TODO: Add translation",
         "invalidElementSubtype":                   "TODO: Add translation",
+        "noGrimoiresAvailableToAttune":            "TODO: Add translation",
+        "noSpellsAvailableToAttune":               "TODO: Add translation",
         "singleton":                               "TODO: Add translation"
       },
       "Info": {
@@ -3125,6 +3142,7 @@
         "notImplementedYet":                       "TODO: Add translation",
         "piecemealArmorSizeExceeded":              "TODO: Add translation",
         "questorItemNotUpdated":                   "TODO: Add translation",
+        "spellAlreadyAttunedInGrimoire":           "TODO: Add translation",
         "warningEffectNoActor":                    "TODO: Add translation"
       }
     },
@@ -3135,6 +3153,7 @@
         "effectTestRoll":                          "TODO: Add translation"
       },
       "Modifiers": {
+        "grimoirePenalty":                         "TODO: Add translation",
         "stunRecoveryWillpower":                   "TODO: Add translation"
       },
       "baseValue":                                 "TODO: Add translation",
@@ -3198,8 +3217,6 @@
         "encumbranceHint":                         "TODO: Add translation"
       },
       "GameMechanics": {
-        "checkEnoughTestsOnRecovery":              "TODO: Add translation",
-        "checkEnoughTestsOnRecoveryHint":          "TODO: Add translation",
         "languages":                               "TODO: Add translation",
         "languagesHint":                           "TODO: Add translation",
         "minimumDifficulty":                       "TODO: Add translation",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -330,6 +330,7 @@
       "Flavor": {
         "AttuningRollOptions":                     "TODO: Add translation",
         "actorTookDamage":                         "TODO: Add translation",
+        "attuningRollOptions":                     "TODO: Add translation",
         "jumpUp":                                  "TODO: Add translation",
         "knockdownTest":                           "TODO: Add translation",
         "rollAbility":                             "TODO: Add translation",
@@ -1490,6 +1491,10 @@
         "Grimoire": {
           "FIELDS": {
             "grimoire": {
+              "attunedSpell": {
+                "hint":                            "TODO: Add translation",
+                "label":                           "TODO: Add translation"
+              },
               "owner": {
                 "hint":                            "TODO: Add translation",
                 "label":                           "TODO: Add translation"
@@ -2921,6 +2926,9 @@
         "lpDescription":                           "TODO: Add translation"
       },
       "RollPrompt": {
+        "Title": {
+          "attuneGrimoire":                        "TODO: Add translation"
+        },
         "devotion":                                "TODO: Add translation",
         "devotionStep":                            "TODO: Add translation",
         "difficulty":                              "TODO: Add translation",
@@ -2958,6 +2966,8 @@
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
         "selectExtraThreads":                      "TODO: Add translation",
+        "selectGrimoireToAttune":                  "TODO: Add translation",
+        "selectSpellToAttuneToGrimoire":           "TODO: Add translation",
         "startRoundCombatantPrompt":               "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation"
@@ -3088,12 +3098,19 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "TODO: Add translation",
+        "attuneAbilityNotFound":                   "TODO: Add translation",
         "formulaMalformedError":                   "TODO: Add translation",
         "formulaMissingReferenceWarn":             "TODO: Add translation",
         "grimoireAddNotAGrimoire":                 "TODO: Add translation",
         "grimoireAddNotASpell":                    "TODO: Add translation",
+        "grimoireAttuneAbilityNotFound":           "TODO: Add translation",
+        "grimoireSetActiveNotAGrimoire":           "TODO: Add translation",
+        "grimoireSetActiveNotASpell":              "TODO: Add translation",
+        "grimoireSetActiveNotInGrimoire":          "TODO: Add translation",
         "identifierError":                         "TODO: Add translation",
         "invalidElementSubtype":                   "TODO: Add translation",
+        "noGrimoiresAvailableToAttune":            "TODO: Add translation",
+        "noSpellsAvailableToAttune":               "TODO: Add translation",
         "singleton":                               "TODO: Add translation"
       },
       "Info": {
@@ -3125,6 +3142,7 @@
         "notImplementedYet":                       "TODO: Add translation",
         "piecemealArmorSizeExceeded":              "TODO: Add translation",
         "questorItemNotUpdated":                   "TODO: Add translation",
+        "spellAlreadyAttunedInGrimoire":           "TODO: Add translation",
         "warningEffectNoActor":                    "TODO: Add translation"
       }
     },
@@ -3135,6 +3153,7 @@
         "effectTestRoll":                          "TODO: Add translation"
       },
       "Modifiers": {
+        "grimoirePenalty":                         "TODO: Add translation",
         "stunRecoveryWillpower":                   "TODO: Add translation"
       },
       "baseValue":                                 "TODO: Add translation",
@@ -3198,8 +3217,6 @@
         "encumbranceHint":                         "TODO: Add translation"
       },
       "GameMechanics": {
-        "checkEnoughTestsOnRecovery":              "TODO: Add translation",
-        "checkEnoughTestsOnRecoveryHint":          "TODO: Add translation",
         "languages":                               "TODO: Add translation",
         "languagesHint":                           "TODO: Add translation",
         "minimumDifficulty":                       "TODO: Add translation",

--- a/module/config/rolls.mjs
+++ b/module/config/rolls.mjs
@@ -61,6 +61,10 @@ export const rollTypes = {
     label:            "ED.Config.RollTypes.ability",
     flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/ability-roll-flavor.hbs",
   },
+  arbitrary: {
+    label:            "ED.Rolls.Labels.arbitraryTestRoll",
+    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/arbitrary-roll-flavor.hbs",
+  },
   attack: {
     label:            "ED.Config.RollTypes.attack",
     flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/attack-roll-flavor.hbs",

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -259,7 +259,7 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
     // update the learned talent with the new data
     await learnedItem.update( {
       "system.talentCategory":        category ?? learnedItem.system.talentCategory,
-      "system.source.class":          learnedItem.system.source?.class ?? discipline,
+      "system.source.class":          learnedItem.system.source?.class ?? discipline.uuid,
       "system.source.atLevel":        learnedItem.system.source?.atLevel ?? learnedAt,
     } );
     

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -2,7 +2,7 @@ import { ED4E } from "../../../../earthdawn4e.mjs";
 import { getSetting } from "../../../settings.mjs";
 import SystemDataModel from "../../abstract/system-data-model.mjs";
 import DialogEd from "../../../applications/api/dialog.mjs";
-import AttuneWorkflow from "../../../workflows/workflow/attune-workflow.mjs";
+import AttuneMatrixWorkflow from "../../../workflows/workflow/attune-matrix-workflow.mjs";
 
 
 const { fields } = foundry.data;
@@ -342,13 +342,13 @@ export default class MatrixTemplate extends SystemDataModel {
       newActiveSpell = this.matrixSpell;
     } else {
       // Not attuned, try to attune a spell
-      const attuneWorkflow = new AttuneWorkflow(
+      const attuneMatrixWorkflow = new AttuneMatrixWorkflow(
         this.containingActor,
         { firstMatrix: this.uuid },
       );
 
       // If the attune workflow is successful, try to select the active spell again
-      return ( await attuneWorkflow.execute() ) ? this.selectActiveSpell() : false;
+      return ( await attuneMatrixWorkflow.execute() ) ? this.selectActiveSpell() : false;
     }
 
     const updated = await this.parent?.update( {

--- a/module/data/roll/attuning.mjs
+++ b/module/data/roll/attuning.mjs
@@ -39,6 +39,9 @@ export default class AttuningRollOptions extends EdRollOptions {
           min:      1,
         },
       ),
+      grimoirePenalty: new fields.BooleanField( {
+        initial:  false,
+      } ),
     } );
   }
 
@@ -55,10 +58,13 @@ export default class AttuningRollOptions extends EdRollOptions {
   /** @inheritDoc */
   _prepareStepData( data ) {
     const ability = fromUuidSync( data.attuningAbility );
-    return {
+    const stepData = {
       base:      ability.system.rankFinal,
-      modifiers: {},
     };
+    stepData.modifiers = ( data.attuningType === "grimoire" && data.grimoirePenalty )
+      ? { [ game.i18n.localize( "ED.Rolls.Modifiers.grimoirePenalty" ) ]: -2 }
+      : {};
+    return stepData;
   }
 
   /** @inheritDoc */

--- a/module/data/roll/attuning.mjs
+++ b/module/data/roll/attuning.mjs
@@ -11,6 +11,12 @@ export default class AttuningRollOptions extends EdRollOptions {
     "ED.Data.Other.AttuningRollOptions",
   ];
 
+  /** @inheritdoc */
+  static TEST_TYPE = "action";
+
+  /** @inheritdoc */
+  static ROLL_TYPE = "attuning";
+
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
@@ -47,23 +53,7 @@ export default class AttuningRollOptions extends EdRollOptions {
   }
 
   /** @inheritDoc */
-  _initializeSource( data, options={} ) {
-    data.step ??= this._getStepData( data );
-    data.target ??= this._getTargetDifficulty( data );
-    data.strain ??= {
-      base: data.attuningType === "matrixOnTheFly" ? 1 : 0,
-    };
-    return super._initializeSource( data, options );
-  }
-
-  /**
-   * Retrieves step data based on the provided input data.
-   * @param {object} data The input data object containing relevant ability information.
-   * @param {string} data.attuningAbility The UUID of the ability with which to attune, "patterncraft" for grimoire,
-   *                                      "thread weaving" for matrix.
-   * @returns {object} An object containing the base rank and empty modifiers for the ability.
-   */
-  _getStepData( data ) {
+  _prepareStepData( data ) {
     const ability = fromUuidSync( data.attuningAbility );
     return {
       base:      ability.system.rankFinal,
@@ -71,13 +61,16 @@ export default class AttuningRollOptions extends EdRollOptions {
     };
   }
 
-  /**
-   * Calculates the target difficulty for an attuning roll.
-   * @param {object} data - The data object containing spell information.
-   * @param {Array<string>} data.spells - Array of spell UUIDs to be attuned.
-   * @returns {object} The target difficulty containing base and modifiers.
-   */
-  _getTargetDifficulty( data ) {
+  /** @inheritDoc */
+  _prepareStrainData( data ) {
+    return {
+      base:      data.attuningType === "matrixOnTheFly" ? 1 : 0,
+      modifiers: {},
+    };
+  }
+
+  /** @inheritDoc */
+  _prepareTargetDifficulty( data ) {
     return  {
       base:      0,
       modifiers: data.spellsToAttune?.reduce( ( acc, spellUuid ) => {
@@ -90,9 +83,9 @@ export default class AttuningRollOptions extends EdRollOptions {
 
   async _getChatFlavor() {
     return game.i18n.format(
-      "ED.Chat.Flavor.AttuningRollOptions",
+      "ED.Chat.Flavor.attuningRollOptions",
       {
-        actor:           createContentAnchor( await fromUuid( this.rollingActorUuid ) ).outerHTML,
+        sourceActor:     createContentAnchor( await fromUuid( this.rollingActorUuid ) ).outerHTML,
         attuningItem:    ED4E.attuningType[ this.attuningType ],
         attuningAbility: createContentAnchor( await fromUuid( this.attuningAbility ) ).outerHTML,
       },

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -76,7 +76,7 @@ export default class EdRollOptions extends SparseDataModel {
    * The type of test that this roll represents.
    * @type {string}
    */
-  static TEST_TYPE = "action";
+  static TEST_TYPE = "arbitrary";
 
   /**
    * The type of roll that this represents.
@@ -232,14 +232,14 @@ export default class EdRollOptions extends SparseDataModel {
         required: true,
         nullable: false,
         blank:    true,
-        initial:  "arbitrary",
+        initial:  "action",
         choices:  ED4E.ROLLS.testTypes,
       } ),
       rollType: new fields.StringField( {
         required: false,
         nullable: true,
         blank:    true,
-        initial:  "",
+        initial:  "arbitrary",
         choices:  ED4E.ROLLS.rollTypes,
       } ),
 

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -11,7 +11,7 @@ import SparseDataModel from "../abstract/sparse-data-model.mjs";
  */
 
 /**
- * @typedef { object} RollStepData Data for a roll step.
+ * @typedef { object } RollStepData Data for a roll step.
  * @property { number } base The base step that is used to determine the dice that are rolled.
  * @property { Record<string, number> } modifiers All modifiers that are applied to the base step.
  *                                              Keys are localized labels. Values are the modifier.
@@ -71,6 +71,18 @@ export default class EdRollOptions extends SparseDataModel {
     ...super.LOCALIZATION_PREFIXES,
     "ED.Data.Other.RollOptions",
   ];
+
+  /**
+   * The type of test that this roll represents.
+   * @type {string}
+   */
+  static TEST_TYPE = "action";
+
+  /**
+   * The type of roll that this represents.
+   * @type {string}
+   */
+  static ROLL_TYPE = "arbitrary";
 
   /** @inheritDoc */
   static defineSchema() {
@@ -285,6 +297,16 @@ export default class EdRollOptions extends SparseDataModel {
   }
 
   /** @inheritDoc */
+  _initializeSource( data, options = {} ) {
+    data.step ??= this._prepareStepData( data );
+    data.target ??= this._prepareTargetDifficulty( data );
+    data.strain ??= this._prepareStrainData( data );
+    data.testType ??= this.constructor.TEST_TYPE;
+    data.rollType ??= this.constructor.ROLL_TYPE;
+    return super._initializeSource( data, options );
+  }
+
+  /** @inheritDoc */
   updateSource( changes = {}, options = {} ) {
     const updates = super.updateSource(
       foundry.utils.mergeObject( changes, {
@@ -301,6 +323,33 @@ export default class EdRollOptions extends SparseDataModel {
 
   static initDiceForStep( parent ) {
     return getDice( parent.step.total ?? parent.step );
+  }
+
+  /**
+   * Used when initializing this data model. Retrieves step data based on the provided input data.
+   * @param {object} data The input data object containing relevant ability information.
+   * @returns {RollStepData} The step data object containing the base step and modifiers, if any.
+   */
+  _prepareStepData( data ) {
+    return {};
+  }
+
+  /**
+   * Used when initializing this data model. Prepares strain data based on the provided input data.
+   * @param {object} data - The input data object containing relevant information for strain calculation.
+   * @returns {RollStrainData} The strain data object containing the base strain and any modifiers.
+   */
+  _prepareStrainData( data ) {
+    return {};
+  }
+
+  /**
+   * Used when initializing this data model. Calculates the target difficulty for a roll based on the input data.
+   * @param {object} data - The data object with which this model is initialized.
+   * @returns {RollTargetData} The target difficulty containing base and modifiers.
+   */
+  _prepareTargetDifficulty( data ) {
+    return {};
   }
 
   /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -14,7 +14,7 @@ import ClassTemplate from "../data/item/templates/class.mjs";
 import DamageRollOptions from "../data/roll/damage.mjs";
 import { typeMigrationConfig } from "./migration/actor/old-system-V082/_module.mjs";
 import AttackWorkflow from "../workflows/workflow/attack-workflow.mjs";
-import { AttuneWorkflow } from "../workflows/workflow/_module.mjs";
+import { AttuneMatrixWorkflow } from "../workflows/workflow/_module.mjs";
 import { getSetting } from "../settings.mjs";
 import RollProcessor from "../services/roll-processor.mjs";
 import RecoveryWorkflow from "../workflows/workflow/recovery-workflow.mjs";
@@ -404,14 +404,14 @@ export default class ActorEd extends Actor {
    * @returns {Promise<any>} A promise that resolves when the attunement workflow execution is complete.
    */
   async reattuneSpells( matrixUuid ) {
-    const attuneWorkflow = new AttuneWorkflow(
+    const attuneMatrixWorkflow = new AttuneMatrixWorkflow(
       this,
       {
         firstMatrix: matrixUuid,
       },
     );
 
-    return attuneWorkflow.execute();
+    return attuneMatrixWorkflow.execute();
   }
 
   /**

--- a/module/workflows/workflow/_module.mjs
+++ b/module/workflows/workflow/_module.mjs
@@ -2,5 +2,5 @@ export { default as Workflow } from "./workflow.mjs";
 export { default as ItemWorkflow } from "./item-workflow.mjs";
 export { default as ActorWorkflow } from "./actor-workflow.mjs";
 export { default as AttackWorkflow } from "./attack-workflow.mjs";
-export { default as AttuneWorkflow } from "./attune-workflow.mjs";
+export { default as AttuneMatrixWorkflow } from "./attune-matrix-workflow.mjs";
 export { default as Rollable } from "./rollable.mjs";

--- a/module/workflows/workflow/_module.mjs
+++ b/module/workflows/workflow/_module.mjs
@@ -2,5 +2,6 @@ export { default as Workflow } from "./workflow.mjs";
 export { default as ItemWorkflow } from "./item-workflow.mjs";
 export { default as ActorWorkflow } from "./actor-workflow.mjs";
 export { default as AttackWorkflow } from "./attack-workflow.mjs";
+export { default as AttuneGrimoireWorkflow } from "./attune-grimoire-workflow.mjs";
 export { default as AttuneMatrixWorkflow } from "./attune-matrix-workflow.mjs";
 export { default as Rollable } from "./rollable.mjs";

--- a/module/workflows/workflow/actor-workflow.mjs
+++ b/module/workflows/workflow/actor-workflow.mjs
@@ -19,7 +19,7 @@ export default class ActorWorkflow extends Workflow {
    * @param {WorkflowOptions} [options] See {@link Workflow#constructor}.
    */
   constructor( actor, options = {} ) {
-    if ( ! ( actor instanceof ActorEd ) )
+    if ( !actor || ! ( actor instanceof ActorEd ) )
       throw new TypeError( "ActorWorkflow constructor expects an Actor instance." );
 
     super( options );

--- a/module/workflows/workflow/attune-grimoire-workflow.mjs
+++ b/module/workflows/workflow/attune-grimoire-workflow.mjs
@@ -72,7 +72,7 @@ export default class AttuneGrimoireWorkflow extends Rollable( ActorWorkflow ) {
         availableGrimoires,
         "ed-button-select-grimoire",
         {
-          title: game.i18n.localize( "ED.Dialogs.Title.selectGrimoire" ),
+          title: game.i18n.localize( "ED.Dialogs.Title.selectGrimoireToAttune" ),
         },
       )
     );
@@ -101,7 +101,7 @@ export default class AttuneGrimoireWorkflow extends Rollable( ActorWorkflow ) {
         availableSpells,
         "ed-button-select-spell",
         {
-          title: game.i18n.localize( "ED.Dialogs.Title.selectSpell" ),
+          title: game.i18n.localize( "ED.Dialogs.Title.selectSpellToAttuneToGrimoire" ),
         },
       )
     );

--- a/module/workflows/workflow/attune-grimoire-workflow.mjs
+++ b/module/workflows/workflow/attune-grimoire-workflow.mjs
@@ -1,0 +1,169 @@
+import Rollable from "./rollable.mjs";
+import ActorWorkflow from "./actor-workflow.mjs";
+import DialogEd from "../../applications/api/dialog.mjs";
+import WorkflowInterruptError from "../workflow-interrupt.mjs";
+import { getSetting } from "../../settings.mjs";
+import AttuningRollOptions from "../../data/roll/attuning.mjs";
+
+/**
+ * @typedef {object} AttuneGrimoireWorkflowOptions
+ * @property {ItemEd} [grimoire] - The grimoire to attune. If not provided, the user will be prompted to select a grimoire.
+ * @property {ItemEd} [spell] - The spell to attune to the grimoire. If not provided, the user will be prompted to select a spell.
+ */
+
+export default class AttuneGrimoireWorkflow extends Rollable( ActorWorkflow ) {
+
+  /**
+   * The patterncraft ability that is used to attune the grimoire.
+   * @type {ItemEd}
+   */
+  _attuneAbility;
+
+  /**
+   * The grimoire that is being attuned.
+   * @type {ItemEd}
+   */
+  _grimoire;
+
+  /**
+   * The spell that is being attuned to the grimoire.
+   * @type {ItemEd}
+   */
+  _spell;
+
+  /**
+   * @param {ActorEd} attuningActor - The actor that is reattuning the grimoire.
+   * @param {WorkflowOptions&AttuneGrimoireWorkflowOptions} options - The options for the attuning workflow.
+   */
+  constructor( attuningActor, options ) {
+    super( attuningActor, options );
+
+    this._rollPromptTitle = game.i18n.localize( "ED.Dialogs.RollPrompt.Title.attuneGrimoire" );
+
+    this._grimoire = options.grimoire || null;
+    this._spell = options.spell || null;
+
+    this._steps.push(
+      this.#selectGrimoire.bind( this ),
+      this.#selectSpell.bind( this ),
+      this.#findPatterncraftAbility.bind( this ),
+      this.#createRollOptions.bind( this ),
+      this._createRoll.bind( this ),
+      this._processRoll.bind( this ),
+      this._rollToChat.bind( this ),
+    );
+  }
+
+  // region Steps
+
+  async #selectGrimoire() {
+    if ( this._grimoire ) return;
+
+    const availableGrimoires = this._attuningActor.items.filter( item => item.isGrimoire );
+    if ( availableGrimoires.length === 0 ) {
+      throw new WorkflowInterruptError(
+        this,
+        game.i18n.localize( "ED.Notifications.Error.noGrimoiresAvailableToAttune" ),
+      );
+    }
+
+    const grimoire = await fromUuid(
+      await DialogEd.waitButtonSelect(
+        availableGrimoires,
+        "ed-button-select-grimoire",
+        {
+          title: game.i18n.localize( "ED.Dialogs.Title.selectGrimoire" ),
+        },
+      )
+    );
+
+    if ( !grimoire ) {
+      this.cancel();
+      return;
+    }
+
+    this._grimoire = grimoire;
+  }
+
+  async #selectSpell() {
+    if ( this._spell ) return;
+
+    const availableSpells = Array.from( this._grimoire.system.grimoire.spells );
+    if ( availableSpells.length === 0 ) {
+      throw new WorkflowInterruptError(
+        this,
+        game.i18n.localize( "ED.Notifications.Error.noSpellsAvailableToAttune" ),
+      );
+    }
+
+    const spell = await fromUuid(
+      await DialogEd.waitButtonSelect(
+        availableSpells,
+        "ed-button-select-spell",
+        {
+          title: game.i18n.localize( "ED.Dialogs.Title.selectSpell" ),
+        },
+      )
+    );
+
+    if ( !spell ) {
+      this.cancel();
+      return;
+    }
+
+    if ( spell.uuid === this._grimoire.system.grimoire.attunedSpell ) {
+      ui.notifications.warn(
+        game.i18n.localize( "ED.Notifications.Warn.spellAlreadyAttunedInGrimoire" ),
+      );
+      this.cancel();
+      return;
+    }
+
+    this._spell = spell;
+  }
+
+  async #findPatterncraftAbility() {
+    if ( this._attuneAbility ) return;
+
+    this._attuneAbility = this._actor.getSingleItemByEdid(
+      getSetting( "edidPatterncraft" ),
+    );
+    if ( !this._attuneAbility ) {
+      throw new WorkflowInterruptError(
+        this,
+        game.i18n.localize( "ED.Notifications.Error.grimoireAttuneAbilityNotFound" ),
+      );
+    }
+  }
+
+  async #createRollOptions() {
+    this._rollOptions = AttuningRollOptions.fromActor(
+      {
+        attuningType:    "grimoire",
+        attuningAbility: this._attuneAbility.uuid,
+        spellsToAttune:  [ this._spell.uuid ],
+        grimoirePenalty: !this._grimoire.system.isOwnGrimoire,
+      },
+      this._actor,
+    );
+  }
+
+  async _processRoll() {
+    this._roll = await this._roll.evaluate();
+    this._result = this._roll;
+
+    // If the roll was unsuccessful, don't attune anything
+    // information about the failure is already shown in the roll message
+    if ( this._roll.isFailure ) {
+      return;
+    }
+
+    // If the roll was successful, attune the spell to the grimoire
+    await this._grimoire.system.setGrimoireActiveSpell( this._spell.uuid );
+
+    super._processRoll();
+  }
+
+  // endregion
+
+}

--- a/module/workflows/workflow/attune-matrix-workflow.mjs
+++ b/module/workflows/workflow/attune-matrix-workflow.mjs
@@ -9,7 +9,7 @@ import Rollable from "./rollable.mjs";
  * @property {string} firstMatrix The UUID for a matrix that should be focused when displaying the attune matrix prompt.
  */
 
-export default class AttuneWorkflow extends Rollable( ActorWorkflow ) {
+export default class AttuneMatrixWorkflow extends Rollable( ActorWorkflow ) {
 
   /**
    * An optional ability with which an attune test should be rolled. "Patterncraft"

--- a/module/workflows/workflow/rollable.mjs
+++ b/module/workflows/workflow/rollable.mjs
@@ -5,6 +5,7 @@
  */
 
 import RollPrompt from "../../applications/global/roll-prompt.mjs";
+import RollProcessor from "../../services/roll-processor.mjs";
 
 /**
  * A mixin that adds roll-related functionality to a workflow.
@@ -80,7 +81,15 @@ export default function Rollable( WorkflowClass ) {
 
     async _processRoll() {
       if ( !this._roll ) return;
+
       // Process the roll results, this can be overridden by subclasses
+      await RollProcessor.process(
+        this._roll,
+        this._actor,
+        {
+          rollToMessage: false,
+        }
+      );
     }
 
     async _rollToChat() {

--- a/templates/item/item-partials/item-details/partials/grimoire.hbs
+++ b/templates/item/item-partials/item-details/partials/grimoire.hbs
@@ -18,6 +18,13 @@
     localize=true
   }}
 
+  {{formGroup
+    systemFields.grimoire.fields.attunedSpell
+    name="system.grimoire.attunedSpell"
+    value=system.grimoire.attunedSpell
+    localize=true
+  }}
+
   {{#each system.grimoire.spells}}
     {{> "systems/ed4e/templates/actor/cards/spell-card.hbs"}}
   {{else}}


### PR DESCRIPTION
This pull request introduces grimoire attunement workflows, as well as improvements to roll options and their initialization. The key changes include the addition of a new `AttuneGrimoireWorkflow`, updates to the `GrimoireTemplate` class to support attuned spells, modifications to roll options for better flexibility, and refactoring of existing workflows to align with the new structure.

### Grimoire and Matrix Attunement Workflows

* **New `AttuneGrimoireWorkflow` Class**: Introduced a dedicated workflow for attuning grimoires. This includes steps for selecting a grimoire, selecting a spell, and processing the attunement roll. It also integrates with the `AttuningRollOptions` class for roll handling. (`module/workflows/workflow/attune-grimoire-workflow.mjs`, [module/workflows/workflow/attune-grimoire-workflow.mjsR1-R169](diffhunk://#diff-faafcfd85ea3542596a406bef7212ca4ac25c90365523d0732513879f433261bR1-R169))
* **Refactored Matrix Workflow**: Replaced the generic `AttuneWorkflow` with a new `AttuneMatrixWorkflow` for matrix-specific attunement logic. (`module/data/item/templates/matrix.mjs`, [[1]](diffhunk://#diff-1e9629750122ee4a588d03b626779c4d3b9ebb6f03870b3d94bf71b6258f53d4L5-R5) [[2]](diffhunk://#diff-1e9629750122ee4a588d03b626779c4d3b9ebb6f03870b3d94bf71b6258f53d4L345-R351)

- if grimoire is not owned (no containing actor, or a different owner than containing actor) : -2 to patterncraft test on attune
- spell management within grimoire, especially interaction with "learned" spell on actor for own grimoires still have to be experimented with

### Enhancements to Grimoire Functionality

* **Grimoire Template Updates**: Added support for attuned spells in the `GrimoireTemplate` class, including methods to attune a spell, retrieve the attuned spell, and set an active spell. (`module/data/item/templates/grimoire.mjs`, [[1]](diffhunk://#diff-41a126682fc750f0ff8c2547ee2697a1db8d962be143f86f5e2138257b5aa005L21-R33) [[2]](diffhunk://#diff-41a126682fc750f0ff8c2547ee2697a1db8d962be143f86f5e2138257b5aa005R151-R228)
* **New Field for Attuned Spell**: Introduced a new `attunedSpell` field to the grimoire schema to store the UUID of the attuned spell. (`module/data/item/templates/grimoire.mjs`, [module/data/item/templates/grimoire.mjsL21-R33](diffhunk://#diff-41a126682fc750f0ff8c2547ee2697a1db8d962be143f86f5e2138257b5aa005L21-R33))

### Roll Options and Initialization Improvements

* **Roll Options Refactoring**: Added new methods (`_prepareStepData`, `_prepareStrainData`, `_prepareTargetDifficulty`) to streamline roll data initialization. Updated `AttuningRollOptions` to include specific logic for grimoire penalties and attuning abilities. (`module/data/roll/attuning.mjs`, [[1]](diffhunk://#diff-e714937073c9d52a92219ff5fc76728916b018f397858f34a62e2df127b9c8f8L50-R79) [[2]](diffhunk://#diff-e714937073c9d52a92219ff5fc76728916b018f397858f34a62e2df127b9c8f8R42-R44)
* **Default Roll Types**: Introduced `TEST_TYPE` and `ROLL_TYPE` constants to define default values for roll types in `EdRollOptions` and `AttuningRollOptions`. (`module/data/roll/common.mjs`, [[1]](diffhunk://#diff-13544520ffc9ba16c5f01ae045946e3a7aeaa0019385621460df6bd005757c76R75-R86) [[2]](diffhunk://#diff-13544520ffc9ba16c5f01ae045946e3a7aeaa0019385621460df6bd005757c76R328-R354)

### Miscellaneous Changes

* **Roll Type Addition**: Added a new "arbitrary" roll type to the `rollTypes` configuration. (`module/config/rolls.mjs`, [module/config/rolls.mjsR64-R67](diffhunk://#diff-0d6be08eda8d511c36f21e6eae0769c49cfc99d016e5fab545465136692ef7adR64-R67))
* **Bug Fixes and Refactoring**: Fixed a bug in `ActorWorkflow` to ensure proper type checking and refactored related imports and methods. (`module/workflows/workflow/actor-workflow.mjs`, [module/workflows/workflow/actor-workflow.mjsL22-R22](diffhunk://#diff-c54b5ecdf609df25b2f076e69a55f4916018cb5f3387e785faea79d97496c74aL22-R22))

