### PR TITLE
Pc migration small

### DIFF
--- a/module/hooks/ready.mjs
+++ b/module/hooks/ready.mjs
@@ -23,8 +23,6 @@ export default function () {
     // Fix all documents that were transformed during migration
     if ( game.user.isGM ) {
       const transformedDocuments = TypeTransformationManager.getAllTransformedDocumentIds();
-      console.log( "Transformed Documents:", transformedDocuments );
-      
       const hasTransformedDocs = Object.values( transformedDocuments ).some( ids => ids.length > 0 );
       if ( hasTransformedDocs ) {
         await TypeTransformationManager.fixAllTransformedDocuments( transformedDocuments );

--- a/module/hooks/ready.mjs
+++ b/module/hooks/ready.mjs
@@ -2,6 +2,39 @@ import EdTour from "../tours/ed-tours.mjs";
 import EdRollOptions from "../data/roll/common.mjs";
 
 /**
+ * Function to fix all character actors using ==system AND recursive: false
+ * This ensures character actors are properly validated in Foundry V13
+ */
+async function fixAllCharacterActors() {
+  const characterActors = game.actors.filter( actor => actor.type === "character" );
+  // Loop through all character actors
+  for ( let i = 0; i < characterActors.length; i++ ) {
+    const actor = characterActors[i];
+    try {
+      // Get the full system data
+      const fullSystemData = foundry.utils.deepClone( actor.system );
+      await actor.update( {
+        type:       "character",
+        "==system": fullSystemData
+      }, {
+        recursive: false,  // This is required for type changes
+        diff:      false,
+        render:    false,
+        broadcast: false
+      } );
+    } catch ( error ) {
+      console.log( `❌ Still failed for ${actor.name}:`, error.message );
+      console.log( "This suggests the actor data is corrupted at database level." );
+    }
+    
+    // Small delay between updates
+    await new Promise( resolve => {
+      setTimeout( resolve, 100 );
+    } );
+  }
+}
+
+/**
  * TODO
  */
 export default function () {
@@ -13,6 +46,14 @@ export default function () {
     /* -------------------------------------------- */
 
     if ( game.user.isGM ) await _createDebugDocuments();
+
+    
+    /* -------------------------------------------- */
+    /*  Fix Character Actors                       */
+    /* -------------------------------------------- */
+    
+    // Uncomment the next line to run the character actor fix
+    if ( game.user.isGM ) await fixAllCharacterActors();
 
 
     /* -------------------------------------------- */

--- a/module/hooks/ready.mjs
+++ b/module/hooks/ready.mjs
@@ -1,38 +1,6 @@
 import EdTour from "../tours/ed-tours.mjs";
 import EdRollOptions from "../data/roll/common.mjs";
-
-/**
- * Function to fix all character actors using ==system AND recursive: false
- * This ensures character actors are properly validated in Foundry V13
- */
-async function fixAllCharacterActors() {
-  const characterActors = game.actors.filter( actor => actor.type === "character" );
-  // Loop through all character actors
-  for ( let i = 0; i < characterActors.length; i++ ) {
-    const actor = characterActors[i];
-    try {
-      // Get the full system data
-      const fullSystemData = foundry.utils.deepClone( actor.system );
-      await actor.update( {
-        type:       "character",
-        "==system": fullSystemData
-      }, {
-        recursive: false,  // This is required for type changes
-        diff:      false,
-        render:    false,
-        broadcast: false
-      } );
-    } catch ( error ) {
-      console.log( `❌ Still failed for ${actor.name}:`, error.message );
-      console.log( "This suggests the actor data is corrupted at database level." );
-    }
-    
-    // Small delay between updates
-    await new Promise( resolve => {
-      setTimeout( resolve, 100 );
-    } );
-  }
-}
+import TypeTransformationManager from "../services/migrations/type-transformation-manager.mjs";
 
 /**
  * TODO
@@ -49,11 +17,19 @@ export default function () {
 
     
     /* -------------------------------------------- */
-    /*  Fix Character Actors                       */
+    /*  Fix Transformed Documents                   */
     /* -------------------------------------------- */
     
-    // Uncomment the next line to run the character actor fix
-    if ( game.user.isGM ) await fixAllCharacterActors();
+    // Fix all documents that were transformed during migration
+    if ( game.user.isGM ) {
+      const transformedDocuments = TypeTransformationManager.getAllTransformedDocumentIds();
+      console.log( "Transformed Documents:", transformedDocuments );
+      
+      const hasTransformedDocs = Object.values( transformedDocuments ).some( ids => ids.length > 0 );
+      if ( hasTransformedDocs ) {
+        await TypeTransformationManager.fixAllTransformedDocuments( transformedDocuments );
+      }
+    }
 
 
     /* -------------------------------------------- */

--- a/module/services/migrations/type-transformation-manager.mjs
+++ b/module/services/migrations/type-transformation-manager.mjs
@@ -272,10 +272,7 @@ export default class TypeTransformationManager {
    */
   static async fixAllTransformedDocuments( documentIds = null ) {
     const documentsToFix = documentIds || this.getAllTransformedDocumentIds();
-    
-    console.log( "=== FIXING ALL TRANSFORMED DOCUMENTS ===" );
-    console.log( "Documents to fix:", documentsToFix );
-    
+
     // Fix actors
     if ( documentsToFix.actors && documentsToFix.actors.length > 0 ) {
       await this.#fixDocuments( "actors", documentsToFix.actors );
@@ -301,12 +298,8 @@ export default class TypeTransformationManager {
       .filter( doc => doc ); // Remove any null/undefined documents
     
     if ( documents.length === 0 ) {
-      console.log( `No ${documentType} found to fix.` );
       return;
     }
-    
-    console.log( `Fixing ${documents.length} transformed ${documentType}...` );
-    
     for ( let i = 0; i < documents.length; i++ ) {
       const document = documents[i];
       try {
@@ -322,9 +315,6 @@ export default class TypeTransformationManager {
           render:    false,
           broadcast: false
         } );
-        
-        console.log( `✅ Fixed ${documentType.slice( 0, -1 )}: ${document.name} (${document.type})` );
-        
       } catch ( error ) {
         console.log( `❌ Failed to fix ${document.name}:`, error.message );
         console.log( "This suggests the document data is corrupted at database level." );
@@ -335,8 +325,6 @@ export default class TypeTransformationManager {
         setTimeout( resolve, 50 );
       } );
     }
-    
-    console.log( `Completed fixing ${documents.length} ${documentType}.` );
   }
 
   /**
@@ -353,11 +341,9 @@ export default class TypeTransformationManager {
       characterActors = actorIds
         .map( id => game.actors.get( id ) )
         .filter( actor => actor && actor.type === "character" );
-      console.log( `Fixing ${characterActors.length} specific transformed character actors...` );
     } else {
       // Fix all character actors
       characterActors = game.actors.filter( actor => actor.type === "character" );
-      console.log( `Fixing all ${characterActors.length} character actors...` );
     }
     
     // Loop through character actors
@@ -385,7 +371,5 @@ export default class TypeTransformationManager {
         setTimeout( resolve, 100 );
       } );
     }
-    
-    console.log( `Completed fixing ${characterActors.length} character actors.` );
   }
 }

--- a/module/services/migrations/type-transformation-manager.mjs
+++ b/module/services/migrations/type-transformation-manager.mjs
@@ -25,6 +25,91 @@ export default class TypeTransformationManager {
   static #complexTypeTransformRegistry = new Map();
 
   /**
+   * Map to track transformed document IDs by document type
+   * Structure: { actors: [id1, id2], items: [id3, id4] }
+   * @type {Map<string, string[]>}
+   * @private
+   */
+  static #transformedDocumentIds = new Map();
+
+  /**
+   * Get the array of transformed document IDs for a specific document type
+   * @param {string} documentType - The document type (e.g., "actors", "items")
+   * @returns {string[]} - Array of document IDs that were transformed
+   */
+  static getTransformedDocumentIds( documentType ) {
+    return [ ...( this.#transformedDocumentIds.get( documentType ) || [] ) ]; // Return a copy
+  }
+
+  /**
+   * Get all transformed document IDs grouped by type
+   * @returns {object} - Object with document types as keys and ID arrays as values
+   */
+  static getAllTransformedDocumentIds() {
+    const result = {};
+    for ( const [ docType, ids ] of this.#transformedDocumentIds ) {
+      result[docType] = [ ...ids ]; // Return copies
+    }
+    return result;
+  }
+
+  /**
+   * Add a document ID to the transformed documents list
+   * @param {string} documentType - The document type (e.g., "actors", "items")
+   * @param {string} documentId - The document ID to track
+   */
+  static addTransformedDocumentId( documentType, documentId ) {
+    if ( !documentId ) return;
+    
+    if ( !this.#transformedDocumentIds.has( documentType ) ) {
+      this.#transformedDocumentIds.set( documentType, [] );
+    }
+    
+    const ids = this.#transformedDocumentIds.get( documentType );
+    if ( !ids.includes( documentId ) ) {
+      ids.push( documentId );
+    }
+  }
+
+  /**
+   * Clear the transformed documents list for a specific type or all types
+   * @param {string} [documentType] - Optional document type to clear. If not provided, clears all
+   */
+  static clearTransformedDocumentIds( documentType = null ) {
+    if ( documentType ) {
+      this.#transformedDocumentIds.delete( documentType );
+    } else {
+      this.#transformedDocumentIds.clear();
+    }
+  }
+
+  /**
+   * Legacy method for backward compatibility
+   * @returns {string[]} - Array of actor IDs that were transformed
+   * @deprecated Use getTransformedDocumentIds("actors") instead
+   */
+  static getTransformedActorIds() {
+    return this.getTransformedDocumentIds( "actors" );
+  }
+
+  /**
+   * Legacy method for backward compatibility
+   * @param {string} actorId - The actor ID to track
+   * @deprecated Use addTransformedDocumentId("actors", actorId) instead
+   */
+  static addTransformedActorId( actorId ) {
+    this.addTransformedDocumentId( "actors", actorId );
+  }
+
+  /**
+   * Legacy method for backward compatibility
+   * @deprecated Use clearTransformedDocumentIds("actors") instead
+   */
+  static clearTransformedActorIds() {
+    this.clearTransformedDocumentIds( "actors" );
+  }
+
+  /**
    * Register a simple type transformation rule for migrations
    * @param {string} sourceSystem - The source system identifier
    * @param {string} sourceType - The original type in the source system
@@ -64,11 +149,52 @@ export default class TypeTransformationManager {
 
       console.log( `MigrationManager: Type Transforming "${source.name || "Name-Not-Found-in-available-data"}" type "${source.type}" → "${targetType}" for system "${sourceSystem}"` );
 
+      const originalType = source.type;
       source.type = targetType;
+      
+      // Track transformed documents for later fixing
+      if ( source._id ) {
+        // Determine document type based on the collection or context
+        const documentType = this.#determineDocumentType( source, originalType, targetType );
+        if ( documentType ) {
+          this.addTransformedDocumentId( documentType, source._id );
+        }
+      }
+      
       return true;
     }
 
     return false;
+  }
+
+  /**
+   * Determine the document type (actors/items) based on the source data
+   * @param {object} source - The source document data
+   * @param {string} originalType - The original type
+   * @param {string} targetType - The target type
+   * @returns {string|null} - The document type ("actors" or "items") or null if unknown
+   * @private
+   */
+  static #determineDocumentType( source, originalType, targetType ) {
+    // Actor types (both original and target)
+    const actorTypes = [ "pc", "character", "creature", "npc", "dragon", "horror", "spirit", "trap", "vehicle" ];
+    
+    // Item types (both original and target)
+    const itemTypes = [ 
+      "armor", "devotion", "equipment", "mask", "namegiver", "shield", "skill", "spell", "talent", "weapon",
+      "discipline", "path", "questor", "knackAbility", "knackKarma", "knackManeuver", "spellKnack",
+      "maneuver", "power", "attack", "knack", "thread"
+    ];
+    
+    if ( actorTypes.includes( originalType ) || actorTypes.includes( targetType ) ) {
+      return "actors";
+    }
+    
+    if ( itemTypes.includes( originalType ) || itemTypes.includes( targetType ) ) {
+      return "items";
+    }
+    
+    return null; // Unknown document type
   }
 
   /**
@@ -135,5 +261,131 @@ export default class TypeTransformationManager {
   static clearAll() {
     this.#typeTransformRegistry.clear();
     this.#complexTypeTransformRegistry.clear();
+  }
+
+  /**
+   * General function to fix all transformed documents using ==system AND recursive: false
+   * This ensures documents are properly validated in Foundry V13 after type transformations
+   * @param {object} [documentIds] - Optional object with document type keys and ID arrays as values
+   *                                      e.g., { actors: ["id1", "id2"], items: ["id3"] }
+   *                                      If not provided, fixes all transformed documents
+   */
+  static async fixAllTransformedDocuments( documentIds = null ) {
+    const documentsToFix = documentIds || this.getAllTransformedDocumentIds();
+    
+    console.log( "=== FIXING ALL TRANSFORMED DOCUMENTS ===" );
+    console.log( "Documents to fix:", documentsToFix );
+    
+    // Fix actors
+    if ( documentsToFix.actors && documentsToFix.actors.length > 0 ) {
+      await this.#fixDocuments( "actors", documentsToFix.actors );
+    }
+    
+    // Fix items
+    if ( documentsToFix.items && documentsToFix.items.length > 0 ) {
+      await this.#fixDocuments( "items", documentsToFix.items );
+    }
+  }
+
+  /**
+   * Internal helper to fix documents of a specific type
+   * @param {string} documentType - The document type ("actors" or "items")
+   * @param {string[]} documentIds - Array of document IDs to fix
+   * @private
+   */
+  static async #fixDocuments( documentType, documentIds ) {
+    const collection = documentType === "actors" ? game.actors : game.items;
+    
+    const documents = documentIds
+      .map( id => collection.get( id ) )
+      .filter( doc => doc ); // Remove any null/undefined documents
+    
+    if ( documents.length === 0 ) {
+      console.log( `No ${documentType} found to fix.` );
+      return;
+    }
+    
+    console.log( `Fixing ${documents.length} transformed ${documentType}...` );
+    
+    for ( let i = 0; i < documents.length; i++ ) {
+      const document = documents[i];
+      try {
+        // Get the full system data
+        const fullSystemData = foundry.utils.deepClone( document.system );
+        
+        await document.update( {
+          type:       document.type, // Keep the current (transformed) type
+          "==system": fullSystemData
+        }, {
+          recursive: false,  // This is required for type changes
+          diff:      false,
+          render:    false,
+          broadcast: false
+        } );
+        
+        console.log( `✅ Fixed ${documentType.slice( 0, -1 )}: ${document.name} (${document.type})` );
+        
+      } catch ( error ) {
+        console.log( `❌ Failed to fix ${document.name}:`, error.message );
+        console.log( "This suggests the document data is corrupted at database level." );
+      }
+      
+      // Small delay between updates
+      await new Promise( resolve => {
+        setTimeout( resolve, 50 );
+      } );
+    }
+    
+    console.log( `Completed fixing ${documents.length} ${documentType}.` );
+  }
+
+  /**
+   * Function to fix character actors using ==system AND recursive: false
+   * This ensures character actors are properly validated in Foundry V13
+   * @param {string[]} actorIds - Optional array of specific actor IDs to fix. If not provided, fixes all character actors
+   * @deprecated Use fixAllTransformedDocuments() for more comprehensive fixing
+   */
+  static async fixAllCharacterActors( actorIds = null ) {
+    let characterActors;
+    
+    if ( actorIds && actorIds.length > 0 ) {
+      // Fix only specific actors
+      characterActors = actorIds
+        .map( id => game.actors.get( id ) )
+        .filter( actor => actor && actor.type === "character" );
+      console.log( `Fixing ${characterActors.length} specific transformed character actors...` );
+    } else {
+      // Fix all character actors
+      characterActors = game.actors.filter( actor => actor.type === "character" );
+      console.log( `Fixing all ${characterActors.length} character actors...` );
+    }
+    
+    // Loop through character actors
+    for ( let i = 0; i < characterActors.length; i++ ) {
+      const actor = characterActors[i];
+      try {
+        // Get the full system data
+        const fullSystemData = foundry.utils.deepClone( actor.system );
+        await actor.update( {
+          type:       "character",
+          "==system": fullSystemData
+        }, {
+          recursive: false,  // This is required for type changes
+          diff:      false,
+          render:    false,
+          broadcast: false
+        } );
+        console.log( `✅ Fixed actor: ${actor.name}` );
+      } catch ( error ) {
+        console.log( `❌ Still failed for ${actor.name}:`, error.message );
+        console.log( "This suggests the actor data is corrupted at database level." );
+      }
+      // Small delay between updates
+      await new Promise( resolve => {
+        setTimeout( resolve, 100 );
+      } );
+    }
+    
+    console.log( `Completed fixing ${characterActors.length} character actors.` );
   }
 }

--- a/module/services/migrations/v082/type-transformations.mjs
+++ b/module/services/migrations/v082/type-transformations.mjs
@@ -58,7 +58,6 @@ export function transformV082ComplexTypes( source ) {
     if ( source._id ) {
       // Determine document type and track it
       const documentType = determineDocumentTypeForTracking( originalType, newType );
-      console.log ( "old and new type", originalType, newType );
       if ( documentType ) {
         TypeTransformationManager.addTransformedDocumentId( documentType, source._id );
       }
@@ -85,7 +84,7 @@ function determineDocumentTypeForTracking( originalType, newType ) {
   const itemTypes = [ 
     "armor", "devotion", "equipment", "mask", "namegiver", "shield", "skill", "spell", "talent", "weapon",
     "discipline", "path", "questor", "knackAbility", "knackKarma", "knackManeuver", "spellKnack",
-    "maneuver", "power", "attack", "knack", "thread"
+    "maneuver", "power", "attack", "knack", "thread", "spellmatrix"
   ];
   
   if ( actorTypes.includes( originalType ) || actorTypes.includes( newType ) ) {


### PR DESCRIPTION
this is fixing the deep db migration of actor and item types. it is a call triggered after migrations are already done and triggered by the ready hook. It will only consider items and actors which where added to an array for later fixing, so this will only run if there are items or actor to be fixed

this is the base for all further migration issues