### PR TITLE
fix not working rolls

### DIFF
--- a/module/data/item/power.mjs
+++ b/module/data/item/power.mjs
@@ -5,6 +5,7 @@ import TargetTemplate from "./templates/targeting.mjs";
 import RollPrompt from "../../applications/global/roll-prompt.mjs";
 import AbilityRollOptions from "../roll/ability.mjs";
 import AttackRollOptions from "../roll/attack.mjs";
+import RollProcessor from "../../services/roll-processor.mjs";
 
 /**
  * Data model template with information on Power items.
@@ -157,7 +158,7 @@ export default class PowerData extends ActionTemplate.mixin(
         rollData: this.containingActor,
       }
     );
-    return this.containingActor.processRoll( roll );
+    return RollProcessor.process( roll, this.containingActor, { rollToMessage: true } );
   }
 
   async rollAttack() {
@@ -181,7 +182,7 @@ export default class PowerData extends ActionTemplate.mixin(
         rollData: this.containingActor,
       }
     );
-    return this.containingActor.processRoll( roll );
+    return RollProcessor.process( roll, this.containingActor, { rollToMessage: true } );
   }
 
   async rollDamage() {

--- a/module/data/item/templates/ability.mjs
+++ b/module/data/item/templates/ability.mjs
@@ -6,6 +6,7 @@ import PromptFactory from "../../../applications/global/prompt-factory.mjs";
 import RollPrompt from "../../../applications/global/roll-prompt.mjs";
 import AttackRollOptions from "../../roll/attack.mjs";
 import AbilityRollOptions from "../../roll/ability.mjs";
+import RollProcessor from "../../../services/roll-processor.mjs";
 
 /**
  * Data model template with information on Ability items.
@@ -220,7 +221,7 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
         rollData: this.containingActor,
       }
     );
-    return this.containingActor.processRoll( roll );
+    return RollProcessor.process( roll, this.containingActor, { rollToMessage: true } );
   }
 
   async rollAttack() {
@@ -261,7 +262,7 @@ export default class AbilityTemplate extends ActionTemplate.mixin(
         rollData: this.containingActor,
       }
     );
-    return this.containingActor.processRoll( roll );
+    return RollProcessor.process( roll, this.containingActor, { rollToMessage: true } );
   }
 
   async _attack() {

--- a/module/data/item/templates/rollable.mjs
+++ b/module/data/item/templates/rollable.mjs
@@ -45,11 +45,11 @@ export default class RollableTemplate extends SystemDataModel {
       case "attack": rollFunc = this.rollAttack.bind( this ); break;
       case "damage": rollFunc = this.rollDamage.bind( this ); break;
       case "effect": rollFunc = this.rollEffect.bind( this ); break;
-      case "initiative": rollFunc = this.rollInitiative.bind( this ); break;
-      case "reaction": rollFunc = this.rollReaction.bind( this ); break;
-      case "recovery": rollFunc = this.rollRecovery.bind( this ); break;
-      case "spellcasting": rollFunc = this.rollSpellcasting.bind( this ); break;
-      case "threadWeaving": rollFunc = this.rollThreadWeaving.bind( this ); break;
+      case "initiative": rollFunc = this.rollAbility.bind( this ); break;
+      case "reaction": rollFunc = this.rollAbility.bind( this ); break;
+      case "recovery": rollFunc = this.rollAbility.bind( this ); break;
+      case "spellcasting": rollFunc = this.rollAbility.bind( this ); break;
+      case "threadWeaving": rollFunc = this.rollAbility.bind( this ); break;
     }
     return rollFunc();
   }

--- a/module/data/item/weapon.mjs
+++ b/module/data/item/weapon.mjs
@@ -10,6 +10,7 @@ import AvailabilityMigration from "./migration/old-system-V082/availability.mjs"
 import PriceMigration from "./migration/old-system-V082/price.mjs";
 import WeightMigration from "./migration/old-system-V082/weight.mjs";
 import UsableItemMigration from "./migration/old-system-V082/usable-items.mjs";
+import RollProcessor from "../../services/roll-processor.mjs";
 
 /**
  * Data model template with information on weapon items.
@@ -334,8 +335,7 @@ export default class WeaponData extends PhysicalItemTemplate.mixin(
         rollData: this.containingActor,
       }
     );
-
-    return this.containingActor.processRoll( roll );
+    return RollProcessor.process( roll, this.containingActor, { rollToMessage: true } );
   }
 
   /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -538,7 +538,7 @@ export default class ActorEd extends Actor {
       this
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    return RollProcessor.process( roll, this, { rollToMessage: true } );
+    return this.processRoll( roll, { rollToMessage: true } );
   }
 
   /**
@@ -620,7 +620,7 @@ export default class ActorEd extends Actor {
       this
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    return RollProcessor.process( roll, this, { rollToMessage: true } );
+    return this.processRoll( roll, { rollToMessage: true } );
   }
 
   /**

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -538,7 +538,7 @@ export default class ActorEd extends Actor {
       this
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    return this.processRoll( roll );
+    return RollProcessor.process( roll, this, { rollToMessage: true } );
   }
 
   /**
@@ -588,6 +588,7 @@ export default class ActorEd extends Actor {
    * @description                 Roll an Equipment item. use {@link RollPrompt} for further input data.
    * @param {ItemEd} equipment    Equipment must be of type EquipmentTemplate & TargetingTemplate
    * @param {object} options      Any additional options for the {@link EdRoll}.
+   * @returns {Promise<EdRoll>}   The processed Roll.
    */
   async rollEquipment( equipment, options = {} ) {
     const arbitraryStep = equipment.system.usableItem.arbitraryStep;
@@ -609,7 +610,7 @@ export default class ActorEd extends Actor {
     const edRollOptions = EdRollOptions.fromActor(
       {
         testType:         "action",
-        rollType:         "equipment",
+        rollType:         "arbitrary",
         strain:           0,
         target:           difficultyFinal,
         step:             arbitraryFinalStep,
@@ -619,7 +620,7 @@ export default class ActorEd extends Actor {
       this
     );
     const roll = await RollPrompt.waitPrompt( edRollOptions, options );
-    this.processRoll( roll );
+    return RollProcessor.process( roll, this, { rollToMessage: true } );
   }
 
   /**


### PR DESCRIPTION
resolves #1792 
resolves #1793 

since the rollFunc is not called for specific roll operations, I set most of the to "rollAbility" for the moment. now every ability is rerouted to roll ability no matter the rollType if it is rolled directly, without the use of an specific workflow (like attack)

