### PR TITLE
Add (matrix) spellcasting workflow foundation

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -329,7 +329,7 @@
       },
       "Flavor": {
         "actorTookDamage":                         "{dealtTo} hat Schaden erlitten.",
-        "attuningRollOptions":                     "{sourceActor} versucht ''{attuningItem}'' und benutzt dafür {attuningAbility}",
+        "attuningRollOptions":                     "{sourceActor} versucht \"{attuningItem}\" und benutzt dafür {attuningAbility}",
         "jumpUp":                                  "{sourceActor} versucht aufzuspringen mit Stufe {step}.",
         "knockdownTest":                           "{sourceActor} macht eine Niederschlagsprobe mit Stufe {step}.",
         "rollAbility":                             "{sourceActor} würfelt {ability} ({step})",
@@ -338,9 +338,10 @@
         "rollInitiative":                          "{sourceActor} würfelt {initiative} ({step})",
         "rollRecovery":                            "{sourceActor} nutzt Erholungsproben für {recoveryMode}",
         "rollUnarmedDamage":                       "{sourceActor} würfelt waffenlosen Schaden",
+        "spellcastingRollOptions":                 "{sourceActor} wirkt<br>{spell} mit<br>{spellcastingAbility}",
         "takeDamage":                              "Schaden nehmen",
         "takeStrainDamage":                        "{actor} nimmt {amount} Überanstrengungsschaden durch {ability}.",
-        "threadWeaving":                           "{sourceActor} webt Fäden für \"{spell}\" ({step})",
+        "threadWeavingRollOptions":                "{sourceActor} webt Fäden für {spell} ({step})",
         "undoDamage":                              "Setzte den Schaden zurück"
       },
       "Header": {
@@ -2578,6 +2579,10 @@
             }
           }
         },
+        "SpellcastingRollOptions": {
+          "FIELDS": {
+          }
+        },
         "ThreadBase": {
           "FIELDS": {
             "characteristics": {
@@ -2720,14 +2725,18 @@
         "free":                                    "Kostenlos",
         "fullRest":                                "Vollständige Rast",
         "goBack":                                  "Zurück",
+        "grimoireCasting":                         "Grimoire",
         "learn":                                   "Lernen",
         "learnSpellPatterncraftTest":              "Lerne den Zauber mit Struktur Verstehen",
+        "matrixCastingAlreadyAttuned":             "Matrix (abgestimmt)",
+        "matrixCastingToAttune":                   "Matrix (neu abstimmen)",
         "nextStep":                                "Nächster Schritt",
         "noAbility":                               "Keine Fähigkeit vorhanden",
         "noDiscipline":                            "Keine Disziplin ausgewählt",
         "notAgain":                                "Zeige diese Nachricht nicht noch einmal",
         "ok":                                      "OK",
         "previousStep":                            "Vorheriger Schritt",
+        "rawCasting":                              "Rohe Magie",
         "reattuneOnTheFly":                        "Neu abstimmen während des Spiels",
         "recoverStun":                             "Erholung von Betäubungsschaden",
         "recovery":                                "Erholung",
@@ -2981,6 +2990,7 @@
         "lpLearnKnack":                            "Lerne Kniff",
         "recovery":                                "Erholung",
         "rollPrompt":                              "Würfel Dialog",
+        "selectCastingMethod":                     "Zaubermethode wählen",
         "selectExtraThreads":                      "Wähle zusätzliche Fäden",
         "selectGrimoireToAttune":                  "Wähle Grimoire zum Abstimmen",
         "selectSpellToAttuneToGrimoire":           "Wähle Zauber mit dem das Grimoire abgestimmt wird",
@@ -2997,6 +3007,7 @@
       "damageStandard":                            "Tödlicher Schaden",
       "damageStun":                                "Betäubungsschaden",
       "damageType":                                "Schadensart",
+      "doYouWantToAttuneGrimoireBeforeCasting":    "Möchtest du das Grimoire vor dem Wirken des Zaubers abstimmen?",
       "ignoreArmor":                               "Ignoriere Rüstung",
       "knockDownChoice":                           "Wähle die Fähigkeit um dem Niederschlag zu widerstehen",
       "mystical":                                  "Mystischer Schaden",
@@ -3114,7 +3125,6 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "Der Actor ist ein Singleton. Es kann nur eine Instanz dieses Actors geben.",
-        "attuneAbilityNotFound":                   "",
         "formulaMalformedError":                   "Die Formel ist fehlerhaft. Bitte überprüfe die Formel.",
         "formulaMissingReferenceWarn":             "Die Formel verweist auf eine nicht existierende Referenz {missingReferences}. Bitte überprüfe die Formel.",
         "grimoireAddNotAGrimoire":                 "Das Item ist kein Grimoire. Bitte überprüfe das Item.",
@@ -3125,9 +3135,13 @@
         "grimoireSetActiveNotInGrimoire":          "Der Zauber ist nicht im Grimoire enthalten. Es kann nicht abgestimmt werden.",
         "identifierError":                         "Der Identifikator ist fehlerhaft. Bitte überprüfe den Identifikator.",
         "invalidElementSubtype":                   "Der Element Untertyp ist ungültig. Bitte überprüfe den Untertyp.",
+        "matrixCastingSpellNotAttuned":            "Der Zauber ist nicht auf die Matrix abgestimmt.",
+        "noCastingMethodSelected":                 "Es wurde keine Methode zur Spruchzauberei ausgewählt.",
         "noGrimoiresAvailableToAttune":            "Es sind keine Grimoire verfügbar, die abgestimmt werden können.",
         "noSpellsAvailableToAttune":               "Das Grimoire enthält keine Zauber, die abgestimmt werden können.",
-        "singleton":                               "Der Actor ist ein Singleton. Es kann nur eine Instanz dieses Actors geben."
+        "singleton":                               "Der Actor ist ein Singleton. Es kann nur eine Instanz dieses Actors geben.",
+        "spellNotAttunedToMatrix":                 "Der Zauber wurde nicht auf eine Matrix abgestimmt.",
+        "spellcastingWorkflowFailed":              ""
       },
       "Info": {
         "noDamageNoRecoveryNeeded":                "Dir gehts gut und hast keinen Schaden. Erholungsprobe nicht nötig.",
@@ -3159,6 +3173,7 @@
         "piecemealArmorSizeExceeded":              "Maximale Menge an stückweiser Rüstung erreicht. Leg andere Teile ab um das neue Stück auszurüsten.",
         "questorItemNotUpdated":                   "Questor-Item konnte nicht aktualisiert werden",
         "spellAlreadyAttunedInGrimoire":           "Der Zauber ist bereits im Grimoire abgestimmt.",
+        "spellNotReadyToCast":                     "Der Zauber ist nicht bereit zum Wirken. Es fehlen noch Fäden.",
         "warningEffectNoActor":                    "Der Effekt hat keinen Actor zugewiesen. Bitte weise einen Actor zu."
       }
     },

--- a/lang/en.json
+++ b/lang/en.json
@@ -339,9 +339,10 @@
         "rollInitiative":                          "TODO: Add translation",
         "rollRecovery":                            "TODO: Add translation",
         "rollUnarmedDamage":                       "TODO: Add translation",
+        "spellcastingRollOptions":                 "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "takeStrainDamage":                        "TODO: Add translation",
-        "threadWeaving":                           "TODO: Add translation",
+        "threadWeavingRollOptions":                "TODO: Add translation",
         "undoDamage":                              "TODO: Add translation"
       },
       "Header": {
@@ -2562,6 +2563,9 @@
             }
           }
         },
+        "SpellcastingRollOptions": {
+          "FIELDS":                                "TODO: Add translation"
+        },
         "ThreadBase": {
           "FIELDS": {
             "characteristics": {
@@ -2704,14 +2708,18 @@
         "free":                                    "TODO: Add translation",
         "fullRest":                                "TODO: Add translation",
         "goBack":                                  "TODO: Add translation",
+        "grimoireCasting":                         "TODO: Add translation",
         "learn":                                   "TODO: Add translation",
         "learnSpellPatterncraftTest":              "TODO: Add translation",
+        "matrixCastingAlreadyAttuned":             "TODO: Add translation",
+        "matrixCastingToAttune":                   "TODO: Add translation",
         "nextStep":                                "TODO: Add translation",
         "noAbility":                               "TODO: Add translation",
         "noDiscipline":                            "TODO: Add translation",
         "notAgain":                                "TODO: Add translation",
         "ok":                                      "TODO: Add translation",
         "previousStep":                            "TODO: Add translation",
+        "rawCasting":                              "TODO: Add translation",
         "reattuneOnTheFly":                        "TODO: Add translation",
         "recoverStun":                             "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
@@ -2965,6 +2973,7 @@
         "lpLearnKnack":                            "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
+        "selectCastingMethod":                     "TODO: Add translation",
         "selectExtraThreads":                      "TODO: Add translation",
         "selectGrimoireToAttune":                  "TODO: Add translation",
         "selectSpellToAttuneToGrimoire":           "TODO: Add translation",
@@ -2981,6 +2990,7 @@
       "damageStandard":                            "Deadly Damage",
       "damageStun":                                "Stun Damage",
       "damageType":                                "Damage Type",
+      "doYouWantToAttuneGrimoireBeforeCasting":    "TODO: Add translation",
       "ignoreArmor":                               "Ignore Armor",
       "knockDownChoice":                           "Chose the Ability to withstand the Knock Down",
       "mystical":                                  "Mystical Damage",
@@ -3098,7 +3108,6 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "TODO: Add translation",
-        "attuneAbilityNotFound":                   "TODO: Add translation",
         "formulaMalformedError":                   "TODO: Add translation",
         "formulaMissingReferenceWarn":             "TODO: Add translation",
         "grimoireAddNotAGrimoire":                 "TODO: Add translation",
@@ -3109,9 +3118,13 @@
         "grimoireSetActiveNotInGrimoire":          "TODO: Add translation",
         "identifierError":                         "TODO: Add translation",
         "invalidElementSubtype":                   "TODO: Add translation",
+        "matrixCastingSpellNotAttuned":            "TODO: Add translation",
+        "noCastingMethodSelected":                 "TODO: Add translation",
         "noGrimoiresAvailableToAttune":            "TODO: Add translation",
         "noSpellsAvailableToAttune":               "TODO: Add translation",
-        "singleton":                               "TODO: Add translation"
+        "singleton":                               "TODO: Add translation",
+        "spellNotAttunedToMatrix":                 "TODO: Add translation",
+        "spellcastingWorkflowFailed":              "TODO: Add translation"
       },
       "Info": {
         "noDamageNoRecoveryNeeded":                "TODO: Add translation",
@@ -3143,6 +3156,7 @@
         "piecemealArmorSizeExceeded":              "Maximum amount of piecemeal armor reached. Unequip other parts to equip the new piece.",
         "questorItemNotUpdated":                   "TODO: Add translation",
         "spellAlreadyAttunedInGrimoire":           "TODO: Add translation",
+        "spellNotReadyToCast":                     "TODO: Add translation",
         "warningEffectNoActor":                    "TODO: Add translation"
       }
     },

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -328,7 +328,6 @@
         "takeDamageTitle":                         "TODO: Add translation"
       },
       "Flavor": {
-        "AttuningRollOptions":                     "TODO: Add translation",
         "actorTookDamage":                         "TODO: Add translation",
         "attuningRollOptions":                     "TODO: Add translation",
         "jumpUp":                                  "TODO: Add translation",
@@ -339,9 +338,10 @@
         "rollInitiative":                          "TODO: Add translation",
         "rollRecovery":                            "TODO: Add translation",
         "rollUnarmedDamage":                       "TODO: Add translation",
+        "spellcastingRollOptions":                 "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "takeStrainDamage":                        "TODO: Add translation",
-        "threadWeaving":                           "TODO: Add translation",
+        "threadWeavingRollOptions":                "TODO: Add translation",
         "undoDamage":                              "TODO: Add translation"
       },
       "Header": {
@@ -2562,6 +2562,9 @@
             }
           }
         },
+        "SpellcastingRollOptions": {
+          "FIELDS":                                "TODO: Add translation"
+        },
         "ThreadBase": {
           "FIELDS": {
             "characteristics": {
@@ -2704,14 +2707,18 @@
         "free":                                    "TODO: Add translation",
         "fullRest":                                "TODO: Add translation",
         "goBack":                                  "TODO: Add translation",
+        "grimoireCasting":                         "TODO: Add translation",
         "learn":                                   "TODO: Add translation",
         "learnSpellPatterncraftTest":              "TODO: Add translation",
+        "matrixCastingAlreadyAttuned":             "TODO: Add translation",
+        "matrixCastingToAttune":                   "TODO: Add translation",
         "nextStep":                                "TODO: Add translation",
         "noAbility":                               "TODO: Add translation",
         "noDiscipline":                            "TODO: Add translation",
         "notAgain":                                "TODO: Add translation",
         "ok":                                      "TODO: Add translation",
         "previousStep":                            "TODO: Add translation",
+        "rawCasting":                              "TODO: Add translation",
         "reattuneOnTheFly":                        "TODO: Add translation",
         "recoverStun":                             "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
@@ -2965,6 +2972,7 @@
         "lpLearnKnack":                            "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
+        "selectCastingMethod":                     "TODO: Add translation",
         "selectExtraThreads":                      "TODO: Add translation",
         "selectGrimoireToAttune":                  "TODO: Add translation",
         "selectSpellToAttuneToGrimoire":           "TODO: Add translation",
@@ -2981,6 +2989,7 @@
       "damageStandard":                            "TODO: Add translation",
       "damageStun":                                "TODO: Add translation",
       "damageType":                                "TODO: Add translation",
+      "doYouWantToAttuneGrimoireBeforeCasting":    "TODO: Add translation",
       "ignoreArmor":                               "TODO: Add translation",
       "knockDownChoice":                           "TODO: Add translation",
       "mystical":                                  "TODO: Add translation",
@@ -3098,7 +3107,6 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "TODO: Add translation",
-        "attuneAbilityNotFound":                   "TODO: Add translation",
         "formulaMalformedError":                   "TODO: Add translation",
         "formulaMissingReferenceWarn":             "TODO: Add translation",
         "grimoireAddNotAGrimoire":                 "TODO: Add translation",
@@ -3109,9 +3117,13 @@
         "grimoireSetActiveNotInGrimoire":          "TODO: Add translation",
         "identifierError":                         "TODO: Add translation",
         "invalidElementSubtype":                   "TODO: Add translation",
+        "matrixCastingSpellNotAttuned":            "TODO: Add translation",
+        "noCastingMethodSelected":                 "TODO: Add translation",
         "noGrimoiresAvailableToAttune":            "TODO: Add translation",
         "noSpellsAvailableToAttune":               "TODO: Add translation",
-        "singleton":                               "TODO: Add translation"
+        "singleton":                               "TODO: Add translation",
+        "spellNotAttunedToMatrix":                 "TODO: Add translation",
+        "spellcastingWorkflowFailed":              "TODO: Add translation"
       },
       "Info": {
         "noDamageNoRecoveryNeeded":                "TODO: Add translation",
@@ -3143,6 +3155,7 @@
         "piecemealArmorSizeExceeded":              "TODO: Add translation",
         "questorItemNotUpdated":                   "TODO: Add translation",
         "spellAlreadyAttunedInGrimoire":           "TODO: Add translation",
+        "spellNotReadyToCast":                     "TODO: Add translation",
         "warningEffectNoActor":                    "TODO: Add translation"
       }
     },

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -328,7 +328,6 @@
         "takeDamageTitle":                         "TODO: Add translation"
       },
       "Flavor": {
-        "AttuningRollOptions":                     "TODO: Add translation",
         "actorTookDamage":                         "TODO: Add translation",
         "attuningRollOptions":                     "TODO: Add translation",
         "jumpUp":                                  "TODO: Add translation",
@@ -339,9 +338,10 @@
         "rollInitiative":                          "TODO: Add translation",
         "rollRecovery":                            "TODO: Add translation",
         "rollUnarmedDamage":                       "TODO: Add translation",
+        "spellcastingRollOptions":                 "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "takeStrainDamage":                        "TODO: Add translation",
-        "threadWeaving":                           "TODO: Add translation",
+        "threadWeavingRollOptions":                "TODO: Add translation",
         "undoDamage":                              "TODO: Add translation"
       },
       "Header": {
@@ -2562,6 +2562,9 @@
             }
           }
         },
+        "SpellcastingRollOptions": {
+          "FIELDS":                                "TODO: Add translation"
+        },
         "ThreadBase": {
           "FIELDS": {
             "characteristics": {
@@ -2704,14 +2707,18 @@
         "free":                                    "TODO: Add translation",
         "fullRest":                                "TODO: Add translation",
         "goBack":                                  "TODO: Add translation",
+        "grimoireCasting":                         "TODO: Add translation",
         "learn":                                   "TODO: Add translation",
         "learnSpellPatterncraftTest":              "TODO: Add translation",
+        "matrixCastingAlreadyAttuned":             "TODO: Add translation",
+        "matrixCastingToAttune":                   "TODO: Add translation",
         "nextStep":                                "TODO: Add translation",
         "noAbility":                               "TODO: Add translation",
         "noDiscipline":                            "TODO: Add translation",
         "notAgain":                                "TODO: Add translation",
         "ok":                                      "TODO: Add translation",
         "previousStep":                            "TODO: Add translation",
+        "rawCasting":                              "TODO: Add translation",
         "reattuneOnTheFly":                        "TODO: Add translation",
         "recoverStun":                             "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
@@ -2965,6 +2972,7 @@
         "lpLearnKnack":                            "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
         "rollPrompt":                              "TODO: Add translation",
+        "selectCastingMethod":                     "TODO: Add translation",
         "selectExtraThreads":                      "TODO: Add translation",
         "selectGrimoireToAttune":                  "TODO: Add translation",
         "selectSpellToAttuneToGrimoire":           "TODO: Add translation",
@@ -2981,6 +2989,7 @@
       "damageStandard":                            "TODO: Add translation",
       "damageStun":                                "TODO: Add translation",
       "damageType":                                "TODO: Add translation",
+      "doYouWantToAttuneGrimoireBeforeCasting":    "TODO: Add translation",
       "ignoreArmor":                               "TODO: Add translation",
       "knockDownChoice":                           "TODO: Add translation",
       "mystical":                                  "TODO: Add translation",
@@ -3098,7 +3107,6 @@
     "Notifications": {
       "Error": {
         "actorWarningSingleton":                   "TODO: Add translation",
-        "attuneAbilityNotFound":                   "TODO: Add translation",
         "formulaMalformedError":                   "TODO: Add translation",
         "formulaMissingReferenceWarn":             "TODO: Add translation",
         "grimoireAddNotAGrimoire":                 "TODO: Add translation",
@@ -3109,9 +3117,13 @@
         "grimoireSetActiveNotInGrimoire":          "TODO: Add translation",
         "identifierError":                         "TODO: Add translation",
         "invalidElementSubtype":                   "TODO: Add translation",
+        "matrixCastingSpellNotAttuned":            "TODO: Add translation",
+        "noCastingMethodSelected":                 "TODO: Add translation",
         "noGrimoiresAvailableToAttune":            "TODO: Add translation",
         "noSpellsAvailableToAttune":               "TODO: Add translation",
-        "singleton":                               "TODO: Add translation"
+        "singleton":                               "TODO: Add translation",
+        "spellNotAttunedToMatrix":                 "TODO: Add translation",
+        "spellcastingWorkflowFailed":              "TODO: Add translation"
       },
       "Info": {
         "noDamageNoRecoveryNeeded":                "TODO: Add translation",
@@ -3143,6 +3155,7 @@
         "piecemealArmorSizeExceeded":              "TODO: Add translation",
         "questorItemNotUpdated":                   "TODO: Add translation",
         "spellAlreadyAttunedInGrimoire":           "TODO: Add translation",
+        "spellNotReadyToCast":                     "TODO: Add translation",
         "warningEffectNoActor":                    "TODO: Add translation"
       }
     },

--- a/module/config/_module.mjs
+++ b/module/config/_module.mjs
@@ -40,6 +40,25 @@ Hooks.on('hotReload', async ({ content, extension, packageId, packageType, path 
 });
 /* eslint-enable */
 
+export {
+  ACTIONS,
+  ACTORS,
+  CHAT,
+  COMBAT,
+  DOCUMENT_DATA,
+  EFFECTS,
+  ITEMS,
+  LEGEND,
+  MAGIC,
+  QUANTITIES,
+  ROLLS,
+  SOCKETS,
+  STATUSES,
+  SYSTEM,
+  MIGRATIONS,
+  WORKFLOWS
+};
+
 // Namespace Configuration Values
 const ED4E = {
   // Need to write this out explicitly since the imported module namespaces are

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -189,6 +189,14 @@ export default class SpellData extends ItemDataModel.mixin(
   }
 
   /**
+   * Is this spell ready to be cast?
+   * @returns {boolean} True if the spell is weaving and has all required threads, false otherwise.
+   */
+  get isWeavingComplete() {
+    return this.isWeaving && this.wovenThreads >= this.totalRequiredThreads;
+  }
+
+  /**
    * @description The difficulty number to dispel this spell.
    * @type {number}
    */
@@ -403,7 +411,6 @@ export default class SpellData extends ItemDataModel.mixin(
         );
         this.parent.update( {
           "system.threads.woven": wovenThreads,
-          "system.isWeaving":     wovenThreads < system.missingThreads,
         } );
       }
     }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -397,11 +397,13 @@ export default class SpellData extends ItemDataModel.mixin(
       await roll.toMessage();
 
       if ( roll?.numSuccesses > 0 ) {
+        const wovenThreads = Math.min(
+          system.totalRequiredThreads,
+          system.wovenThreads + roll.numSuccesses
+        );
         this.parent.update( {
-          "system.threads.woven": Math.min(
-            system.totalRequiredThreads,
-            system.wovenThreads + roll.numSuccesses
-          ),
+          "system.threads.woven": wovenThreads,
+          "system.isWeaving":     wovenThreads < system.missingThreads,
         } );
       }
     }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -22,6 +22,8 @@ export default class SpellData extends ItemDataModel.mixin(
   TargetTemplate
 )  {
 
+  // region Static Properties
+
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
@@ -174,6 +176,8 @@ export default class SpellData extends ItemDataModel.mixin(
     return undefined;
   }
 
+  // endregion
+
   // region Properties
 
   /**
@@ -234,9 +238,9 @@ export default class SpellData extends ItemDataModel.mixin(
 
   // endregion
 
-  /* -------------------------------------------- */
-  /*  LP Tracking                                 */
-  /* -------------------------------------------- */
+  // region Methods
+
+  // region LP Tracking
 
   /** @inheritDoc */
   get canBeLearned() {
@@ -300,9 +304,11 @@ export default class SpellData extends ItemDataModel.mixin(
     return learnedItem;
   }
 
-  // region Methods
+  // endregion
 
   // region Spellcasting
+
+  cast( caster, options = {} ) {}
 
   /**
    * Set woven threads to zero and empty the chosen extra threads.
@@ -403,16 +409,34 @@ export default class SpellData extends ItemDataModel.mixin(
 
   // endregion
 
+  getAttunedMatrix() {
+    return this.containingActor?.items.find( item => {
+      return item.system.matrix?.activeSpell === this.parent.uuid;
+    } );
+  }
+
+  /**
+   * Checks if the spell is known/learned by the given actor. This is defined as the spell being present in the actor's
+   * items of type "spell".
+   * @param {ActorEd} actor - The actor to check for the spell.
+   * @returns {boolean} - Returns the spell item if it is known/learned by the actor, false otherwise.
+   */
+  knownBy( actor ) {
+    if ( !actor ) return undefined;
+
+    return !!actor.itemTypes.spell.find( i => i.uuid === this.parent.uuid );
+  }
+
   // endregion
 
-  /* -------------------------------------------- */
-  /*  Migrations                                  */
-  /* -------------------------------------------- */
+  // region Migration
 
   /** @inheritDoc */
   static migrateData( source ) {
     super.migrateData( source );
     // specific migration functions
   }
+
+  // endregion
 
 }

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -411,7 +411,7 @@ export default class SpellData extends ItemDataModel.mixin(
 
   getAttunedMatrix() {
     return this.containingActor?.items.find( item => {
-      return item.system.matrix?.activeSpell === this.parent.uuid;
+      return item.system.matrix?.spells.has( this.parent.uuid );
     } );
   }
 

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -416,12 +416,21 @@ export default class SpellData extends ItemDataModel.mixin(
   }
 
   /**
-   * Checks if the spell is known/learned by the given actor. This is defined as the spell being present in the actor's
+   * Checks if the spell is in any of the actor's grimoires.
+   * @param {ActorEd} actor - The actor to check for the spell.
+   * @returns {boolean} - Returns true if the spell is in any of the actor's grimoires, false otherwise.
+   */
+  inActorGrimoires( actor ) {
+    return !!actor.itemTypes.equipment.find( item => item.system.grimoire?.spells?.has( this.parent.uuid ) );
+  }
+
+  /**
+   * Checks if the spell is learned by the given actor. This is defined as the spell being present in the actor's
    * items of type "spell".
    * @param {ActorEd} actor - The actor to check for the spell.
-   * @returns {boolean} - Returns the spell item if it is known/learned by the actor, false otherwise.
+   * @returns {boolean} - Returns the spell item if it is learned by the actor, false otherwise.
    */
-  knownBy( actor ) {
+  learnedBy( actor ) {
     if ( !actor ) return undefined;
 
     return !!actor.itemTypes.spell.find( i => i.uuid === this.parent.uuid );

--- a/module/data/item/templates/matrix.mjs
+++ b/module/data/item/templates/matrix.mjs
@@ -165,9 +165,13 @@ export default class MatrixTemplate extends SystemDataModel {
     const edidMatrix = getSetting( "edidSpellMatrix" );
 
     if ( !this.matrixHasMultipleSpells && this.matrixSpellUuid && !this.matrix.activeSpell ) {
-      // If the matrix has only one spell attuned, only that one
+      // If the matrix has only one spell attuned, only that one can be active
       data.system.matrix ??= {};
       data.system.matrix.activeSpell = this.matrixSpellUuid;
+    } else if ( this.matrix?.activeSpell && !this.matrix?.spells?.has( this.matrix.activeSpell ) ) {
+      // If the active spell is not in the list of spells, reset it
+      data.system.matrix ??= {};
+      data.system.matrix.activeSpell = null;
     }
 
     if ( this._isBecomingMatrix( data, edidMatrix ) ) {

--- a/module/data/roll/_module.mjs
+++ b/module/data/roll/_module.mjs
@@ -5,4 +5,5 @@ export {default as AttuningRollData} from "./attuning.mjs";
 export {default as DamageRollData} from "./damage.mjs";
 export {default as InitiativeRollData} from "./initiative.mjs";
 export {default as RecoveryRollData} from "./recovery.mjs";
+export {default as SpellcastingRollData} from "./spellcasting.mjs";
 export {default as WeavingRollData} from "./weaving.mjs";

--- a/module/data/roll/attuning.mjs
+++ b/module/data/roll/attuning.mjs
@@ -87,15 +87,13 @@ export default class AttuningRollOptions extends EdRollOptions {
     };
   }
 
-  async _getChatFlavor() {
-    return game.i18n.format(
-      "ED.Chat.Flavor.attuningRollOptions",
-      {
-        sourceActor:     createContentAnchor( await fromUuid( this.rollingActorUuid ) ).outerHTML,
-        attuningItem:    ED4E.attuningType[ this.attuningType ],
-        attuningAbility: createContentAnchor( await fromUuid( this.attuningAbility ) ).outerHTML,
-      },
-    );
+  /** @inheritDoc */
+  _getChatFlavorData() {
+    return {
+      sourceActor:     createContentAnchor( fromUuidSync( this.rollingActorUuid ) ).outerHTML,
+      attuningItem:    ED4E.attuningType[ this.attuningType ],
+      attuningAbility: createContentAnchor( fromUuidSync( this.attuningAbility ) ).outerHTML,
+    };
   }
 
   /**
@@ -112,7 +110,6 @@ export default class AttuningRollOptions extends EdRollOptions {
   async getFlavorTemplateData( context ) {
     const newContext = await super.getFlavorTemplateData( context );
 
-    newContext.customFlavor ||= await this._getChatFlavor();
     newContext.spellsToAttune = ( await this.getSpellItems() ).filter( spell => !!spell );
 
     return newContext;

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -1,4 +1,4 @@
-import { sum } from "../../utils.mjs";
+import { lowerCaseFirstLetter, sum } from "../../utils.mjs";
 import getDice from "../../dice/step-tables.mjs";
 import ED4E from "../../config/_module.mjs";
 import MappingField from "../fields/mapping-field.mjs";
@@ -326,6 +326,26 @@ export default class EdRollOptions extends SparseDataModel {
   }
 
   /**
+   * Generates the chat flavor text for this roll. The localized key is 'ED.Chat.Flavor.' + the
+   * camelCase class name.
+   * @returns {string} The formatted chat flavor text for this roll.
+   */
+  _getChatFlavor() {
+    return game.i18n.format(
+      `ED.Chat.Flavor.${lowerCaseFirstLetter( this.constructor.name )}`,
+      this._getChatFlavorData( this.source ),
+    );
+  }
+
+  /**
+   * Generates the data object for the `format` method call of the chat flavor text.
+   * @returns {object} The data object containing the data for the call to {@link Localization.format}.
+   */
+  _getChatFlavorData() {
+    return {};
+  }
+
+  /**
    * Used when initializing this data model. Retrieves step data based on the provided input data.
    * @param {object} data The input data object containing relevant ability information.
    * @returns {RollStepData} The step data object containing the base step and modifiers, if any.
@@ -404,7 +424,10 @@ export default class EdRollOptions extends SparseDataModel {
    * @returns {Promise<FlavorTemplateData>} Enhanced template data for the specific roll type
    */
   async getFlavorTemplateData( context ) {
-    return context;
+    return {
+      ...context,
+      customFlavor: context.customFlavor || this._getChatFlavor(),
+    };
   }
 
 }

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -232,7 +232,7 @@ export default class EdRollOptions extends SparseDataModel {
         required: true,
         nullable: false,
         blank:    true,
-        initial:  "action",
+        initial:  "arbitrary",
         choices:  ED4E.ROLLS.testTypes,
       } ),
       rollType: new fields.StringField( {

--- a/module/data/roll/spellcasting.mjs
+++ b/module/data/roll/spellcasting.mjs
@@ -1,6 +1,7 @@
 import EdRollOptions from "./common.mjs";
 import { createContentAnchor } from "../../utils.mjs";
-import ED4E from "../../config/_module.mjs";
+import { EFFECTS } from "../../config/_module.mjs";
+
 
 export default class SpellcastingRollOptions extends EdRollOptions {
 
@@ -47,9 +48,9 @@ export default class SpellcastingRollOptions extends EdRollOptions {
     return {
       base:      ability.system.rankFinal,
       modifiers: {
-        [ ED4E.EFFECTS.globalBonuses.allSpellcasting.label ]: actor.system.globalBonuses.allSpellcasting.value,
-        [ ED4E.EFFECTS.globalBonuses.allSpellTests.label ]:   actor.system.globalBonuses.allSpellTests.value,
-        [ ED4E.EFFECTS.globalBonuses.allTests.label ]:        actor.system.globalBonuses.allTests.value,
+        [ EFFECTS.globalBonuses.allSpellcasting.label ]: actor.system.globalBonuses.allSpellcasting.value,
+        [ EFFECTS.globalBonuses.allSpellTests.label ]:   actor.system.globalBonuses.allSpellTests.value,
+        [ EFFECTS.globalBonuses.allTests.label ]:        actor.system.globalBonuses.allTests.value,
       },
     };
   }

--- a/module/data/roll/spellcasting.mjs
+++ b/module/data/roll/spellcasting.mjs
@@ -1,0 +1,67 @@
+import EdRollOptions from "./common.mjs";
+import { createContentAnchor } from "../../utils.mjs";
+
+export default class SpellcastingRollOptions extends EdRollOptions {
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.SpellcastingRollOptions",
+  ];
+
+  /** @inheritdoc */
+  static TEST_TYPE = "action";
+
+  /** @inheritdoc */
+  static ROLL_TYPE = "spellcasting";
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return this.mergeSchema( super.defineSchema(), {
+      spell: new fields.DocumentUUIDField( {
+        required: true,
+        type:     "Item",
+      } ),
+      spellcastingAbility: new fields.DocumentUUIDField( {
+        required: true,
+        type:     "Item",
+        embedded: true,
+      } ),
+    } );
+  }
+
+  /** @inheritDoc */
+  _getChatFlavorData() {
+    return {
+      sourceActor:         createContentAnchor( fromUuidSync( this.rollingActorUuid ) ).outerHTML,
+      spell:               createContentAnchor( fromUuidSync( this.spell ) ).outerHTML,
+      spellcastingAbility: createContentAnchor( fromUuidSync( this.spellcastingAbility ) ).outerHTML,
+    };
+  }
+
+  /** @inheritDoc */
+  _prepareStepData( data ) {
+    const ability = fromUuidSync( data.spellcastingAbility );
+    return {
+      base:      ability.system.rankFinal,
+      modifiers: {},
+    };
+  }
+
+  /** @inheritDoc */
+  _prepareStrainData( data ) {
+    const ability = fromUuidSync( data.spellcastingAbility );
+    return {
+      base: ability.system.strain,
+    };
+  }
+
+  /** @inheritDoc */
+  _prepareTargetDifficulty( data ) {
+    const spell = fromUuidSync( data.spell );
+    return {
+      base: spell.system.getDifficulty(),
+    };
+  }
+
+}

--- a/module/data/roll/spellcasting.mjs
+++ b/module/data/roll/spellcasting.mjs
@@ -1,5 +1,6 @@
 import EdRollOptions from "./common.mjs";
 import { createContentAnchor } from "../../utils.mjs";
+import ED4E from "../../config/_module.mjs";
 
 export default class SpellcastingRollOptions extends EdRollOptions {
 
@@ -42,9 +43,14 @@ export default class SpellcastingRollOptions extends EdRollOptions {
   /** @inheritDoc */
   _prepareStepData( data ) {
     const ability = fromUuidSync( data.spellcastingAbility );
+    const actor = fromUuidSync( data.rollingActorUuid );
     return {
       base:      ability.system.rankFinal,
-      modifiers: {},
+      modifiers: {
+        [ ED4E.EFFECTS.globalBonuses.allSpellcasting.label ]: actor.system.globalBonuses.allSpellcasting.value,
+        [ ED4E.EFFECTS.globalBonuses.allSpellTests.label ]:   actor.system.globalBonuses.allSpellTests.value,
+        [ ED4E.EFFECTS.globalBonuses.allTests.label ]:        actor.system.globalBonuses.allTests.value,
+      },
     };
   }
 

--- a/module/data/roll/weaving.mjs
+++ b/module/data/roll/weaving.mjs
@@ -1,4 +1,6 @@
 import EdRollOptions from "./common.mjs";
+import { createContentAnchor } from "../../utils.mjs";
+
 
 export default class ThreadWeavingRollOptions extends EdRollOptions {
 
@@ -32,6 +34,15 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
         } ),
       } ),
     } );
+  }
+
+  /** @inheritDoc */
+  _getChatFlavorData() {
+    return {
+      sourceActor: createContentAnchor( fromUuidSync( this.rollingActorUuid ) ).outerHTML,
+      spell:       createContentAnchor( fromUuidSync( this.spellUuid ) ).outerHTML,
+      step:        this.step.total,
+    };
   }
 
   /** @inheritDoc */

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -256,11 +256,7 @@ export default class ActorEd extends Actor {
    * @returns {ItemEd|null} The discipline item, or null if none was found.
    */
   getDisciplineForSpellcastingType( spellcastingType ) {
-    const threadWeavingTalent = this.getItemsByEdid(
-      getSetting( "edidThreadWeaving" ),
-    ).find(
-      item => spellcastingType === item.system.rollTypeDetails?.threadWeaving?.castingType
-    );
+    const threadWeavingTalent = this.getThreadWeavingByCastingType( spellcastingType );
     if ( !threadWeavingTalent ) return null;
 
     return fromUuidSync( threadWeavingTalent.system.source?.class );
@@ -319,6 +315,14 @@ export default class ActorEd extends Actor {
    */
   getSingleItemByEdid( edid, type ) {
     return this.getItemsByEdid( edid, type )[0];
+  }
+
+  getThreadWeavingByCastingType( spellcastingType ) {
+    return this.getItemsByEdid(
+      getSetting( "edidThreadWeaving" ),
+    ).find(
+      item => spellcastingType === item.system.rollTypeDetails?.threadWeaving?.castingType
+    );
   }
 
   /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -330,6 +330,17 @@ export default class ActorEd extends Actor {
   }
 
   /**
+   * Checks if this actor has at least one matrix that can hold the given spell.
+   * @param {ItemEd} spell The spell to check for.
+   * @returns {boolean} True if there is at least one matrix that has a level >= the spell's level, false otherwise.
+   */
+  hasMatrixForSpell( spell ) {
+    return this.getMatrices().some(
+      matrix => matrix.system.matrix.level >= spell.system.level
+    );
+  }
+
+  /**
    * @param {('standard'|'blood'|'any')} [type] The type of wounds that is to be checked.
    * @returns {boolean} True if there is a positive amount of wounds of the given type marked on this actor, false otherwise.
    */

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -1,7 +1,4 @@
-
-/* -------------------------------------------- */
-/*  Earthdawn                                   */
-/* -------------------------------------------- */
+// region Earthdawn
 
 import ED4E from "./config/_module.mjs";
 
@@ -32,9 +29,9 @@ export function getDefenseValue( attributeValue ) {
   return attributeValue <= 0 ? 0 : Math.ceil( attributeValue / 2 ) + 1;
 }
 
-/* -------------------------------------------- */
-/*  Foundry                                     */
-/* -------------------------------------------- */
+// endregion
+
+// region Foundry
 
 /**
  * Get all ED-IDs of all Items in the game world, optionally filtered by Item type.
@@ -294,9 +291,10 @@ export function staticStatusId( status ) {
   return status.padEnd( 16, "0" );
 }
 
-/* -------------------------------------------- */
-/*  View Helper                                 */
-/* -------------------------------------------- */
+// endregion
+
+// region View Helpers
+
 /**
  * 
  * @param {*} ms milliseconds
@@ -309,9 +307,9 @@ export async function delay( ms ) {
 
 }
 
-/* -------------------------------------------- */
-/*  Maths                                       */
-/* -------------------------------------------- */
+// endregion
+
+// region Maths
 
 /**
  * Computes the sum of the values in array.
@@ -321,8 +319,6 @@ export async function delay( ms ) {
 export function sum( arr ) {
   return arr.reduce( ( partialSum, a ) => partialSum + a, 0 );
 }
-
-/* -------------------------------------------- */
 
 /**
  * Computes the sum of a specific property's  values in an array of objects. The sum for only one property can be
@@ -347,9 +343,9 @@ export function inRange( value, min, max, includeLimits = true ) {
   return includeLimits ? value >= min && value <= max : value > min && value < max;
 }
 
-/* -------------------------------------------- */
-/*  Formatting                                  */
-/* -------------------------------------------- */
+// endregion
+
+// region Formatting
 
 /**
  * @description Converts a date object or integer to a string that can be used as value in a datetime input field.
@@ -360,9 +356,19 @@ export function dateToInputString( date ) {
   return ( new Date( date ) ).toISOString().substring( 0, 16 );
 }
 
-/* -------------------------------------------- */
-/*  Object Helpers                              */
-/* -------------------------------------------- */
+/**
+ * Converts the first letter of a string to lowercase.
+ * @param { string } str The string to be modified.
+ * @returns { string } The input string with its first letter converted to lowercase.
+ */
+export function lowerCaseFirstLetter( str ) {
+  if ( !str || str.length === 0 ) return str;
+  return str.charAt( 0 ).toLowerCase() + str.slice( 1 );
+}
+
+// endregion
+
+// region Object Helpers
 
 /**
  * Safely call a method if it exists on the object.
@@ -391,8 +397,6 @@ export function sortObjectEntries( obj, sortKey ) {
   return Object.fromEntries( sorted );
 }
 
-/* -------------------------------------------- */
-
 /**
  * Filter an object's entries by the given predicate (filter function). Creates
  * a new object with only entries that satisfy the predicate.
@@ -413,8 +417,6 @@ export function filterObject( obj, predicate ) {
   );
 }
 
-/* -------------------------------------------- */
-
 /**
  * Map an object's entries by the given function. Creates a new object with the
  * mapped entries according to the function.
@@ -434,8 +436,6 @@ export function mapObject( obj, mappingFunction ) {
   );
 }
 
-/* -------------------------------------------- */
-
 /**
  * Renames all keys of an object by prepending a specified prefix to each key.
  * @param {object} obj - The object whose keys are to be renamed.
@@ -450,8 +450,6 @@ export function renameKeysWithPrefix( obj ) {
   }
   return renamedObj;
 }
-
-/* -------------------------------------------- */
 
 /**
  * Retrieves the value of a given string property of an object which works for nested property names.
@@ -486,8 +484,6 @@ export function multiplyArray( arr, times ) {
   return Array.from( { length: times }, () => clonedArray ).flat();
 }
 
-/* -------------------------------------------- */
-
 /**
  * Creates an HTML document link for the provided UUID.
  * @param {string} uuid  UUID for which to produce the link.
@@ -496,8 +492,6 @@ export function multiplyArray( arr, times ) {
 export async function linkForUuid( uuid ) {
   return TextEditor._createContentLink( [ "", "UUID", uuid ] );
 }
-
-/* -------------------------------------------- */
 
 /**
  * Creates an HTML document link for the provided UUID.
@@ -525,9 +519,9 @@ export function linkForUuidSync( uuid ) {
     </a>`;
 }
 
-/* -------------------------------------------- */
-/*  Validators                                  */
-/* -------------------------------------------- */
+// endregion
+
+// region Validation
 
 /**
  * Ensure the provided string contains only the characters allowed in identifiers.
@@ -571,10 +565,9 @@ export const validators = {
   validateEdid:      validateEdid,
 };
 
+// endregion
 
-/* -------------------------------------------- */
-/*  Config Pre-Localization                     */
-/* -------------------------------------------- */
+// region Config Pre-localization
 
 /**
  * Storage for pre-localization configuration.
@@ -598,8 +591,6 @@ export function preLocalize( configKeyPath, { key, keys=[], sort=false }={} ) {
   _preLocalizationRegistrations[configKeyPath] = { keys, sort };
 }
 
-/* -------------------------------------------- */
-
 /**
  * Execute previously defined pre-localization tasks on the provided config object.
  * @param {object} config  The `CONFIG.ED4E` object to localize and sort. *Will be mutated.*
@@ -611,8 +602,6 @@ export function performPreLocalization( config ) {
     if ( settings.sort ) foundry.utils.setProperty( config, keyPath, sortObjectEntries( target, settings.keys[0] ) );
   }
 }
-
-/* -------------------------------------------- */
 
 /**
  * Localize the values of a configuration object by translating them in-place.
@@ -648,9 +637,9 @@ function _localizeObject( obj, keys ) {
   }
 }
 
-/* -------------------------------------------- */
-/*                    Migration                 */
-/* -------------------------------------------- */
+// endregion
+
+// region Migration
 
 /**
  * Determine the new target value of an item setting based on its name referenced in a config.
@@ -667,9 +656,9 @@ export function determineConfigValue( slugifiedName, configMappings ) {
   return;
 }
 
-/* -------------------------------------------- */
-/*  Handlebars -  Template - Helpers            */
-/* -------------------------------------------- */
+// endregion
+
+// region Handlebars - Template - Helpers
 
 /**
  * Define a set of template paths to preload.
@@ -890,3 +879,5 @@ export async function preloadHandlebarsTemplates() {
 
   return foundry.applications.handlebars.loadTemplates( paths );
 }
+
+// endregion

--- a/module/workflows/workflow/_module.mjs
+++ b/module/workflows/workflow/_module.mjs
@@ -5,6 +5,7 @@ export { default as AttackWorkflow } from "./attack-workflow.mjs";
 export { default as AttuneGrimoireWorkflow } from "./attune-grimoire-workflow.mjs";
 export { default as AttuneMatrixWorkflow } from "./attune-matrix-workflow.mjs";
 export { default as SpellcastingWorkflow } from "./spellcasting-workflow.mjs";
+export { default as BaseCastingWorkflow } from "./base-casting-workflow.mjs";
 export { default as MatrixCastingWorkflow } from "./matrix-casting-workflow.mjs";
 export { default as GrimoireCastingWorkflow } from "./grimoire-casting-workflow.mjs";
 export { default as RawCastingWorkflow } from "./raw-casting-workflow.mjs";

--- a/module/workflows/workflow/_module.mjs
+++ b/module/workflows/workflow/_module.mjs
@@ -4,4 +4,8 @@ export { default as ActorWorkflow } from "./actor-workflow.mjs";
 export { default as AttackWorkflow } from "./attack-workflow.mjs";
 export { default as AttuneGrimoireWorkflow } from "./attune-grimoire-workflow.mjs";
 export { default as AttuneMatrixWorkflow } from "./attune-matrix-workflow.mjs";
+export { default as SpellcastingWorkflow } from "./spellcasting-workflow.mjs";
+export { default as MatrixCastingWorkflow } from "./matrix-casting-workflow.mjs";
+export { default as GrimoireCastingWorkflow } from "./grimoire-casting-workflow.mjs";
+export { default as RawCastingWorkflow } from "./raw-casting-workflow.mjs";
 export { default as Rollable } from "./rollable.mjs";

--- a/module/workflows/workflow/base-casting-workflow.mjs
+++ b/module/workflows/workflow/base-casting-workflow.mjs
@@ -1,0 +1,133 @@
+import ActorWorkflow from "./actor-workflow.mjs";
+import Rollable from "./rollable.mjs";
+import { getSetting } from "../../settings.mjs";
+
+/**
+ * @typedef {object} BaseCastingWorkflowOptions
+ * @property {boolean} [stopOnWeaving=true] - Whether to stop the workflow after thread weaving is required
+ */
+
+/**
+ * An interface that defines the contract all specialized casting workflows must implement.
+ * Formalizes the expected methods and properties for any workflow that
+ * handles a specific casting method.
+ * @abstract
+ */
+export default class BaseCastingWorkflow extends Rollable( ActorWorkflow ) {
+
+  /**
+   * The spell being cast
+   * @type {ItemEd}
+   */
+  _spell;
+
+  /**
+   * The ability used for spellcasting
+   * @type {ItemEd}
+   */
+  _spellcastingAbility;
+
+  /**
+   * The roll made for spellcasting
+   * @type {EdRoll}
+   */
+  _spellcastingRoll;
+
+  /**
+   * Whether to stop the workflow after thread weaving is required
+   * @type {boolean}
+   */
+  _stopOnWeaving = true;
+
+  /**
+   * The ability used for thread weaving
+   * @type {ItemEd}
+   */
+  _threadWeavingAbility;
+
+  /**
+   * The roll made for weaving threads, if needed
+   * @type {EdRoll}
+   */
+  _threadWeavingRoll;
+
+  /**
+   * @param {ActorEd} caster - The actor casting the spell
+   * @param {WorkflowOptions&BaseCastingWorkflowOptions} [options] - Options for the workflow
+   */
+  constructor( caster, options = {} ) {
+    if ( new.target === BaseCastingWorkflow ) {
+      throw new Error( "CastingWorkflowInterface is an abstract class and cannot be instantiated directly." );
+    }
+    super( caster, options );
+    this.stopOnWeaving = options.stopOnWeaving ?? true;
+  }
+
+  /**
+   * Prepare for thread weaving
+   * @returns {Promise<void>}
+   */
+  async _preWeaveThreads() {
+    this._threadWeavingAbility = this._actor.getThreadWeavingByCastingType( this._spell.system.spellcastingType );
+  }
+
+  /**
+   * Weave threads for the spell
+   * @returns {Promise<void>}
+   */
+  async _weaveThreads() {
+    if ( this._spell.system.isWeavingComplete ) return;
+
+    this._threadWeavingRoll = await this._spell.system.weaveThreads(
+      this._threadWeavingAbility,
+      this._matrix,
+    );
+
+    if ( this._stopOnWeaving ) {
+      this.cancel();
+    }
+  }
+
+  /**
+   * Prepare for spellcasting
+   * @returns {Promise<void>}
+   */
+  async _preCastSpell() {
+    this._spellcastingAbility = this._actor.getSingleItemByEdid(
+      getSetting( "edidSpellcasting" )
+    );
+  }
+
+  /**
+   * Perform the spellcasting test
+   * @returns {Promise<void>}
+   */
+  async _castSpell() {
+    this._spellcastingRoll = await this._spell.system.cast(
+      this._actor,
+      this._spellcastingAbility,
+    );
+  }
+
+  /**
+   * Handle any aftermath of the casting (drain, feedback, etc.)
+   * @abstract
+   * @returns {Promise<void>}
+   */
+  async _handleAftermath() {
+    throw new Error( "Method 'handleAftermath()' must be implemented by derived classes" );
+  }
+
+  /**
+   * Sets the final result of the casting
+   * @returns {object} The complete casting result
+   */
+  async _setResult() {
+    this._result = {
+      _threadWeavingRoll: this._threadWeavingRoll,
+      _spellcastingRoll:  this._spellcastingRoll,
+    };
+    return this._result;
+  }
+}
+

--- a/module/workflows/workflow/base-casting-workflow.mjs
+++ b/module/workflows/workflow/base-casting-workflow.mjs
@@ -37,7 +37,7 @@ export default class BaseCastingWorkflow extends Rollable( ActorWorkflow ) {
    * Whether to stop the workflow after thread weaving is required
    * @type {boolean}
    */
-  _stopOnWeaving = true;
+  _stopOnWeaving;
 
   /**
    * The ability used for thread weaving
@@ -60,7 +60,7 @@ export default class BaseCastingWorkflow extends Rollable( ActorWorkflow ) {
       throw new Error( "CastingWorkflowInterface is an abstract class and cannot be instantiated directly." );
     }
     super( caster, options );
-    this.stopOnWeaving = options.stopOnWeaving ?? true;
+    this._stopOnWeaving = options.stopOnWeaving ?? true;
   }
 
   /**

--- a/module/workflows/workflow/grimoire-casting-workflow.mjs
+++ b/module/workflows/workflow/grimoire-casting-workflow.mjs
@@ -45,7 +45,7 @@ export default class GrimoireCastingWorkflow extends BaseCastingWorkflow {
 
     if ( !grimoire ) {
       throw new WorkflowInterruptError( this,
-        game.i18n.localize( "ED.Notifications.Warn.spellcastingNoGrimoire" ) );
+        game.i18n.localize( "" ) );
     }
 
     // Check if the grimoire contains the spell
@@ -57,7 +57,7 @@ export default class GrimoireCastingWorkflow extends BaseCastingWorkflow {
 
     if ( !grimoireContainsSpell ) {
       throw new WorkflowInterruptError( this,
-        game.i18n.format( "ED.Notifications.Warn.spellcastingGrimoireDoesNotContainSpell", {
+        game.i18n.format( "", {
           spell: this._spell.name
         } ) );
     }
@@ -101,7 +101,7 @@ export default class GrimoireCastingWorkflow extends BaseCastingWorkflow {
       // If thread weaving fails, the workflow is interrupted
       if ( !isSuccess ) {
         throw new WorkflowInterruptError( this,
-          game.i18n.format( "ED.Notifications.Warn.spellcastingThreadWeavingFailed", {
+          game.i18n.format( "", {
             threadNumber: i + 1
           } ) );
       }
@@ -146,7 +146,7 @@ export default class GrimoireCastingWorkflow extends BaseCastingWorkflow {
 
     if ( !isSuccess ) {
       throw new WorkflowInterruptError( this,
-        game.i18n.localize( "ED.Notifications.Warn.spellcastingTestFailed" ) );
+        game.i18n.localize( "" ) );
     }
   }
 

--- a/module/workflows/workflow/grimoire-casting-workflow.mjs
+++ b/module/workflows/workflow/grimoire-casting-workflow.mjs
@@ -1,5 +1,4 @@
-import Workflow from "./workflow.mjs";
-import Rollable from "./rollable.mjs";
+import BaseCastingWorkflow from "./base-casting-workflow.mjs";
 
 /**
  * @typedef {import("./spellcasting-workflow.mjs").SpellcastingWorkflowOptions} SpellcastingWorkflowOptions
@@ -7,8 +6,15 @@ import Rollable from "./rollable.mjs";
 
 /**
  * Handles the workflow for casting a spell from a grimoire
+ * @augments BaseCastingWorkflow
  */
-export default class GrimoireCastingWorkflow extends Rollable( Workflow ) {
+export default class GrimoireCastingWorkflow extends BaseCastingWorkflow {
+
+  constructor() {
+    super();
+    throw new Error( "RawCastingWorkflow: Not implemented yet." );
+  }
+
   /* /!**
    * @param {SpellcastingWorkflowOptions} options
    *!/

--- a/module/workflows/workflow/grimoire-casting-workflow.mjs
+++ b/module/workflows/workflow/grimoire-casting-workflow.mjs
@@ -1,0 +1,451 @@
+import Workflow from "./workflow.mjs";
+import Rollable from "./rollable.mjs";
+
+/**
+ * @typedef {import("./spellcasting-workflow.mjs").SpellcastingWorkflowOptions} SpellcastingWorkflowOptions
+ */
+
+/**
+ * Handles the workflow for casting a spell from a grimoire
+ */
+export default class GrimoireCastingWorkflow extends Rollable( Workflow ) {
+  /* /!**
+   * @param {SpellcastingWorkflowOptions} options
+   *!/
+  constructor( options = {} ) {
+    // Ensure casting method is set to grimoire
+    options.castingMethod = "grimoire";
+    super( options );
+  }
+
+  /!**
+   * Prepare for thread weaving by validating the grimoire
+   * @override
+   *!/
+  async preWeaveThreads() {
+    this.validateGrimoire();
+
+    // If the grimoire is not attuned, the caster can still proceed but may suffer raw magic effects
+    if ( !this._grimoireData?.isAttuned ) {
+      console.log( "Grimoire is not attuned. Casting will proceed but may result in raw magic effects." );
+    }
+  }
+
+  /!**
+   * Validate that the grimoire contains the spell
+   *!/
+  validateGrimoire() {
+    const grimoire = this._grimoireData?.grimoire;
+
+    if ( !grimoire ) {
+      throw new WorkflowInterruptError( this,
+        game.i18n.localize( "ED.Notifications.Warn.spellcastingNoGrimoire" ) );
+    }
+
+    // Check if the grimoire contains the spell
+    // This would depend on how grimoires are implemented in the system
+    const grimoireSpells = grimoire.system.spells || [];
+    const grimoireContainsSpell = grimoireSpells.some( s =>
+      s.id === this._spell.id || s.name === this._spell.name
+    );
+
+    if ( !grimoireContainsSpell ) {
+      throw new WorkflowInterruptError( this,
+        game.i18n.format( "ED.Notifications.Warn.spellcastingGrimoireDoesNotContainSpell", {
+          spell: this._spell.name
+        } ) );
+    }
+  }
+
+  /!**
+   * Weave threads for the spell
+   * @override
+   *!/
+  async weaveThreads() {
+    const requiredThreads = this._spell.system.threads?.required || 0;
+    const totalThreads = requiredThreads + this._additionalThreads;
+    const isOwnGrimoire = this._grimoireData?.isOwnGrimoire || false;
+
+    if ( totalThreads <= 0 ) {
+      return;
+    }
+
+    // For non-own grimoires, there's a -2 penalty to Thread Weaving
+    const threadWeavingPenalty = isOwnGrimoire ? 0 : -2;
+
+    // Handle thread weaving for each required thread
+    for ( let i = 0; i < totalThreads; i++ ) {
+      // Create a thread weaving roll with the appropriate penalty
+      const threadWeavingRoll = await this.createThreadWeavingRoll( { stepModifier: threadWeavingPenalty } );
+
+      // Determine success based on the roll result vs difficulty
+      const difficultyTarget = this._spell.system.threadDifficulty || this._spell.system.circle + 5;
+      const isSuccess = threadWeavingRoll.total >= difficultyTarget;
+
+      const threadWeavingResult = {
+        roll:             threadWeavingRoll,
+        success:          isSuccess,
+        threadIndex:      i,
+        difficultyTarget: difficultyTarget,
+        penalty:          threadWeavingPenalty
+      };
+
+      this._threadWeavingResults.push( threadWeavingResult );
+
+      // If thread weaving fails, the workflow is interrupted
+      if ( !isSuccess ) {
+        throw new WorkflowInterruptError( this,
+          game.i18n.format( "ED.Notifications.Warn.spellcastingThreadWeavingFailed", {
+            threadNumber: i + 1
+          } ) );
+      }
+    }
+  }
+
+  /!**
+   * Prepare for spellcasting
+   * @override
+   *!/
+  async preCastSpell() {
+    // Grimoire casting doesn't need special preparation beyond thread weaving
+  }
+
+  /!**
+   * Cast the spell using the grimoire
+   * @override
+   *!/
+  async castSpell() {
+    const isOwnGrimoire = this._grimoireData?.isOwnGrimoire || false;
+
+    // For non-own grimoires, there's a -2 penalty to Spellcasting
+    const spellcastingPenalty = isOwnGrimoire ? 0 : -2;
+
+    // Create a spellcasting roll with the appropriate penalty
+    const spellcastingRoll = await this.createSpellcastingRoll( { stepModifier: spellcastingPenalty } );
+
+    // Determine success
+    const difficultyTarget = this._spell.system.difficulty ||
+                           ( this._targets.length > 0 ? this._targets[0].system.defense?.mystic?.value : 0 ) ||
+                           this._spell.system.circle + 5;
+
+    const isSuccess = spellcastingRoll.total >= difficultyTarget;
+
+    this._spellcastingResult = {
+      roll:             spellcastingRoll,
+      success:          isSuccess,
+      difficultyTarget: difficultyTarget,
+      penalty:          spellcastingPenalty,
+      extraSuccesses:   Math.max( 0, Math.floor( ( spellcastingRoll.total - difficultyTarget ) / 5 ) )
+    };
+
+    if ( !isSuccess ) {
+      throw new WorkflowInterruptError( this,
+        game.i18n.localize( "ED.Notifications.Warn.spellcastingTestFailed" ) );
+    }
+  }
+
+  /!**
+   * Determine the effect of the spell
+   * If using own grimoire, gain an extra success
+   * @override
+   *!/
+  async determineEffect() {
+    const isOwnGrimoire = this._grimoireData?.isOwnGrimoire || false;
+
+    // If using own grimoire, add an extra success
+    if ( isOwnGrimoire && this._spellcastingResult.success ) {
+      this._spellcastingResult.extraSuccesses += 1;
+    }
+
+    // Calculate the effect based on the spell's properties and spellcasting result
+    this._effectResult = {
+      damage:           this.calculateSpellDamage(),
+      duration:         this.calculateSpellDuration(),
+      range:            this.calculateSpellRange(),
+      area:             this.calculateSpellArea(),
+      extraEffects:     this._spellcastingResult.extraSuccesses > 0,
+      ownGrimoireBonus: isOwnGrimoire
+    };
+  }
+
+  /!**
+   * Calculate the spell's damage if applicable
+   * @returns {object|null} Damage information or null if not applicable
+   *!/
+  calculateSpellDamage() {
+    // If the spell does damage, calculate it
+    if ( this._spell.system.damage?.does ) {
+      const baseDamageStep = this._spell.system.damage?.step || 0;
+      const totalDamageStep = baseDamageStep + this._spellcastingResult.extraSuccesses;
+
+      return {
+        step:           totalDamageStep,
+        extraSuccesses: this._spellcastingResult.extraSuccesses
+      };
+    }
+
+    return null;
+  }
+
+  /!**
+   * Calculate the spell's duration
+   * @returns {object} Duration information
+   *!/
+  calculateSpellDuration() {
+    const baseDuration = this._spell.system.duration?.base || 0;
+    const durationUnit = this._spell.system.duration?.unit || "rounds";
+    let totalDuration = baseDuration;
+
+    // Some spells increase duration with extra successes
+    if ( this._spell.system.duration?.increasesWithSuccess ) {
+      totalDuration += this._spellcastingResult.extraSuccesses * ( this._spell.system.duration?.perSuccess || 1 );
+    }
+
+    return {
+      value:          totalDuration,
+      unit:           durationUnit,
+      extraSuccesses: this._spellcastingResult.extraSuccesses
+    };
+  }
+
+  /!**
+   * Calculate the spell's range
+   * @returns {object} Range information
+   *!/
+  calculateSpellRange() {
+    const baseRange = this._spell.system.range?.base || 0;
+    const rangeUnit = this._spell.system.range?.unit || "yards";
+    let totalRange = baseRange;
+
+    // Some spells increase range with extra successes
+    if ( this._spell.system.range?.increasesWithSuccess ) {
+      totalRange += this._spellcastingResult.extraSuccesses * ( this._spell.system.range?.perSuccess || 5 );
+    }
+
+    return {
+      value: totalRange,
+      unit:  rangeUnit
+    };
+  }
+
+  /!**
+   * Calculate the spell's area of effect
+   * @returns {object|null} Area information or null if not applicable
+   *!/
+  calculateSpellArea() {
+    if ( !this._spell.system.area?.does ) return null;
+
+    const baseArea = this._spell.system.area?.base || 0;
+    const areaUnit = this._spell.system.area?.unit || "yards";
+    let totalArea = baseArea;
+
+    // Some spells increase area with extra successes
+    if ( this._spell.system.area?.increasesWithSuccess ) {
+      totalArea += this._spellcastingResult.extraSuccesses * ( this._spell.system.area?.perSuccess || 1 );
+    }
+
+    return {
+      value: totalArea,
+      unit:  areaUnit
+    };
+  }
+
+  /!**
+   * Apply any additional effects based on casting method
+   * For grimoire casting, if the grimoire is not attuned, apply raw magic effects
+   * @override
+   *!/
+  async applyAdditionalEffects() {
+    const isAttuned = this._grimoireData?.isAttuned || false;
+
+    // If the grimoire is attuned, no additional effects
+    if ( isAttuned ) {
+      return;
+    }
+
+    // If not attuned, apply raw magic effects
+    // This should be similar to the raw casting workflow
+    const astralSpaceType = this._grimoireData?.astralSpaceType || "safe";
+    this._rawMagicResults = await this._applyRawMagicEffects( astralSpaceType );
+  }
+
+  /!**
+   * Apply raw magic effects
+   * @param {string} astralSpaceType - The classification of the local astral space
+   * @returns {object} The results of the raw magic effects
+   * @private
+   *!/
+  async _applyRawMagicEffects( astralSpaceType ) {
+    // This is similar to what would be in the RawCastingWorkflow
+    const spellCircle = this._spell.system.circle || 1;
+
+    // Determine warping and damage steps based on astral space type
+    const warpingSteps = {
+      "safe":    spellCircle,
+      "open":    spellCircle + 5,
+      "tainted": spellCircle + 10,
+      "corrupt": spellCircle + 15
+    };
+
+    const damageSteps = {
+      "safe":    spellCircle + 4,
+      "open":    spellCircle + 8,
+      "tainted": spellCircle + 12,
+      "corrupt": spellCircle + 16
+    };
+
+    const horrorMarkSteps = {
+      "safe":    0, // No horror mark in safe space
+      "open":    spellCircle + 2,
+      "tainted": spellCircle + 5,
+      "corrupt": spellCircle + 10
+    };
+
+    // Perform warping test
+    const warpingStep = warpingSteps[astralSpaceType] || spellCircle;
+    const warpingResult = await this._performWarpingTest( warpingStep );
+
+    // If warping test succeeds, perform damage test
+    let damageResult = null;
+    if ( warpingResult.success ) {
+      const damageStep = damageSteps[astralSpaceType] || ( spellCircle + 4 );
+      damageResult = await this._performDamageTest( damageStep );
+    }
+
+    // Perform horror mark test if in dangerous astral space
+    let horrorMarkResult = null;
+    if ( astralSpaceType !== "safe" ) {
+      const horrorMarkStep = horrorMarkSteps[astralSpaceType] || 0;
+      if ( horrorMarkStep > 0 ) {
+        horrorMarkResult = await this._performHorrorMarkTest( horrorMarkStep );
+      }
+    }
+
+    return {
+      astralSpaceType,
+      warping:    warpingResult,
+      damage:     damageResult,
+      horrorMark: horrorMarkResult
+    };
+  }
+
+  /!**
+   * Perform a warping test
+   * @param {number} warpingStep - The step number for the warping test
+   * @returns {object} The result of the warping test
+   * @private
+   *!/
+  async _performWarpingTest( warpingStep ) {
+    // Get the caster's mystic defense
+    const casterMysticDefense = this._caster.system.defense?.mystic?.value || 0;
+
+    // Create roll options for the warping test
+    const rollOptions = {
+      step: {
+        base:  warpingStep,
+        total: warpingStep
+      },
+      testType: "effect",
+      rollType: "warpingTest",
+      actor:    null, // No actor for this roll
+      target:   {
+        base:  casterMysticDefense,
+        total: casterMysticDefense
+      }
+    };
+
+    // Create and evaluate the roll
+    const roll = new EdRoll( rollOptions );
+    await roll.evaluate( { async: true } );
+
+    // Determine if the warping succeeds (roll >= mystic defense)
+    const success = roll.total >= casterMysticDefense;
+
+    return {
+      roll:    roll,
+      success: success,
+      step:    warpingStep,
+      target:  casterMysticDefense
+    };
+  }
+
+  /!**
+   * Perform a damage test from raw magic
+   * @param {number} damageStep - The step number for the damage test
+   * @returns {object} The result of the damage test
+   * @private
+   *!/
+  async _performDamageTest( damageStep ) {
+    // Get the caster's mystic armor
+    const casterMysticArmor = this._caster.system.armor?.mystic?.value || 0;
+
+    // Create roll options for the damage test
+    const rollOptions = {
+      step: {
+        base:  damageStep,
+        total: damageStep
+      },
+      testType: "effect",
+      rollType: "damageTest",
+      actor:    null, // No actor for this roll
+      damage:   {
+        type:       "mystic",
+        armorValue: casterMysticArmor
+      }
+    };
+
+    // Create and evaluate the roll
+    const roll = new EdRoll( rollOptions );
+    await roll.evaluate( { async: true } );
+
+    // Calculate final damage after armor
+    const finalDamage = Math.max( 0, roll.total - casterMysticArmor );
+
+    return {
+      roll:        roll,
+      step:        damageStep,
+      mysticArmor: casterMysticArmor,
+      damage:      finalDamage
+    };
+  }
+
+  /!**
+   * Perform a horror mark test
+   * @param {number} horrorMarkStep - The step number for the horror mark test
+   * @returns {object} The result of the horror mark test
+   * @private
+   *!/
+  async _performHorrorMarkTest( horrorMarkStep ) {
+    // Get the caster's mystic defense
+    const casterMysticDefense = this._caster.system.defense?.mystic?.value || 0;
+
+    // Create roll options for the horror mark test
+    const rollOptions = {
+      step: {
+        base:  horrorMarkStep,
+        total: horrorMarkStep
+      },
+      testType: "effect",
+      rollType: "horrorMarkTest",
+      actor:    null, // No actor for this roll
+      target:   {
+        base:  casterMysticDefense,
+        total: casterMysticDefense
+      }
+    };
+
+    // Create and evaluate the roll
+    const roll = new EdRoll( rollOptions );
+    await roll.evaluate( { async: true } );
+
+    // Determine if the horror mark test succeeds (roll >= mystic defense)
+    const success = roll.total >= casterMysticDefense;
+
+    return {
+      roll:    roll,
+      success: success,
+      step:    horrorMarkStep,
+      target:  casterMysticDefense
+    };
+  } */
+}

--- a/module/workflows/workflow/matrix-casting-workflow.mjs
+++ b/module/workflows/workflow/matrix-casting-workflow.mjs
@@ -1,6 +1,5 @@
-import Rollable from "./rollable.mjs";
-import ActorWorkflow from "./actor-workflow.mjs";
-// import WorkflowInterruptError from "../workflow-interrupt.mjs";
+import WorkflowInterruptError from "../workflow-interrupt.mjs";
+import BaseCastingWorkflow from "./base-casting-workflow.mjs";
 
 /**
  * @typedef MatrixCastingWorkflowOptions
@@ -11,26 +10,36 @@ import ActorWorkflow from "./actor-workflow.mjs";
 /**
  * Handles the workflow for casting a spell from a matrix
  */
-export default class MatrixCastingWorkflow extends Rollable( ActorWorkflow ) {
-/*
-  /!**
+export default class MatrixCastingWorkflow extends BaseCastingWorkflow {
+
+  /**
+   * The matrix being used for casting
+   * @type {ItemEd}
+   */
+  _matrix;
+
+  /**
    * @param {ActorEd} caster - The actor casting the spell
    * @param {MatrixCastingWorkflowOptions} options - Options for the workflow
-   *!/
+   */
   constructor( caster, options ) {
     super( caster, options );
     this._matrix = options.matrix;
 
     this._steps.push(
-      this.#ensureActiveSpell.bind( this ),
-      this.#weaveThreads.bind( this ),
+      this._preWeaveThreads.bind( this ),
+      this._weaveThreads.bind( this ),
+      this._preCastSpell.bind( this ),
+      this._castSpell.bind( this ),
+      this._setResult.bind( this ),
     );
   }
 
-  async #ensureActiveSpell() {
+  /** @inheritDoc */
+  async _preWeaveThreads() {
     const activeSpell = await this._matrix.system.getActiveSpell();
 
-    if ( activeSpell.system?.getAttunedMatrix()?.uuid !== this._matrix.uuid ) {
+    if ( activeSpell?.system?.getAttunedMatrix()?.uuid !== this._matrix.uuid ) {
       throw new WorkflowInterruptError(
         this,
         game.i18n.localize( "ED.Notifications.Error.matrixCastingSpellNotAttuned" ),
@@ -38,152 +47,13 @@ export default class MatrixCastingWorkflow extends Rollable( ActorWorkflow ) {
     }
 
     this._spell = activeSpell;
+
+    await super._preWeaveThreads();
   }
 
-  async #weaveThreads() {
-
+  /** @inheritDoc */
+  async _handleAftermath() {
+    // No aftermath handling needed for matrix casting
   }
-
-  /!**
-   * Prepare for spellcasting
-   * @override
-   *!/
-  async preCastSpell() {
-    // Matrix casting doesn't need special preparation beyond thread weaving
-  }
-
-  /!**
-   * Cast the spell using the matrix
-   * @override
-   *!/
-  async castSpell() {
-    // Create a spellcasting roll
-    const spellcastingRoll = await this.createSpellcastingRoll( { stepModifier: 0 } );
-
-    // Determine success
-    const difficultyTarget = this._spell.system.difficulty ||
-                           ( this._targets.length > 0 ? this._targets[0].system.defense?.mystic?.value : 0 ) ||
-                           this._spell.system.circle + 5;
-
-    const isSuccess = spellcastingRoll.total >= difficultyTarget;
-
-    this._spellcastingResult = {
-      roll:             spellcastingRoll,
-      success:          isSuccess,
-      difficultyTarget: difficultyTarget,
-      extraSuccesses:   Math.max( 0, Math.floor( ( spellcastingRoll.total - difficultyTarget ) / 5 ) )
-    };
-
-    if ( !isSuccess ) {
-      throw new WorkflowInterruptError( this,
-        game.i18n.localize( "ED.Notifications.Warn.spellcastingTestFailed" ) );
-    }
-  }
-
-  /!**
-   * Determine the effect of the spell based on the spellcasting result
-   * @override
-   *!/
-  async determineEffect() {
-    // Calculate the effect based on the spell's properties and spellcasting result
-    this._effectResult = {
-      damage:       this.calculateSpellDamage(),
-      duration:     this.calculateSpellDuration(),
-      range:        this.calculateSpellRange(),
-      area:         this.calculateSpellArea(),
-      extraEffects: this._spellcastingResult.extraSuccesses > 0
-    };
-  }
-
-  /!**
-   * Calculate the spell's damage if applicable
-   * @returns {object|null} Damage information or null if not applicable
-   *!/
-  calculateSpellDamage() {
-    // If the spell does damage, calculate it
-    if ( this._spell.system.damage?.does ) {
-      const baseDamageStep = this._spell.system.damage?.step || 0;
-      const totalDamageStep = baseDamageStep + this._spellcastingResult.extraSuccesses;
-
-      return {
-        step:           totalDamageStep,
-        extraSuccesses: this._spellcastingResult.extraSuccesses
-      };
-    }
-
-    return null;
-  }
-
-  /!**
-   * Calculate the spell's duration
-   * @returns {object} Duration information
-   *!/
-  calculateSpellDuration() {
-    const baseDuration = this._spell.system.duration?.base || 0;
-    const durationUnit = this._spell.system.duration?.unit || "rounds";
-    let totalDuration = baseDuration;
-
-    // Some spells increase duration with extra successes
-    if ( this._spell.system.duration?.increasesWithSuccess ) {
-      totalDuration += this._spellcastingResult.extraSuccesses * ( this._spell.system.duration?.perSuccess || 1 );
-    }
-
-    return {
-      value:          totalDuration,
-      unit:           durationUnit,
-      extraSuccesses: this._spellcastingResult.extraSuccesses
-    };
-  }
-
-  /!**
-   * Calculate the spell's range
-   * @returns {object} Range information
-   *!/
-  calculateSpellRange() {
-    const baseRange = this._spell.system.range?.base || 0;
-    const rangeUnit = this._spell.system.range?.unit || "yards";
-    let totalRange = baseRange;
-
-    // Some spells increase range with extra successes
-    if ( this._spell.system.range?.increasesWithSuccess ) {
-      totalRange += this._spellcastingResult.extraSuccesses * ( this._spell.system.range?.perSuccess || 5 );
-    }
-
-    return {
-      value: totalRange,
-      unit:  rangeUnit
-    };
-  }
-
-  /!**
-   * Calculate the spell's area of effect
-   * @returns {object|null} Area information or null if not applicable
-   *!/
-  calculateSpellArea() {
-    if ( !this._spell.system.area?.does ) return null;
-
-    const baseArea = this._spell.system.area?.base || 0;
-    const areaUnit = this._spell.system.area?.unit || "yards";
-    let totalArea = baseArea;
-
-    // Some spells increase area with extra successes
-    if ( this._spell.system.area?.increasesWithSuccess ) {
-      totalArea += this._spellcastingResult.extraSuccesses * ( this._spell.system.area?.perSuccess || 1 );
-    }
-
-    return {
-      value: totalArea,
-      unit:  areaUnit
-    };
-  }
-
-  /!**
-   * Apply any additional effects - for matrix casting, there typically aren't any
-   * negative consequences like with raw magic
-   * @override
-   *!/
-  async applyAdditionalEffects() {
-    // Matrix casting doesn't typically have additional negative effects
-  } */
 }
 

--- a/module/workflows/workflow/matrix-casting-workflow.mjs
+++ b/module/workflows/workflow/matrix-casting-workflow.mjs
@@ -1,0 +1,189 @@
+import Rollable from "./rollable.mjs";
+import ActorWorkflow from "./actor-workflow.mjs";
+// import WorkflowInterruptError from "../workflow-interrupt.mjs";
+
+/**
+ * @typedef MatrixCastingWorkflowOptions
+ * @property {ItemEd} matrix - The matrix being used for casting. Must be attuned to the spell.
+ * @property {ItemEd} [spell] - The spell being cast
+ */
+
+/**
+ * Handles the workflow for casting a spell from a matrix
+ */
+export default class MatrixCastingWorkflow extends Rollable( ActorWorkflow ) {
+/*
+  /!**
+   * @param {ActorEd} caster - The actor casting the spell
+   * @param {MatrixCastingWorkflowOptions} options - Options for the workflow
+   *!/
+  constructor( caster, options ) {
+    super( caster, options );
+    this._matrix = options.matrix;
+
+    this._steps.push(
+      this.#ensureActiveSpell.bind( this ),
+      this.#weaveThreads.bind( this ),
+    );
+  }
+
+  async #ensureActiveSpell() {
+    const activeSpell = await this._matrix.system.getActiveSpell();
+
+    if ( activeSpell.system?.getAttunedMatrix()?.uuid !== this._matrix.uuid ) {
+      throw new WorkflowInterruptError(
+        this,
+        game.i18n.localize( "ED.Notifications.Error.matrixCastingSpellNotAttuned" ),
+      );
+    }
+
+    this._spell = activeSpell;
+  }
+
+  async #weaveThreads() {
+
+  }
+
+  /!**
+   * Prepare for spellcasting
+   * @override
+   *!/
+  async preCastSpell() {
+    // Matrix casting doesn't need special preparation beyond thread weaving
+  }
+
+  /!**
+   * Cast the spell using the matrix
+   * @override
+   *!/
+  async castSpell() {
+    // Create a spellcasting roll
+    const spellcastingRoll = await this.createSpellcastingRoll( { stepModifier: 0 } );
+
+    // Determine success
+    const difficultyTarget = this._spell.system.difficulty ||
+                           ( this._targets.length > 0 ? this._targets[0].system.defense?.mystic?.value : 0 ) ||
+                           this._spell.system.circle + 5;
+
+    const isSuccess = spellcastingRoll.total >= difficultyTarget;
+
+    this._spellcastingResult = {
+      roll:             spellcastingRoll,
+      success:          isSuccess,
+      difficultyTarget: difficultyTarget,
+      extraSuccesses:   Math.max( 0, Math.floor( ( spellcastingRoll.total - difficultyTarget ) / 5 ) )
+    };
+
+    if ( !isSuccess ) {
+      throw new WorkflowInterruptError( this,
+        game.i18n.localize( "ED.Notifications.Warn.spellcastingTestFailed" ) );
+    }
+  }
+
+  /!**
+   * Determine the effect of the spell based on the spellcasting result
+   * @override
+   *!/
+  async determineEffect() {
+    // Calculate the effect based on the spell's properties and spellcasting result
+    this._effectResult = {
+      damage:       this.calculateSpellDamage(),
+      duration:     this.calculateSpellDuration(),
+      range:        this.calculateSpellRange(),
+      area:         this.calculateSpellArea(),
+      extraEffects: this._spellcastingResult.extraSuccesses > 0
+    };
+  }
+
+  /!**
+   * Calculate the spell's damage if applicable
+   * @returns {object|null} Damage information or null if not applicable
+   *!/
+  calculateSpellDamage() {
+    // If the spell does damage, calculate it
+    if ( this._spell.system.damage?.does ) {
+      const baseDamageStep = this._spell.system.damage?.step || 0;
+      const totalDamageStep = baseDamageStep + this._spellcastingResult.extraSuccesses;
+
+      return {
+        step:           totalDamageStep,
+        extraSuccesses: this._spellcastingResult.extraSuccesses
+      };
+    }
+
+    return null;
+  }
+
+  /!**
+   * Calculate the spell's duration
+   * @returns {object} Duration information
+   *!/
+  calculateSpellDuration() {
+    const baseDuration = this._spell.system.duration?.base || 0;
+    const durationUnit = this._spell.system.duration?.unit || "rounds";
+    let totalDuration = baseDuration;
+
+    // Some spells increase duration with extra successes
+    if ( this._spell.system.duration?.increasesWithSuccess ) {
+      totalDuration += this._spellcastingResult.extraSuccesses * ( this._spell.system.duration?.perSuccess || 1 );
+    }
+
+    return {
+      value:          totalDuration,
+      unit:           durationUnit,
+      extraSuccesses: this._spellcastingResult.extraSuccesses
+    };
+  }
+
+  /!**
+   * Calculate the spell's range
+   * @returns {object} Range information
+   *!/
+  calculateSpellRange() {
+    const baseRange = this._spell.system.range?.base || 0;
+    const rangeUnit = this._spell.system.range?.unit || "yards";
+    let totalRange = baseRange;
+
+    // Some spells increase range with extra successes
+    if ( this._spell.system.range?.increasesWithSuccess ) {
+      totalRange += this._spellcastingResult.extraSuccesses * ( this._spell.system.range?.perSuccess || 5 );
+    }
+
+    return {
+      value: totalRange,
+      unit:  rangeUnit
+    };
+  }
+
+  /!**
+   * Calculate the spell's area of effect
+   * @returns {object|null} Area information or null if not applicable
+   *!/
+  calculateSpellArea() {
+    if ( !this._spell.system.area?.does ) return null;
+
+    const baseArea = this._spell.system.area?.base || 0;
+    const areaUnit = this._spell.system.area?.unit || "yards";
+    let totalArea = baseArea;
+
+    // Some spells increase area with extra successes
+    if ( this._spell.system.area?.increasesWithSuccess ) {
+      totalArea += this._spellcastingResult.extraSuccesses * ( this._spell.system.area?.perSuccess || 1 );
+    }
+
+    return {
+      value: totalArea,
+      unit:  areaUnit
+    };
+  }
+
+  /!**
+   * Apply any additional effects - for matrix casting, there typically aren't any
+   * negative consequences like with raw magic
+   * @override
+   *!/
+  async applyAdditionalEffects() {
+    // Matrix casting doesn't typically have additional negative effects
+  } */
+}
+

--- a/module/workflows/workflow/raw-casting-workflow.mjs
+++ b/module/workflows/workflow/raw-casting-workflow.mjs
@@ -1,5 +1,4 @@
-import Workflow from "./workflow.mjs";
-import Rollable from "./rollable.mjs";
+import BaseCastingWorkflow from "./base-casting-workflow.mjs";
 
 /**
  * @typedef {import("./spellcasting-workflow.mjs").SpellcastingWorkflowOptions} SpellcastingWorkflowOptions
@@ -7,9 +6,15 @@ import Rollable from "./rollable.mjs";
 
 /**
  * Handles the workflow for casting a spell using raw magic
- * @implements {BaseCastingWorkflow}
+ * @augments {BaseCastingWorkflow}
  */
-export default class RawCastingWorkflow extends Rollable( Workflow ) {
+export default class RawCastingWorkflow extends BaseCastingWorkflow {
+
+  constructor() {
+    super();
+    throw new Error( "RawCastingWorkflow: Not implemented yet." );
+  }
+
   /* /!**
    * The type of astral space (safe, open, tainted, corrupt)
    * @type {string}
@@ -394,7 +399,8 @@ export default class RawCastingWorkflow extends Rollable( Workflow ) {
       target:  casterMysticDefense
     };
   } */
-/*
+
+  /*
   /!**
    * Additional results specific to raw magic
    * @type {object}

--- a/module/workflows/workflow/raw-casting-workflow.mjs
+++ b/module/workflows/workflow/raw-casting-workflow.mjs
@@ -1,0 +1,396 @@
+import Workflow from "./workflow.mjs";
+import Rollable from "./rollable.mjs";
+
+/**
+ * @typedef {import("./spellcasting-workflow.mjs").SpellcastingWorkflowOptions} SpellcastingWorkflowOptions
+ */
+
+/**
+ * Handles the workflow for casting a spell using raw magic
+ */
+export default class RawCastingWorkflow extends Rollable( Workflow ) {
+  /* /!**
+   * The type of astral space (safe, open, tainted, corrupt)
+   * @type {string}
+   *!/
+  _astralSpaceType = "safe";
+
+  /!**
+   * @param {SpellcastingWorkflowOptions} options
+   *!/
+  constructor( options = {} ) {
+    // Ensure casting method is set to raw
+    options.castingMethod = "raw";
+    super( options );
+
+    // Raw casting specific properties
+    this._astralSpaceType = this._rawData?.astralSpaceType || "safe";
+  }
+
+  // region Properties
+
+  get astralSpaceType() { return this._astralSpaceType; }
+
+  // endregion
+
+  /!**
+   * Prepare for thread weaving
+   * Raw casting doesn't require special preparation
+   * @override
+   *!/
+  async preWeaveThreads() {
+    // Warn the caster about the dangers of raw magic
+    console.log( `Casting with raw magic in ${this._astralSpaceType} astral space. This may result in harmful effects.` );
+  }
+
+  /!**
+   * Weave threads for the spell
+   * @override
+   *!/
+  async weaveThreads() {
+    const requiredThreads = this._spell.system.threads?.required || 0;
+    const totalThreads = requiredThreads + this._additionalThreads;
+
+    if ( totalThreads <= 0 ) {
+      return;
+    }
+
+    // Handle thread weaving for each required thread
+    for ( let i = 0; i < totalThreads; i++ ) {
+      // Create a thread weaving roll
+      const threadWeavingRoll = await this.createThreadWeavingRoll( { stepModifier: 0 } );
+
+      // Determine success based on the roll result vs difficulty
+      const difficultyTarget = this._spell.system.threadDifficulty || this._spell.system.circle + 5;
+      const isSuccess = threadWeavingRoll.total >= difficultyTarget;
+
+      const threadWeavingResult = {
+        roll:             threadWeavingRoll,
+        success:          isSuccess,
+        threadIndex:      i,
+        difficultyTarget: difficultyTarget
+      };
+
+      this._threadWeavingResults.push( threadWeavingResult );
+
+      // If thread weaving fails, the workflow is interrupted
+      if ( !isSuccess ) {
+        throw new WorkflowInterruptError( this,
+          game.i18n.format( "ED.Notifications.Warn.spellcastingThreadWeavingFailed", {
+            threadNumber: i + 1
+          } ) );
+      }
+    }
+  }
+
+  /!**
+   * Prepare for spellcasting
+   * @override
+   *!/
+  async preCastSpell() {
+    // Raw casting doesn't need special preparation beyond thread weaving
+  }
+
+  /!**
+   * Cast the spell using raw magic
+   * @override
+   *!/
+  async castSpell() {
+    // Create a spellcasting roll
+    const spellcastingRoll = await this.createSpellcastingRoll( { stepModifier: 0 } );
+
+    // Determine success
+    const difficultyTarget = this._spell.system.difficulty ||
+                           ( this._targets.length > 0 ? this._targets[0].system.defense?.mystic?.value : 0 ) ||
+                           this._spell.system.circle + 5;
+
+    const isSuccess = spellcastingRoll.total >= difficultyTarget;
+
+    this._spellcastingResult = {
+      roll:             spellcastingRoll,
+      success:          isSuccess,
+      difficultyTarget: difficultyTarget,
+      extraSuccesses:   Math.max( 0, Math.floor( ( spellcastingRoll.total - difficultyTarget ) / 5 ) )
+    };
+
+    if ( !isSuccess ) {
+      throw new WorkflowInterruptError( this,
+        game.i18n.localize( "ED.Notifications.Warn.spellcastingTestFailed" ) );
+    }
+  }
+
+  /!**
+   * Determine the effect of the spell based on the spellcasting result
+   * @override
+   *!/
+  async determineEffect() {
+    // Calculate the effect based on the spell's properties and spellcasting result
+    this._effectResult = {
+      damage:       this.calculateSpellDamage(),
+      duration:     this.calculateSpellDuration(),
+      range:        this.calculateSpellRange(),
+      area:         this.calculateSpellArea(),
+      extraEffects: this._spellcastingResult.extraSuccesses > 0
+    };
+  }
+
+  /!**
+   * Calculate the spell's damage if applicable
+   * @returns {object|null} Damage information or null if not applicable
+   *!/
+  calculateSpellDamage() {
+    // If the spell does damage, calculate it
+    if ( this._spell.system.damage?.does ) {
+      const baseDamageStep = this._spell.system.damage?.step || 0;
+      const totalDamageStep = baseDamageStep + this._spellcastingResult.extraSuccesses;
+
+      return {
+        step:           totalDamageStep,
+        extraSuccesses: this._spellcastingResult.extraSuccesses
+      };
+    }
+
+    return null;
+  }
+
+  /!**
+   * Calculate the spell's duration
+   * @returns {object} Duration information
+   *!/
+  calculateSpellDuration() {
+    const baseDuration = this._spell.system.duration?.base || 0;
+    const durationUnit = this._spell.system.duration?.unit || "rounds";
+    let totalDuration = baseDuration;
+
+    // Some spells increase duration with extra successes
+    if ( this._spell.system.duration?.increasesWithSuccess ) {
+      totalDuration += this._spellcastingResult.extraSuccesses * ( this._spell.system.duration?.perSuccess || 1 );
+    }
+
+    return {
+      value:          totalDuration,
+      unit:           durationUnit,
+      extraSuccesses: this._spellcastingResult.extraSuccesses
+    };
+  }
+
+  /!**
+   * Calculate the spell's range
+   * @returns {object} Range information
+   *!/
+  calculateSpellRange() {
+    const baseRange = this._spell.system.range?.base || 0;
+    const rangeUnit = this._spell.system.range?.unit || "yards";
+    let totalRange = baseRange;
+
+    // Some spells increase range with extra successes
+    if ( this._spell.system.range?.increasesWithSuccess ) {
+      totalRange += this._spellcastingResult.extraSuccesses * ( this._spell.system.range?.perSuccess || 5 );
+    }
+
+    return {
+      value: totalRange,
+      unit:  rangeUnit
+    };
+  }
+
+  /!**
+   * Calculate the spell's area of effect
+   * @returns {object|null} Area information or null if not applicable
+   *!/
+  calculateSpellArea() {
+    if ( !this._spell.system.area?.does ) return null;
+
+    const baseArea = this._spell.system.area?.base || 0;
+    const areaUnit = this._spell.system.area?.unit || "yards";
+    let totalArea = baseArea;
+
+    // Some spells increase area with extra successes
+    if ( this._spell.system.area?.increasesWithSuccess ) {
+      totalArea += this._spellcastingResult.extraSuccesses * ( this._spell.system.area?.perSuccess || 1 );
+    }
+
+    return {
+      value: totalArea,
+      unit:  areaUnit
+    };
+  }
+
+  /!**
+   * Apply additional effects for raw magic casting
+   * This includes Warping, Damage, and Horror Mark tests
+   * @override
+   *!/
+  async applyAdditionalEffects() {
+    const spellCircle = this._spell.system.circle || 1;
+
+    // Determine warping and damage steps based on astral space type
+    const warpingSteps = {
+      "safe":    spellCircle,
+      "open":    spellCircle + 5,
+      "tainted": spellCircle + 10,
+      "corrupt": spellCircle + 15
+    };
+
+    const damageSteps = {
+      "safe":    spellCircle + 4,
+      "open":    spellCircle + 8,
+      "tainted": spellCircle + 12,
+      "corrupt": spellCircle + 16
+    };
+
+    const horrorMarkSteps = {
+      "safe":    0, // No horror mark in safe space
+      "open":    spellCircle + 2,
+      "tainted": spellCircle + 5,
+      "corrupt": spellCircle + 10
+    };
+
+    // Perform warping test
+    const warpingStep = warpingSteps[this._astralSpaceType] || spellCircle;
+    const warpingResult = await this._performWarpingTest( warpingStep );
+
+    // If warping test succeeds, perform damage test
+    let damageResult = null;
+    if ( warpingResult.success ) {
+      const damageStep = damageSteps[this._astralSpaceType] || ( spellCircle + 4 );
+      damageResult = await this._performDamageTest( damageStep );
+    }
+
+    // Perform horror mark test if in dangerous astral space
+    let horrorMarkResult = null;
+    if ( this._astralSpaceType !== "safe" ) {
+      const horrorMarkStep = horrorMarkSteps[this._astralSpaceType] || 0;
+      if ( horrorMarkStep > 0 ) {
+        horrorMarkResult = await this._performHorrorMarkTest( horrorMarkStep );
+      }
+    }
+
+    this._rawMagicResults = {
+      astralSpaceType: this._astralSpaceType,
+      warping:         warpingResult,
+      damage:          damageResult,
+      horrorMark:      horrorMarkResult
+    };
+  }
+
+  /!**
+   * Perform a warping test
+   * @param {number} warpingStep - The step number for the warping test
+   * @returns {object} The result of the warping test
+   * @private
+   *!/
+  async _performWarpingTest( warpingStep ) {
+    // Get the caster's mystic defense
+    const casterMysticDefense = this._caster.system.defense?.mystic?.value || 0;
+
+    // Create roll options for the warping test
+    const rollOptions = {
+      step: {
+        base:  warpingStep,
+        total: warpingStep
+      },
+      testType: "effect",
+      rollType: "warpingTest",
+      actor:    null, // No actor for this roll
+      target:   {
+        base:  casterMysticDefense,
+        total: casterMysticDefense
+      }
+    };
+
+    // Create and evaluate the roll
+    const roll = new EdRoll( rollOptions );
+    await roll.evaluate( { async: true } );
+
+    // Determine if the warping succeeds (roll >= mystic defense)
+    const success = roll.total >= casterMysticDefense;
+
+    return {
+      roll:    roll,
+      success: success,
+      step:    warpingStep,
+      target:  casterMysticDefense
+    };
+  }
+
+  /!**
+   * Perform a damage test from raw magic
+   * @param {number} damageStep - The step number for the damage test
+   * @returns {object} The result of the damage test
+   * @private
+   *!/
+  async _performDamageTest( damageStep ) {
+    // Get the caster's mystic armor
+    const casterMysticArmor = this._caster.system.armor?.mystic?.value || 0;
+
+    // Create roll options for the damage test
+    const rollOptions = {
+      step: {
+        base:  damageStep,
+        total: damageStep
+      },
+      testType: "effect",
+      rollType: "damageTest",
+      actor:    null, // No actor for this roll
+      damage:   {
+        type:       "mystic",
+        armorValue: casterMysticArmor
+      }
+    };
+
+    // Create and evaluate the roll
+    const roll = new EdRoll( rollOptions );
+    await roll.evaluate( { async: true } );
+
+    // Calculate final damage after armor
+    const finalDamage = Math.max( 0, roll.total - casterMysticArmor );
+
+    return {
+      roll:        roll,
+      step:        damageStep,
+      mysticArmor: casterMysticArmor,
+      damage:      finalDamage
+    };
+  }
+
+  /!**
+   * Perform a horror mark test
+   * @param {number} horrorMarkStep - The step number for the horror mark test
+   * @returns {object} The result of the horror mark test
+   * @private
+   *!/
+  async _performHorrorMarkTest( horrorMarkStep ) {
+    // Get the caster's mystic defense
+    const casterMysticDefense = this._caster.system.defense?.mystic?.value || 0;
+
+    // Create roll options for the horror mark test
+    const rollOptions = {
+      step: {
+        base:  horrorMarkStep,
+        total: horrorMarkStep
+      },
+      testType: "effect",
+      rollType: "horrorMarkTest",
+      actor:    null, // No actor for this roll
+      target:   {
+        base:  casterMysticDefense,
+        total: casterMysticDefense
+      }
+    };
+
+    // Create and evaluate the roll
+    const roll = new EdRoll( rollOptions );
+    await roll.evaluate( { async: true } );
+
+    // Determine if the horror mark test succeeds (roll >= mystic defense)
+    const success = roll.total >= casterMysticDefense;
+
+    return {
+      roll:    roll,
+      success: success,
+      step:    horrorMarkStep,
+      target:  casterMysticDefense
+    };
+  } */
+}

--- a/module/workflows/workflow/raw-casting-workflow.mjs
+++ b/module/workflows/workflow/raw-casting-workflow.mjs
@@ -82,7 +82,7 @@ export default class RawCastingWorkflow extends BaseCastingWorkflow {
       // If thread weaving fails, the workflow is interrupted
       if ( !isSuccess ) {
         throw new WorkflowInterruptError( this,
-          game.i18n.format( "ED.Notifications.Warn.spellcastingThreadWeavingFailed", {
+          game.i18n.format( ".", {
             threadNumber: i + 1
           } ) );
       }
@@ -121,7 +121,7 @@ export default class RawCastingWorkflow extends BaseCastingWorkflow {
 
     if ( !isSuccess ) {
       throw new WorkflowInterruptError( this,
-        game.i18n.localize( "ED.Notifications.Warn.spellcastingTestFailed" ) );
+        game.i18n.localize( "" ) );
     }
   }
 
@@ -481,7 +481,7 @@ export default class RawCastingWorkflow extends BaseCastingWorkflow {
       // If thread weaving fails, the workflow is interrupted
       if ( !isSuccess ) {
         throw new WorkflowInterruptError( this,
-          game.i18n.format( "ED.Notifications.Warn.spellcastingThreadWeavingFailed", {
+          game.i18n.format( "", {
             threadNumber: i + 1
           } ) );
       }
@@ -520,7 +520,7 @@ export default class RawCastingWorkflow extends BaseCastingWorkflow {
 
     if ( !isSuccess ) {
       throw new WorkflowInterruptError( this,
-        game.i18n.localize( "ED.Notifications.Warn.spellcastingTestFailed" ) );
+        game.i18n.localize( "" ) );
     }
   }
 

--- a/module/workflows/workflow/spellcasting-workflow.mjs
+++ b/module/workflows/workflow/spellcasting-workflow.mjs
@@ -12,6 +12,7 @@ import AttuneGrimoireWorkflow from "./attune-grimoire-workflow.mjs";
  * @typedef {object} SpellcastingWorkflowOptions
  * @property {Item} spell - The spell being cast
  * @property {"raw"|"grimoire"|"matrix"} [castingMethod] - The method used to cast the spell (matrix, grimoire, raw)
+ * @property {boolean} [stopOnWeaving=true] - Whether to stop the workflow after thread weaving is required
  * @property {Actor[]} [targets] - The targets of the spell
  * @property {number} [additionalThreads=0] - Additional threads to weave
  */
@@ -85,6 +86,12 @@ export default class SpellcastingWorkflow extends Rollable( ActorWorkflow ) {
   _rawMagicResults = null;
 
   /**
+   * Whether to stop the workflow after thread weaving
+   * @type {boolean}
+   */
+  _stopOnWeaving;
+
+  /**
    * @override
    * @param {ActorEd} caster The actor casting the spell
    * @param {WorkflowOptions & SpellcastingWorkflowOptions} options Options for the spellcasting workflow
@@ -94,8 +101,8 @@ export default class SpellcastingWorkflow extends Rollable( ActorWorkflow ) {
     this._spell = options.spell;
     this._matrix = options.spell.system.getAttunedMatrix();
     this._targets = options.targets || [];
-    this._additionalThreads = options.additionalThreads || 0;
     this._castingMethod = options.castingMethod;
+    this._stopOnWeaving = options.stopOnWeaving ?? true;
 
     this._steps.push(
       this.#chooseCastingMethod.bind( this ),
@@ -222,6 +229,7 @@ export default class SpellcastingWorkflow extends Rollable( ActorWorkflow ) {
     const castingWorkflow = new this._CastingWorkflow( this._actor, {
       spell:             this._spell,
       matrix:            this._matrix,
+      stopOnWeaving:     this._stopOnWeaving,
     } );
 
     try {

--- a/module/workflows/workflow/spellcasting-workflow.mjs
+++ b/module/workflows/workflow/spellcasting-workflow.mjs
@@ -1,0 +1,318 @@
+import WorkflowInterruptError from "../workflow-interrupt.mjs";
+import RawCastingWorkflow from "./raw-casting-workflow.mjs";
+import GrimoireCastingWorkflow from "./grimoire-casting-workflow.mjs";
+import MatrixCastingWorkflow from "./matrix-casting-workflow.mjs";
+import DialogEd from "../../applications/api/dialog.mjs";
+import ActorWorkflow from "./actor-workflow.mjs";
+import Rollable from "./rollable.mjs";
+import AttuneMatrixWorkflow from "./attune-matrix-workflow.mjs";
+import AttuneGrimoireWorkflow from "./attune-grimoire-workflow.mjs";
+
+/**
+ * @typedef {object} SpellcastingWorkflowOptions
+ * @property {Item} spell - The spell being cast
+ * @property {"raw"|"grimoire"|"matrix"} [castingMethod] - The method used to cast the spell (matrix, grimoire, raw)
+ * @property {Actor[]} [targets] - The targets of the spell
+ * @property {number} [additionalThreads=0] - Additional threads to weave
+ */
+
+/**
+ * Base class for all spellcasting workflows
+ * @abstract
+ */
+export default class SpellcastingWorkflow extends Rollable( ActorWorkflow ) {
+
+  static CASTING_WORKFLOW_TYPES = {
+    "grimoire": GrimoireCastingWorkflow,
+    "matrix":   MatrixCastingWorkflow,
+    "raw":      RawCastingWorkflow,
+  };
+
+  get _isRawCaster() {
+    return [ "dragon", "horror", "spirit" ].includes( this._actor.type );
+  }
+
+  get _sufferRawConsequences() {
+    return ![ "horror", "spirit" ].includes( this._actor.type );
+  }
+
+  /**
+   * The spell being cast
+   * @type {Item}
+   */
+  _spell;
+
+  /**
+   * The method used to cast the spell (matrix, grimoire, raw)
+   * @type {string}
+   */
+  _castingMethod;
+
+  /**
+   * The matrix the spell is attuned to, if applicable
+   * @type {Item}
+   */
+  _matrix;
+
+  /**
+   * The targets of the spell
+   * @type {Actor[]}
+   */
+  _targets = [];
+
+  /**
+   * Additional threads to weave
+   * @type {number}
+   */
+  _additionalThreads = 0;
+
+  /**
+   * Results of thread weaving tests
+   * @type {Array}
+   */
+  _threadWeavingResults = [];
+
+  /**
+   * Result of the spellcasting test
+   * @type {object}
+   */
+  _spellcastingResult = null;
+
+  /**
+   * The determined effect of the spell
+   * @type {object}
+   */
+  _effectResult = null;
+
+  /**
+   * Results of raw magic effects
+   * @type {object}
+   */
+  _rawMagicResults = null;
+
+  /**
+   * @override
+   * @param {ActorEd} caster The actor casting the spell
+   * @param {WorkflowOptions & SpellcastingWorkflowOptions} options Options for the spellcasting workflow
+   */
+  constructor( caster, options ) {
+    super( caster, options );
+    this._spell = options.spell;
+    this._matrix = options.spell.system.getAttunedMatrix();
+    this._targets = options.targets || [];
+    this._additionalThreads = options.additionalThreads || 0;
+    this._castingMethod = options.castingMethod;
+
+    this._steps.push(
+      this.#chooseCastingMethod.bind( this ),
+      this.#attuneSpell.bind( this ),
+      this.#createCastingWorkflow.bind( this ),
+    );
+  }
+
+  async #chooseCastingMethod() {
+    if ( this._castingMethod ) return;
+    if ( this._isRawCaster ) {
+      this._castingMethod = "raw";
+      return;
+    }
+    this._castingMethod = await this.#promptCastingMethod();
+    if ( !this._castingMethod ) this.cancel();
+  }
+
+  async #promptCastingMethod() {
+    const buttonClass = "ed-button-select-casting-method";
+
+    const castingMethods = [];
+    if (
+      this._spell.system.learnedBy( this._actor )
+      && this._actor.hasMatrixForSpell( this._spell )
+    ) {
+      castingMethods.push( {
+        action:  "matrix",
+        label:   this._matrix
+          ? game.i18n.localize( "ED.Dialogs.Buttons.matrixCastingAlreadyAttuned" )
+          : game.i18n.localize( "ED.Dialogs.Buttons.matrixCastingToAttune" ),
+        icon:    "systems/ed4e/assets/icons/matrix.svg",
+        class:   buttonClass,
+      } );
+    }
+    if ( this._spell.system.inActorGrimoires( this._actor ) ) {
+      castingMethods.push( {
+        action:  "grimoire",
+        label:   game.i18n.localize( "ED.Dialogs.Buttons.grimoireCasting" ),
+        icon:    "systems/ed4e/assets/icons/grimoire.svg",
+        class:   buttonClass,
+      } );
+    }
+    castingMethods.push( {
+      action:  "raw",
+      label:   game.i18n.localize( "ED.Dialogs.Buttons.rawCasting" ),
+      icon:    "systems/ed4e/assets/icons/rawMagic.svg",
+      class:   buttonClass,
+    } );
+
+    return DialogEd.waitButtonSelect(
+      castingMethods,
+      buttonClass,
+      {
+        title: game.i18n.localize( "ED.Dialogs.Title.selectCastingMethod" ),
+      }
+    );
+  }
+
+  async #attuneSpell() {
+    if ( ![ "matrix", "grimoire" ].includes( this._castingMethod ) ) return;
+
+    if ( this._castingMethod === "matrix" && !this._matrix ) {
+      await this.#handleAttuneMatrix();
+    } else if ( this._castingMethod === "grimoire" ) {
+      await this.#handleAttuneGrimoire();
+    }
+  }
+
+  async #handleAttuneGrimoire() {
+    try {
+      const attuneGrimoire = await DialogEd.confirm( {
+        content:     game.i18n.localize( "ED.Dialogs.doYouWantToAttuneGrimoireBeforeCasting" ),
+        rejectClose: true
+      } );
+      if ( attuneGrimoire ) {
+        const attuneGrimoireWorkflow = new AttuneGrimoireWorkflow(
+          this._actor,
+          {
+            spell: this._spell
+          }
+        );
+        await attuneGrimoireWorkflow.execute();
+      }
+    } catch ( promiseRejection ) {
+      this.cancel();
+    }
+  }
+
+  async #handleAttuneMatrix() {
+    const attuneMatrixWorkflow = new AttuneMatrixWorkflow( this._actor, {} );
+    await attuneMatrixWorkflow.execute();
+    this._matrix = this._spell.system.getAttunedMatrix();
+    if ( attuneMatrixWorkflow.canceled ) {
+      this.cancel();
+      return;
+    }
+    if ( !this._matrix ) {
+      throw new WorkflowInterruptError(
+        this,
+        game.i18n.localize( "ED.Notifications.Error.spellNotAttunedToMatrix" )
+      );
+    }
+  }
+
+  async #createCastingWorkflow() {
+    if ( !this._castingMethod ) {
+      throw new WorkflowInterruptError(
+        this,
+        game.i18n.localize( "ED.Notifications.Error.noCastingMethodSelected" )
+      );
+    }
+
+    const CastingWorkflow = SpellcastingWorkflow.CASTING_WORKFLOW_TYPES[ this._castingMethod ];
+    if ( !CastingWorkflow ) {
+      throw new Error( `Unknown casting method: ${this._castingMethod}` );
+    }
+
+    const castingWorkflow = new CastingWorkflow( this._actor, {
+      spell:               this._spell,
+      targets:             this._targets,
+      additionalThreads:   this._additionalThreads,
+      matrix:              this._matrix,
+    } );
+
+    await castingWorkflow.execute();
+
+    // Store results from the casting workflow
+    this._threadWeavingResults = castingWorkflow.threadWeavingResults;
+    this._spellcastingResult = castingWorkflow.spellcastingResult;
+    this._effectResult = castingWorkflow.effectResult;
+    this._rawMagicResults = castingWorkflow.rawMagicResults;
+
+    // Finalize the workflow
+    await this.finalizeWorkflow();
+  }
+
+  /**
+   * Creates a spellcasting roll
+   * @param {object} options - Options for the spellcasting roll
+   * @param {number} [options.stepModifier] - Modifier to the spellcasting step
+   * @returns {Promise<EdRoll>} The resulting roll
+   */
+  async createSpellcastingRoll( options = {} ) {
+    const { stepModifier = 0 } = options;
+
+    // Get the spellcasting talent step from the caster
+    const spellcastingTalent = this._actor.items.find( i =>
+      i.type === "talent" && i.name.includes( "Spellcasting" ) );
+
+    if ( !spellcastingTalent ) {
+      throw new WorkflowInterruptError( this,
+        game.i18n.localize( "ED.Notifications.Warn.spellcastingNoSpellcasting" ) );
+    }
+
+    const baseStep = spellcastingTalent.system.step || 0;
+    const totalStep = baseStep + stepModifier;
+
+    // Create the roll options
+    const rollOptions = {
+      step: {
+        base:      baseStep,
+        modifiers: { modifier: stepModifier },
+        total:     totalStep
+      },
+      testType: "spellCasting",
+      rollType: "spellCasting",
+      actor:    this._actor,
+      item:     this._spell
+    };
+
+    // Create and evaluate the roll
+    const roll = new EdRoll( rollOptions );
+    await roll.evaluate( { async: true } );
+
+    return roll;
+  }
+
+  /**
+   * Determine the effect of the spell
+   * @returns {Promise<void>}
+   */
+  async determineEffect() {
+    // Determine spell effect and duration
+    // Base implementation - subclasses may override or extend
+  }
+
+  /**
+   * Apply any additional effects based on casting method
+   * @abstract
+   * @returns {Promise<void>}
+   */
+  async applyAdditionalEffects() {
+    // To be implemented by subclasses
+  }
+
+  /**
+   * Finalize the workflow and set the result
+   * @returns {Promise<void>}
+   */
+  async finalizeWorkflow() {
+    this._result = {
+      caster:               this._actor,
+      spell:                this._spell,
+      targets:              this._targets,
+      threadWeavingResults: this._threadWeavingResults,
+      spellcastingResult:   this._spellcastingResult,
+      effectResult:         this._effectResult,
+      additionalEffects:    this._rawMagicResults,
+      success:              this._spellcastingResult?.success && this._effectResult
+    };
+  }
+}
+

--- a/module/workflows/workflow/workflow.mjs
+++ b/module/workflows/workflow/workflow.mjs
@@ -75,6 +75,10 @@ export default class Workflow {
     return this._canceled;
   }
 
+  get result() {
+    return this._result;
+  }
+
   // endregion
 
   /**

--- a/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
@@ -1,4 +1,4 @@
-<div class="custom-flavor">{{ customFlavor }}</div>
+<div class="custom-flavor">{{{ customFlavor }}}</div>
 {{#if (eq ruleOfOne true)}}
   <div class="roll-failure">{{localize "ED.Rolls.ruleOfOne"}}</div>
 {{else}}

--- a/templates/item/item-partials/item-details/partials/matrix.hbs
+++ b/templates/item/item-partials/item-details/partials/matrix.hbs
@@ -16,10 +16,4 @@
     value=system.matrix.threads.hold.value
     localize=true
   }}
-  {{formGroup
-    systemFields.matrix.fields.threads.fields.woven
-    name=(concat "system.matrix.threads.woven")
-    value=system.matrix.threads.woven
-    localize=true
-  }}
 </fieldset>

--- a/templates/workflow/select-extra-threads.hbs
+++ b/templates/workflow/select-extra-threads.hbs
@@ -1,7 +1,7 @@
 <div>
 
   <div>
-    {{localize "ED.Dialogs.SelectExtraThreads.selectedXofYthreads" numSelected maxExtraThreads}}
+    {{localize "ED.Dialogs.SelectExtraThreads.selectedXofYthreads" numSelected=numSelected maxExtraThreads=maxExtraThreads}}
   </div>
 
   <fieldset class="extra-threads">


### PR DESCRIPTION
This pull request introduces the foundation for using spellcasting as workflows. It comes with a workflow for matrix casting. Grimoire and raw are still to come. 
⚠️  This is only functional, not usable from the UI yet! ⚠️ 
The changes include improvements to dialog handling, spellcasting logic, and matrix template validation. Below is a summary of the most significant changes:

### Localization Updates
* Adjusted various German localization strings for consistency and clarity, including replacing single quotes with double quotes in specific contexts. [[1]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dL332-R332) [[2]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dR341-R344)
* Added new localization keys for spellcasting features, such as `"grimoireCasting"`, `"matrixCastingToAttune"`, and `"rawCasting"`.
* Introduced error messages for spellcasting and matrix-related workflows, such as `"matrixCastingSpellNotAttuned"` and `"spellNotReadyToCast"`. [[1]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dR3138-R3144) [[2]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dR3176)

### Spellcasting Enhancements
* Added a new `isWeavingComplete` property to determine if a spell is ready to cast based on woven threads.
* Implemented a `cast` method to handle spellcasting logic, including checks for readiness and rolling mechanics.
* Improved the `weaveThreads` method to return the roll result and updated the woven threads logic. [[1]](diffhunk://#diff-1fe64093a9e088e2db2943035faa79a2098df53a191277077adbacdbb29d0292L336-R380) [[2]](diffhunk://#diff-1fe64093a9e088e2db2943035faa79a2098df53a191277077adbacdbb29d0292L388-R483)

### Dialog Handling Improvements
* Enhanced the `DialogEd` class to support mixed item types (e.g., `ItemEd`, UUIDs, strings, and `DialogV2Button` objects) in dialog creation methods. [[1]](diffhunk://#diff-28bf9878e80bd362ee7e78351fb3630ccb5dbdd13cc73cbbbdba6266a1ed356cL19-R24) [[2]](diffhunk://#diff-28bf9878e80bd362ee7e78351fb3630ccb5dbdd13cc73cbbbdba6266a1ed356cL42-R115)
* Added fallback handling for unrecognized item formats in `createItemButtons`.

### Matrix Template Validation
* Updated the `MatrixTemplate` class to reset the active spell if it is no longer in the list of attuned spells.

### Miscellaneous
* Exported additional constants from `module/config/_module.mjs` for better modularity.
* Added a new import for `SpellcastingRollOptions` in `module/data/item/spell.mjs`.

### Usage Example
For the happy path, you need an actor with a spell, the talents "Spellcasting" (defined by edid) and "Thread Weaving" (edid) according to the spells spellcasting type, and a matrix the spell can fit into. Then you can do:
```javascript
let actor = fromUuidSync("actorUuid")
let spell = await fromUuid("embeddedSpellItemUuid")
let swflow = new ed4e.workflows.workflow.SpellcastingWorkflow(actor, {spell: spell, })
await swflow.execute()
``` 