### PR TITLE
Remove hot reload functionality for Handlebars templates

### DIFF
--- a/module/config/_module.mjs
+++ b/module/config/_module.mjs
@@ -20,25 +20,25 @@ import * as WORKFLOWS from "./workflows.mjs";
 /*  Enable .hbs Hot Reload                      */
 /* -------------------------------------------- */
 
-/* eslint-disable */
+ 
 // Since Foundry does not support hot reloading object notation templates...
-Hooks.on('hotReload', async ({ content, extension, packageId, packageType, path } = {}) => {
-  if (extension === 'hbs') {
-    const key = Object.entries(flattenObject(templates)).find(([_, templatePath]) => templatePath == path)?.[0];
-    if (!key) throw new Error(`Unrecognized template: ${path}`);
-    await new Promise((resolve, reject) => {
-      game.socket.emit('template', path, resp => {
-        if (resp.error) return reject(new Error(resp.error));
-        const compiled = Handlebars.compile(resp.html);
-        Handlebars.registerPartial(generateTemplateKey(key), compiled);
-        console.log(`Foundry VTT | Retrieved and compiled template ${path} as ${key}`);
-        resolve(compiled);
-      });
-    });
-    Object.values(ui.windows).forEach(app => app.render(true));
+/* Hooks.on( "hotReload", async ( { content, extension, packageId, packageType, path } = {} ) => {
+  if ( extension === "hbs" ) {
+    const key = Object.entries( flattenObject( templates ) ).find( ( [ _, templatePath ] ) => templatePath == path )?.[0];
+    if ( !key ) throw new Error( `Unrecognized template: ${path}` );
+    await new Promise( ( resolve, reject ) => {
+      game.socket.emit( "template", path, resp => {
+        if ( resp.error ) return reject( new Error( resp.error ) );
+        const compiled = Handlebars.compile( resp.html );
+        Handlebars.registerPartial( generateTemplateKey( key ), compiled );
+        console.log( `Foundry VTT | Retrieved and compiled template ${path} as ${key}` );
+        resolve( compiled );
+      } );
+    } );
+    Object.values( ui.windows ).forEach( app => app.render( true ) );
   }
-});
-/* eslint-enable */
+} ); */
+ 
 
 export {
   ACTIONS,

--- a/system.json
+++ b/system.json
@@ -32,7 +32,8 @@
   ],
   "flags": {
     "hotReload": {
-      "extensions": ["css", "hbs", "json"]
+      "extensions": ["css", "hbs", "json"],
+      "paths": [ "templates", "lang" ]
     }
   },
   "packs": [


### PR DESCRIPTION
It works without the function. CSS hot reload is still not possible because of https://github.com/foundryvtt/foundryvtt/issues/9958 