### PR TITLE
Add scene configuration and astral pollution options for Earthdawn

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -390,6 +390,12 @@
         "mystical":                                "Mystische Rüstung",
         "physical":                                "Physische Rüstung"
       },
+      "AstralSpacePollution": {
+        "corrupt":                                 "Verdorben",
+        "open":                                    "Offen",
+        "safe":                                    "Sicher",
+        "tainted":                                 "Befleckt"
+      },
       "AttuningType": {
         "grimoire":                                "Abstimmung eines Grimoires",
         "matrixOnTheFly":                          "Eine Matrix auf die Schnelle abstimmen",
@@ -3033,7 +3039,8 @@
       "itemSheetEd":                               "Item-Bogen",
       "itemSheetEdClass":                          "Berufung-Bogen",
       "itemSheetEdPhysical":                       "Ausrüstungs-Bogen",
-      "journalSheetEd":                            "Journal-Bogen"
+      "journalSheetEd":                            "Journal-Bogen",
+      "sceneConfigEd":                             "Szene Konfiguration"
     },
     "Item": {
       "CreateData": {
@@ -3199,6 +3206,12 @@
       "successesAchieved":                         "Gesamt Erfolge ( {numSuccesses} + {numExtraSuccesses} extra Erfolge )",
       "targetDifficulty":                          "Schwierigkeit",
       "targetModifiers":                           "Ziel Modifikatoren"
+    },
+    "Scene": {
+      "AstralPollution": {
+        "hint":                                    "Bestimmt die Kategorie der Verunreinigung in der sich der Astralraum dieser Szene befindet.",
+        "label":                                   "Astrale Verunreinigung"
+      }
     },
     "Settings": {
       "CharGen": {
@@ -3378,6 +3391,9 @@
         "chronological":                           "Zeitlich",
         "earned":                                  "Erhalten",
         "spend":                                   "Ausgegeben"
+      },
+      "Scene": {
+        "earthdawn":                               "Earthdawn"
       }
     },
     "ToolTips": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -391,6 +391,12 @@
         "mystical":                                "Mystical Armor",
         "physical":                                "Physical Armor"
       },
+      "AstralSpacePollution": {
+        "corrupt":                                 "TODO: Add translation",
+        "open":                                    "TODO: Add translation",
+        "safe":                                    "TODO: Add translation",
+        "tainted":                                 "TODO: Add translation"
+      },
       "AttuningType": {
         "grimoire":                                "TODO: Add translation",
         "matrixOnTheFly":                          "TODO: Add translation",
@@ -3016,7 +3022,8 @@
       "itemSheetEd":                               "TODO: Add translation",
       "itemSheetEdClass":                          "TODO: Add translation",
       "itemSheetEdPhysical":                       "TODO: Add translation",
-      "journalSheetEd":                            "TODO: Add translation"
+      "journalSheetEd":                            "TODO: Add translation",
+      "sceneConfigEd":                             "TODO: Add translation"
     },
     "Item": {
       "CreateData": {
@@ -3182,6 +3189,12 @@
       "successesAchieved":                         "Total Successes",
       "targetDifficulty":                          "Difficulty",
       "targetModifiers":                           "Target Modifier"
+    },
+    "Scene": {
+      "AstralPollution": {
+        "hint":                                    "TODO: Add translation",
+        "label":                                   "TODO: Add translation"
+      }
     },
     "Settings": {
       "CharGen": {
@@ -3361,6 +3374,9 @@
         "chronological":                           "TODO: Add translation",
         "earned":                                  "TODO: Add translation",
         "spend":                                   "TODO: Add translation"
+      },
+      "Scene": {
+        "earthdawn":                               "TODO: Add translation"
       }
     },
     "ToolTips": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -390,6 +390,12 @@
         "mystical":                                "TODO: Add translation",
         "physical":                                "TODO: Add translation"
       },
+      "AstralSpacePollution": {
+        "corrupt":                                 "TODO: Add translation",
+        "open":                                    "TODO: Add translation",
+        "safe":                                    "TODO: Add translation",
+        "tainted":                                 "TODO: Add translation"
+      },
       "AttuningType": {
         "grimoire":                                "TODO: Add translation",
         "matrixOnTheFly":                          "TODO: Add translation",
@@ -3015,7 +3021,8 @@
       "itemSheetEd":                               "TODO: Add translation",
       "itemSheetEdClass":                          "TODO: Add translation",
       "itemSheetEdPhysical":                       "TODO: Add translation",
-      "journalSheetEd":                            "TODO: Add translation"
+      "journalSheetEd":                            "TODO: Add translation",
+      "sceneConfigEd":                             "TODO: Add translation"
     },
     "Item": {
       "CreateData": {
@@ -3181,6 +3188,12 @@
       "successesAchieved":                         "TODO: Add translation",
       "targetDifficulty":                          "TODO: Add translation",
       "targetModifiers":                           "TODO: Add translation"
+    },
+    "Scene": {
+      "AstralPollution": {
+        "hint":                                    "TODO: Add translation",
+        "label":                                   "TODO: Add translation"
+      }
     },
     "Settings": {
       "CharGen": {
@@ -3360,6 +3373,9 @@
         "chronological":                           "TODO: Add translation",
         "earned":                                  "TODO: Add translation",
         "spend":                                   "TODO: Add translation"
+      },
+      "Scene": {
+        "earthdawn":                               "TODO: Add translation"
       }
     },
     "ToolTips": {

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -390,6 +390,12 @@
         "mystical":                                "TODO: Add translation",
         "physical":                                "TODO: Add translation"
       },
+      "AstralSpacePollution": {
+        "corrupt":                                 "TODO: Add translation",
+        "open":                                    "TODO: Add translation",
+        "safe":                                    "TODO: Add translation",
+        "tainted":                                 "TODO: Add translation"
+      },
       "AttuningType": {
         "grimoire":                                "TODO: Add translation",
         "matrixOnTheFly":                          "TODO: Add translation",
@@ -3015,7 +3021,8 @@
       "itemSheetEd":                               "TODO: Add translation",
       "itemSheetEdClass":                          "TODO: Add translation",
       "itemSheetEdPhysical":                       "TODO: Add translation",
-      "journalSheetEd":                            "TODO: Add translation"
+      "journalSheetEd":                            "TODO: Add translation",
+      "sceneConfigEd":                             "TODO: Add translation"
     },
     "Item": {
       "CreateData": {
@@ -3181,6 +3188,12 @@
       "successesAchieved":                         "TODO: Add translation",
       "targetDifficulty":                          "TODO: Add translation",
       "targetModifiers":                           "TODO: Add translation"
+    },
+    "Scene": {
+      "AstralPollution": {
+        "hint":                                    "TODO: Add translation",
+        "label":                                   "TODO: Add translation"
+      }
     },
     "Settings": {
       "CharGen": {
@@ -3360,6 +3373,9 @@
         "chronological":                           "TODO: Add translation",
         "earned":                                  "TODO: Add translation",
         "spend":                                   "TODO: Add translation"
+      },
+      "Scene": {
+        "earthdawn":                               "TODO: Add translation"
       }
     },
     "ToolTips": {

--- a/module/applications/_module.mjs
+++ b/module/applications/_module.mjs
@@ -8,6 +8,7 @@ export * as global from "./global/_module.mjs";
 export * as hud from "./hud/_module.mjs";
 export * as item from "./item/_module.mjs";
 export * as journal from "./journal/_module.mjs";
+export * as scene from "./scene/_module.mjs";
 export * as workflow from "./workflow/_module.mjs";
 
 

--- a/module/applications/scene/_module.mjs
+++ b/module/applications/scene/_module.mjs
@@ -1,0 +1,1 @@
+export { default as SceneConfigEd } from "./scene-config.mjs";

--- a/module/applications/scene/scene-config.mjs
+++ b/module/applications/scene/scene-config.mjs
@@ -1,0 +1,74 @@
+import { MAGIC, SYSTEM } from "../../config/_module.mjs";
+
+export default class SceneConfigEd extends foundry.applications.sheets.SceneConfig {
+
+  static PARTS = {
+    tabs:      { ...super.PARTS.tabs },
+    basics:    { ...super.PARTS.basics },
+    grid:      { ...super.PARTS.grid },
+    lighting:  { ...super.PARTS.lighting },
+    ambience:  { ...super.PARTS.ambience },
+    earthdawn: { template: "systems/ed4e/templates/configs/scene-config-tab-ed.hbs" },
+    footer:    { ...super.PARTS.footer },
+  };
+
+  /** @override */
+  static TABS = {
+    ...super.TABS,
+    sheet: {
+      ...super.TABS.sheet,
+      tabs: [
+        ...super.TABS.sheet.tabs,
+        { id: "earthdawn", icon: `fa-solid ${SYSTEM.icons.earthdawn}`, label: "ED.Tabs.Scene.earthdawn" },
+      ],
+    },
+  };
+
+  /** @override */
+  async _onRender( context, options ) {
+    await super._onRender( context, options );
+    this._addAstralPollutionToScene( context, options );
+  }
+
+  /**
+   * Adds a select input for astral pollution to the scene config.
+   */
+  _addAstralPollutionToScene() {
+    const SYSTEM_ID = game?.system?.id ?? "ed4e";
+    const fields = foundry.applications.fields;
+
+    /** @type {Scene} */
+    const scene = this.document;
+
+    const selectOptions = Object.entries(
+      MAGIC.astralSpacePollution
+    ).map(
+      entry => {
+        const key = entry[0];
+        const value = entry[1];
+        return {
+          value:    key,
+          label:    value.label,
+        };
+      }
+    );
+
+    const input = fields.createSelectInput( {
+      name:    `flags.${SYSTEM_ID}.astralPollution`,
+      value:   scene.getFlag( SYSTEM_ID, "astralPollution" ),
+      options: selectOptions,
+    } );
+
+    const group = fields.createFormGroup( {
+      input,
+      label:    "ED.Scene.AstralPollution.label",
+      hint:     "ED.Scene.AstralPollution.hint",
+      localize: true,
+    } );
+    
+    const edOptions = this.element.querySelector( ".tab[data-group=\"sheet\"][data-tab=\"earthdawn\"]" );
+
+    edOptions.append( group );
+    this.setPosition();
+  }
+}

--- a/module/config/magic.mjs
+++ b/module/config/magic.mjs
@@ -1,6 +1,51 @@
 import { preLocalize } from "../utils.mjs";
 
 
+export const astralSpacePollution = {
+  safe: {
+    label:            "ED.Config.AstralSpacePollution.safe",
+    sensingModifier:   0,
+    backlashModifier:  4,
+    rawMagic:          {
+      warpingModifier:    0,
+      damageModifier:     4,
+      horrorMarkModifier: null,
+    },
+  },
+  open: {
+    label:            "ED.Config.AstralSpacePollution.open",
+    sensingModifier:   2,
+    backlashModifier:  8,
+    rawMagic:          {
+      warpingModifier:    5,
+      damageModifier:     5,
+      horrorMarkModifier: 2,
+    },
+  },
+  tainted: {
+    label:            "ED.Config.AstralSpacePollution.tainted",
+    sensingModifier:   5,
+    backlashModifier:  12,
+    rawMagic:          {
+      warpingModifier:    10,
+      damageModifier:     12,
+      horrorMarkModifier: 5,
+    },
+  },
+  corrupt: {
+    label:            "ED.Config.AstralSpacePollution.corrupt",
+    sensingModifier:   12,
+    backlashModifier:  16,
+    rawMagic:          {
+      warpingModifier:    15,
+      damageModifier:     16,
+      horrorMarkModifier: 10,
+    },
+  },
+};
+preLocalize( "astralSpacePollution", { key: "label" } );
+
+
 /**
  * The different ways of attuning spells.
  * @enum {string}

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -71,6 +71,7 @@ export const icons = {
   damage:           "fa-skull-crossbones",
   delete:           "fa-trash",
   dice:             "fa-dice",
+  earthdawn:        "fa-e",
   effect:           "fa-biohazard",
   effectExecution:  "fa-light fa-arrow-progress",
   emptyMatrices:    "fa-empty-set",

--- a/module/hooks/init.mjs
+++ b/module/hooks/init.mjs
@@ -15,7 +15,7 @@ import { staticStatusId } from "../utils.mjs";
 
 const { DocumentSheetConfig } = foundry.applications.apps;
 const { ActiveEffectConfig, CombatantConfig } = foundry.applications.sheets;
-const { Actors, Items, Journal } = foundry.documents.collections;
+const { Actors, Items, Journal, Scenes } = foundry.documents.collections;
 
 /**
  *
@@ -163,6 +163,12 @@ export default function () {
     Journal.registerSheet( "earthdawn4e", applications.journal.JournalSheetEd, {
       makeDefault: true,
       label:       "ED.Documents.journalSheetEd"
+    } );
+
+    Scenes.unregisterSheet( "core", foundry.applications.sheets.SceneConfig );
+    Scenes.registerSheet( "earthdawn4e", applications.scene.SceneConfigEd, {
+      makeDefault: true,
+      label:       "ED.Documents.sceneConfigEd"
     } );
 
     // endregion

--- a/templates/configs/scene-config-tab-ed.hbs
+++ b/templates/configs/scene-config-tab-ed.hbs
@@ -1,0 +1,3 @@
+<div class="tab{{#if tab.active}} active{{/if}}" data-group="{{tab.group}}" data-tab="{{tab.id}}">
+
+</div>


### PR DESCRIPTION
This pull request introduces a new feature for managing astral pollution in scenes. The updates include a custom scene configuration class, and additional configuration options for astral pollution.

### Feature: Astral Pollution Management in Scenes

* **Localization Updates**  
  Added new localization strings for astral pollution categories (`safe`, `open`, `tainted`, `corrupt`) and scene configuration labels and hints in `lang/de.json`. [[1]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dR393-R398) [[2]](diffhunk://#diff-b856eeca8165aed4012d1d98ca6e927f20366c9c1272932ad9d8004358c1f38dR3210-R3215)

* **Astral Pollution Configuration**  
  Defined the `astralSpacePollution` object in `module/config/magic.mjs`, which includes labels and modifiers for different pollution levels.

* **Custom Scene Configuration Class**  
  Introduced `SceneConfigEd`, a subclass of `SceneConfig`, to add a new "Earthdawn" tab in the scene configuration UI. This tab includes a dropdown for selecting astral pollution levels.

### Codebase Integration

* **Module Exports**  
  Added exports for the new `SceneConfigEd` class and the `scene` module in `module/applications/_module.mjs` and `module/applications/scene/_module.mjs`. [[1]](diffhunk://#diff-60e55cc8acd5fcd49093e13986e941a08bd2e6baddbd872cf57ada9b325c9dbfR11) [[2]](diffhunk://#diff-f058d4474009ee1aa2318d66e6e9d9159c846c48c3dfe85332f20d469dcc95aeR1)

* **Hooks and Registration**  
  Registered `SceneConfigEd` as the default scene configuration sheet for the system and unregistered the core `SceneConfig` in `module/hooks/init.mjs`.

### UI Enhancements

* **Scene Tab Template**  
  Added a new Handlebars template file (`scene-config-tab-ed.hbs`) for the "Earthdawn" tab in the scene configuration UI.

* **System Icon**  
  Added a new `earthdawn` icon to the system configuration in `module/config/system.mjs`.