### PR TITLE
📝 ♻️ Refactor auto initialization of roll options

### DIFF
--- a/module/config/_module.mjs
+++ b/module/config/_module.mjs
@@ -15,6 +15,8 @@ import * as SYSTEM from "./system.mjs";
 import * as MIGRATIONS from "./migrations.mjs";
 import * as WORKFLOWS from "./workflows.mjs";
 
+/** @module config */
+
 export {
   ACTIONS,
   ACTORS,

--- a/module/data/roll/ability.mjs
+++ b/module/data/roll/ability.mjs
@@ -1,12 +1,35 @@
 import EdRollOptions from "./common.mjs";
 
+/**
+ * Roll options for ability rolls.
+ * @augments { EdRollOptions }
+ * @property { string } abilityUuid The UUID of the ability being rolled.
+ */
 export default class AbilityRollOptions extends EdRollOptions {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
     "ED.Data.Other.AbilityRollOptions",
   ];
+
+  /** @inheritdoc */
+  static TEST_TYPE = "action";
+
+  /** @inheritdoc */
+  static ROLL_TYPE = "ability";
+
+  /** @inheritdoc */
+  static GLOBAL_MODIFIERS = [
+    "allActions",
+    ...super.GLOBAL_MODIFIERS,
+  ];
+
+  // endregion
+
+  // region Static Methods
 
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -17,6 +40,24 @@ export default class AbilityRollOptions extends EdRollOptions {
       } ),
     } );
   }
+
+  /**
+   * @inheritdoc
+   * @returns { AbilityRollOptions } A new instance of AbilityRollOptions.
+   */
+  static fromData( data, options = {} ) {
+    return /** @type { AbilityRollOptions } */ super.fromData( data, options );
+  }
+
+  /**
+   * @inheritDoc
+   * @returns { AbilityRollOptions } A new instance of AbilityRollOptions.
+   */
+  static fromActor( data, actor, options = {} ) {
+    return /** @type { AbilityRollOptions } */ super.fromActor( data, actor, options );
+  }
+
+  // endregion
 
   /** @inheritDoc */
   async getFlavorTemplateData( context ) {

--- a/module/data/roll/attack.mjs
+++ b/module/data/roll/attack.mjs
@@ -49,18 +49,12 @@ export default class AttackRollOptions extends EdRollOptions {
     } );
   }
 
-  /**
-   * @inheritdoc
-   * @returns { AttackRollOptions } A new instance of AttackRollOptions.
-   */
+  /** @inheritdoc */
   static fromData( data, options = {} ) {
     return /** @type { AttackRollOptions } */ super.fromData( data, options );
   }
 
-  /**
-   * @inheritDoc
-   * @returns { AttackRollOptions } A new instance of AttackRollOptions.
-   */
+  /** @inheritDoc */
   static fromActor( data, actor, options = {} ) {
     return /** @type { AttackRollOptions } */ super.fromActor( data, actor, options );
   }

--- a/module/data/roll/attack.mjs
+++ b/module/data/roll/attack.mjs
@@ -1,13 +1,40 @@
 import ED4E from "../../config/_module.mjs";
 import EdRollOptions from "./common.mjs";
 
+/**
+ * Roll options for attack rolls.
+ * @augments { EdRollOptions }
+ * @property { string } weaponType The type of the weapon used for the attack.
+ * Should be one of the keys in {@link module:config~ITEMS~weaponType}.
+ * @property { string } weaponUuid The UUID of the weapon used for the attack.
+ * This should be an embedded item UUID, i.e. `Actor.<actorId>.Item.<itemId>`.
+ */
 export default class AttackRollOptions extends EdRollOptions {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
     "ED.Data.Other.AttackRollOptions",
   ];
+
+  /** @inheritdoc */
+  static TEST_TYPE = "action";
+
+  /** @inheritdoc */
+  static ROLL_TYPE = "attack";
+
+  /** @inheritdoc */
+  static GLOBAL_MODIFIERS = [
+    "allActions",
+    "allAttacks",
+    ...super.GLOBAL_MODIFIERS,
+  ];
+
+  // endregion
+
+  // region Static Methods
 
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -21,6 +48,24 @@ export default class AttackRollOptions extends EdRollOptions {
       } ),
     } );
   }
+
+  /**
+   * @inheritdoc
+   * @returns { AttackRollOptions } A new instance of AttackRollOptions.
+   */
+  static fromData( data, options = {} ) {
+    return /** @type { AttackRollOptions } */ super.fromData( data, options );
+  }
+
+  /**
+   * @inheritDoc
+   * @returns { AttackRollOptions } A new instance of AttackRollOptions.
+   */
+  static fromActor( data, actor, options = {} ) {
+    return /** @type { AttackRollOptions } */ super.fromActor( data, actor, options );
+  }
+
+  // endregion
 
   /** @inheritDoc */
   async getFlavorTemplateData( context ) {

--- a/module/data/roll/attuning.mjs
+++ b/module/data/roll/attuning.mjs
@@ -3,12 +3,6 @@ import { ED4E } from "../../../earthdawn4e.mjs";
 import { createContentAnchor } from "../../utils.mjs";
 
 /**
- * @typedef { object } EdAttuningRollOptionsInitializationData
- * @augments { EdRollOptionsInitializationData }
- */
-
-
-/**
  * Roll options for attuning spells to matrices or grimoires.
  * @augments { EdRollOptions }
  * @property { string } attuningType The type of attuning, either "matrixOnTheFly" or "grimoire".
@@ -66,20 +60,12 @@ export default class AttuningRollOptions extends EdRollOptions {
     } );
   }
 
-  /**
-   * @inheritDoc
-   * @param { EdAttuningRollOptionsInitializationData & Partial<AttuningRollOptions> } data The data to initialize the roll options with.
-   * @returns { AttuningRollOptions } A new instance of AttuningRollOptions.
-   */
+  /** @inheritDoc */
   static fromActor( data, actor, options = {} ) {
     return /** @type { AttuningRollOptions } */ super.fromActor( data, actor, options );
   }
 
-  /**
-   * @inheritDoc
-   * @param { EdAttuningRollOptionsInitializationData & Partial<AttuningRollOptions> } data The data to initialize the roll options with.
-   * @returns { AttuningRollOptions } A new instance of AttuningRollOptions.
-   */
+  /** @inheritDoc */
   static fromData( data, options = {} ) {
     return /** @type { AttuningRollOptions } */ super.fromData( data, options );
   }

--- a/module/data/roll/attuning.mjs
+++ b/module/data/roll/attuning.mjs
@@ -68,8 +68,8 @@ export default class AttuningRollOptions extends EdRollOptions {
 
   /**
    * @inheritDoc
-   * @param { EdAttuningRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
-   * @returns { AttuningRollOptions } A new instance of ThreadWeavingRollOptions.
+   * @param { EdAttuningRollOptionsInitializationData & Partial<AttuningRollOptions> } data The data to initialize the roll options with.
+   * @returns { AttuningRollOptions } A new instance of AttuningRollOptions.
    */
   static fromActor( data, actor, options = {} ) {
     return /** @type { AttuningRollOptions } */ super.fromActor( data, actor, options );
@@ -77,7 +77,7 @@ export default class AttuningRollOptions extends EdRollOptions {
 
   /**
    * @inheritDoc
-   * @param { EdAttuningRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
+   * @param { EdAttuningRollOptionsInitializationData & Partial<AttuningRollOptions> } data The data to initialize the roll options with.
    * @returns { AttuningRollOptions } A new instance of AttuningRollOptions.
    */
   static fromData( data, options = {} ) {

--- a/module/data/roll/attuning.mjs
+++ b/module/data/roll/attuning.mjs
@@ -2,8 +2,25 @@ import EdRollOptions from "./common.mjs";
 import { ED4E } from "../../../earthdawn4e.mjs";
 import { createContentAnchor } from "../../utils.mjs";
 
+/**
+ * @typedef { object } EdAttuningRollOptionsInitializationData
+ * @augments { EdRollOptionsInitializationData }
+ */
 
+
+/**
+ * Roll options for attuning spells to matrices or grimoires.
+ * @augments { EdRollOptions }
+ * @property { string } attuningType The type of attuning, either "matrixOnTheFly" or "grimoire".
+ * See {@link module:config~MAGIC~attuningType}.
+ * @property { string } attuningAbility The UUID of the ability used for attuning, usually thread weaving for matrices
+ * or patterncraft for grimoires.
+ * @property { Set<string> } spellsToAttune The UUIDs of the spells to attune.
+ * @property { boolean } grimoirePenalty Whether the penalty for unowned grimoires applies.
+ */
 export default class AttuningRollOptions extends EdRollOptions {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
@@ -16,6 +33,10 @@ export default class AttuningRollOptions extends EdRollOptions {
 
   /** @inheritdoc */
   static ROLL_TYPE = "attuning";
+
+  // endregion
+
+  // region Static Methods
 
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -45,18 +66,30 @@ export default class AttuningRollOptions extends EdRollOptions {
     } );
   }
 
-  /** @inheritDoc */
+  /**
+   * @inheritDoc
+   * @param { EdAttuningRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
+   * @returns { AttuningRollOptions } A new instance of ThreadWeavingRollOptions.
+   */
   static fromActor( data, actor, options = {} ) {
-    const modifiedData = {
-      ...data,
-      testType: "action",
-      rollType: "attuning",
-    };
-    return super.fromActor( modifiedData, actor, options );
+    return /** @type { AttuningRollOptions } */ super.fromActor( data, actor, options );
   }
 
+  /**
+   * @inheritDoc
+   * @param { EdAttuningRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
+   * @returns { AttuningRollOptions } A new instance of AttuningRollOptions.
+   */
+  static fromData( data, options = {} ) {
+    return /** @type { AttuningRollOptions } */ super.fromData( data, options );
+  }
+
+  // endregion
+
+  // region Data Initialization
+
   /** @inheritDoc */
-  _prepareStepData( data ) {
+  static _prepareStepData( data ) {
     const ability = fromUuidSync( data.attuningAbility );
     const stepData = {
       base:      ability.system.rankFinal,
@@ -68,7 +101,7 @@ export default class AttuningRollOptions extends EdRollOptions {
   }
 
   /** @inheritDoc */
-  _prepareStrainData( data ) {
+  static _prepareStrainData( data ) {
     return {
       base:      data.attuningType === "matrixOnTheFly" ? 1 : 0,
       modifiers: {},
@@ -76,7 +109,7 @@ export default class AttuningRollOptions extends EdRollOptions {
   }
 
   /** @inheritDoc */
-  _prepareTargetDifficulty( data ) {
+  static _prepareTargetDifficulty( data ) {
     return  {
       base:      0,
       modifiers: data.spellsToAttune?.reduce( ( acc, spellUuid ) => {
@@ -95,6 +128,8 @@ export default class AttuningRollOptions extends EdRollOptions {
       attuningAbility: createContentAnchor( fromUuidSync( this.attuningAbility ) ).outerHTML,
     };
   }
+
+  // endregion
 
   /**
    * Get the spell items that will be attuned.

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -7,6 +7,16 @@ import FormulaField from "../fields/formula-field.mjs";
 import SparseDataModel from "../abstract/sparse-data-model.mjs";
 
 /**
+ * @typedef { object } EdRollOptionsInitializationData
+ * @property { RollStepData } [step] The step data for the roll. Can be omitted if to be initialized automatically.
+ * @property { RollTargetData } [target] The target data for the roll. Can be omitted if to be initialized automatically.
+ * @property { RollStrainData } [strain] The strain data for the roll. Can be omitted if to be initialized automatically.
+ * @property { RollResourceData } [karma] The karma data for the roll. Can be omitted if to initialize to default.
+ * @property { RollResourceData } [devotion] The devotion data for the roll. Can be omitted to initialize to default.
+ * @property { Record<string, number> } [extraDice] Extra dice that are added to the roll, see {@link EdRollOptions.extraDice}.
+ */
+
+/**
  * @typedef {import('../../dice/ed-roll.mjs').FlavorTemplateData} FlavorTemplateData
  */
 
@@ -89,7 +99,53 @@ export default class EdRollOptions extends SparseDataModel {
     "allTests",
   ];
 
+  /**
+   * @description Bonus resources to be added globally
+   * @type { RollResourceData }
+   */
+  static get _bonusResource() {
+    const fields = foundry.data.fields;
+    return new fields.SchemaField(
+      {
+        pointsUsed: new fields.NumberField( {
+          required: true,
+          nullable: false,
+          initial:  0,
+          min:      0,
+          step:     1,
+          integer:  true,
+        } ),
+        available: new fields.NumberField( {
+          required: true,
+          nullable: false,
+          initial:  0,
+          min:      0,
+          step:     1,
+          integer:  true,
+        } ),
+        step: new fields.NumberField( {
+          required: true,
+          nullable: false,
+          initial:  this.initResourceStep,
+          min:      1,
+          step:     1,
+          integer:  true,
+        } ),
+        dice: new FormulaField( {
+          required: true,
+          initial:  this.initDiceForStep,
+        } ),
+      },
+      {
+        required: true,
+        nullable: true,
+      },
+    );
+  }
+
   // endregion
+
+  // region Static Methods
 
   /** @inheritDoc */
   static defineSchema() {
@@ -268,56 +324,12 @@ export default class EdRollOptions extends SparseDataModel {
   }
 
   /**
-   * @description Bonus resources to be added globally
-   * @type { RollResourceData }
-   */
-  static get _bonusResource() {
-    const fields = foundry.data.fields;
-    return new fields.SchemaField(
-      {
-        pointsUsed: new fields.NumberField( {
-          required: true,
-          nullable: false,
-          initial:  0,
-          min:      0,
-          step:     1,
-          integer:  true,
-        } ),
-        available: new fields.NumberField( {
-          required: true,
-          nullable: false,
-          initial:  0,
-          min:      0,
-          step:     1,
-          integer:  true,
-        } ),
-        step: new fields.NumberField( {
-          required: true,
-          nullable: false,
-          initial:  this.initResourceStep,
-          min:      1,
-          step:     1,
-          integer:  true,
-        } ),
-        dice: new FormulaField( {
-          required: true,
-          initial:  this.initDiceForStep,
-        } ),
-      },
-      {
-        required: true,
-        nullable: true,
-      },
-    );
-  }
-
-  /**
    * Creates a new instance of EdRollOptions from the provided data and actor. Subclasses may extend this method.
    * This basic implementation initializes the roll with karma and devotion data derived from the actor.
-   * @param {object} data - The data object containing the roll options, see {@link foundry.abstract.DataModel}.
-   * @param {ActorEd} actor - The actor from which to derive additional roll options.
-   * @param {RollOptions} [options] - Additional options for the roll, see {@link foundry.abstract.DataModel}.
-   * @returns {EdRollOptions} A new instance of EdRollOptions initialized with the provided data and actor.
+   * @param { EdRollOptionsInitializationData & Partial<EdRollOptions> } data - The data to initialize the roll options with.
+   * @param { ActorEd } actor - The actor from which to derive additional roll options.
+   * @param { DataModelConstructionContext } [options] - Additional options for the data model, see {@link foundry.abstract.DataModel}.
+   * @returns { EdRollOptions } A new instance of EdRollOptions initialized with the provided data and actor.
    */
   static fromActor( data, actor, options = {} ) {
     data.karma = {
@@ -332,8 +344,26 @@ export default class EdRollOptions extends SparseDataModel {
     };
     data.rollingActorUuid = actor.uuid;
 
+    return this.fromData( data, options );
+  }
+
+  /**
+   * Creates a new instance of EdRollOptions. It uses the provided data to automatically initialize
+   * step, target, and strain data, if possible.
+   * @param { EdRollOptionsInitializationData & Partial<EdRollOptions> } data The data object containing the roll options and/or
+   * additional data for automatic initialization.
+   * @param { DataModelConstructionContext } [options] Additional options for the data model, see {@link foundry.abstract.DataModel}.
+   * @returns { EdRollOptions } A new instance of EdRollOptions initialized with the provided data.
+   */
+  static fromData( data, options = {} ) {
+    data.step ??= this._prepareStepData( data );
+    data.target ??= this._prepareTargetDifficulty( data );
+    data.strain ??= this._prepareStrainData( data );
+
     return new this( data, options );
   }
+
+  // endregion
 
   // region Data Field Initialization
 
@@ -385,10 +415,9 @@ export default class EdRollOptions extends SparseDataModel {
 
   /** @inheritDoc */
   _initializeSource( data, options = {} ) {
-    data.step ??= this._prepareStepData( data );
-    data.step = this._applyGlobalStepModifiers( data );
-    data.target ??= this._prepareTargetDifficulty( data );
-    data.strain ??= this._prepareStrainData( data );
+    const modifiedStepData = this._applyGlobalStepModifiers( data );
+    if ( modifiedStepData ) data.step = modifiedStepData;
+
     data.testType ??= this.constructor.TEST_TYPE;
     data.rollType ??= this.constructor.ROLL_TYPE;
 
@@ -451,7 +480,7 @@ export default class EdRollOptions extends SparseDataModel {
    * @param {object} data The input data object containing relevant ability information.
    * @returns {RollStepData} The step data object containing the base step and modifiers, if any.
    */
-  _prepareStepData( data ) {
+  static _prepareStepData( data ) {
     return data.step ?? {};
   }
 
@@ -460,7 +489,7 @@ export default class EdRollOptions extends SparseDataModel {
    * @param {object} data - The input data object containing relevant information for strain calculation.
    * @returns {RollStrainData|null} The strain data object containing the base strain and any modifiers or null if not applicable.
    */
-  _prepareStrainData( data ) {
+  static _prepareStrainData( data ) {
     return data.strain ?? null;
   }
 
@@ -469,17 +498,18 @@ export default class EdRollOptions extends SparseDataModel {
    * @param {object} data - The data object with which this model is initialized.
    * @returns {RollTargetData|null} The target difficulty containing base and modifiers or null if not applicable (e.g. for effect tests).
    */
-  _prepareTargetDifficulty( data ) {
+  static _prepareTargetDifficulty( data ) {
     return data.target ?? null;
   }
 
   /**
    * Applies global step modifiers to the step data of the roll.
    * @param {object} data - The data object with which this model is initialized.
-   * @returns {RollStepData} The modified step data with global bonuses applied.
+   * @returns {RollStepData|undefined} The modified step data with global bonuses applied, or undefined if no step data is present.
    */
   _applyGlobalStepModifiers( data ) {
     const stepData = data.step;
+    if ( !stepData ) return;
     const actor = fromUuidSync( stepData.rollingActorUuid );
 
     if ( !actor ) return stepData;

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -45,7 +45,9 @@ import SparseDataModel from "../abstract/sparse-data-model.mjs";
  */
 
 /**
- * EdRollOptions for creating an EdRoll instance.
+ * EdRollOptions Options for creating an {@link EdRoll} instance.
+ * If not provided, values for `step`, `target`, and `strain` will be initialized to their automatically.
+ * This should be overridden by subclasses to provide automation. This class only provides the default values.
  * @property { RollStepData } step Ever information related to the step of the action, Mods, Bonuses, Mali etc.
  * @property { RollResourceData } karma Available Karma, Karma dice and used karma.
  * @property { RollResourceData } devotion Available Devotions, Devotion die, Devotion die used and used devotion.
@@ -54,15 +56,8 @@ import SparseDataModel from "../abstract/sparse-data-model.mjs";
  * @property { RollTargetData } target All information of the targets array. Defenses, number, resistance.
  * @property { RollStrainData } strain How much strain this roll will cost
  * @property { string } chatFlavor The text that is added to the ChatMessage when this call is put to chat.
- * @property { ( 'action' | 'effect' ) } testType The type of roll.
- * @property { string } rollType Type of roll, like
- *                               damageRanged (Effect), damageMelee (Effect), attackRanged, attackMelee,
- *                               ability,
- *                               resistances (Effect), reaction, opposed
- *                               spellCasting, threadWeaving, spellCastingEffect (Effect)
- *                               Initiative (effect), Recovery (Effect), effects (Effect)
- *                               poison
- *                               etc. TODO: complete list
+ * @property { ( 'action' | 'effect' | 'arbitrary' ) } testType The type of the test. See {@link module:config~ROLLS~testTypes}.
+ * @property { string } rollType The type of the roll. See {@link module:config~ROLLS~rollTypes}.
  */
 export default class EdRollOptions extends SparseDataModel {
 

--- a/module/data/roll/common.mjs
+++ b/module/data/roll/common.mjs
@@ -23,9 +23,9 @@ import SparseDataModel from "../abstract/sparse-data-model.mjs";
 /**
  * @typedef { object } RollStepData Data for a roll step.
  * @property { number } base The base step that is used to determine the dice that are rolled.
- * @property { Record<string, number> } modifiers All modifiers that are applied to the base step.
+ * @property { Record<string, number> } [modifiers] All modifiers that are applied to the base step.
  *                                              Keys are localized labels. Values are the modifier.
- * @property { number } total The final step that is used to determine the dice that are rolled.
+ * @property { number } [total] The final step that is used to determine the dice that are rolled.
  *                            The sum of all modifiers is added to the base value.
  */
 
@@ -40,18 +40,18 @@ import SparseDataModel from "../abstract/sparse-data-model.mjs";
 /**
  * @typedef { object } RollTargetData Data for the target number of a roll.
  * @property { number } base The base target number.
- * @property { Record<string, number> } modifiers All modifiers that are applied to the base target number.
+ * @property { Record<string, number> } [modifiers] All modifiers that are applied to the base target number.
  *                                             Keys are localized labels. Values are the modifier.
- * @property { number } total The final target number. The sum of all modifiers is added to the base value.
- * @property { boolean } public Whether the target number is shown in chat or hidden.
+ * @property { number } [total] The final target number. The sum of all modifiers is added to the base value.
+ * @property { boolean } [public] Whether the target number is shown in chat or hidden.
  */
 
 /**
  * @typedef { object } RollStrainData Data for the strain that is taken after a roll.
  * @property { number } base The base strain that is taken.
- * @property { Record<string, number> } modifiers All modifiers that are applied to the base strain.
+ * @property { Record<string, number> } [modifiers] All modifiers that are applied to the base strain.
  *                                            Keys are localized labels. Values are the modifier.
- * @property { number } total The final strain that is taken. The sum of all modifiers is added to the base value.
+ * @property { number } [total] The final strain that is taken. The sum of all modifiers is added to the base value.
  */
 
 /**

--- a/module/data/roll/horror-mark.mjs
+++ b/module/data/roll/horror-mark.mjs
@@ -3,7 +3,29 @@ import { createContentAnchor } from "../../utils.mjs";
 import { MAGIC } from "../../config/_module.mjs";
 import { getSetting } from "../../settings.mjs";
 
+/**
+ * @typedef { object } EdHorrorMarkRollOptionsInitializationData
+ * @augments { EdRollOptionsInitializationData }
+ * @property { ActorEd } caster The actor that is casting the horror mark.
+ * Can be omitted if `casterUuid` in {@link HorrorMarkRollOptions} is provided.
+ * @property { ActorEd } [horror] The horror that is trying to mark the target.
+ * Can be omitted if `horrorUuid` in {@link HorrorMarkRollOptions} is provided.
+ * @property { ItemEd } [spell] The spell that is causing the horror mark,
+ * Can be omitted if `spellUuid` in {@link HorrorMarkRollOptions} is provided
+ */
+
+/**
+ * Roll options for horror mark rolls.
+ * @augments { EdRollOptions }
+ * @property { string } casterUuid The UUID of the actor that is casting the horror mark.
+ * @property { string } [astralSpacePollution] The astral space pollution level. Should be one of the keys
+ * in {@link module:config~MAGIC~astralSpacePollution}.
+ * @property { string } [horrorUuid] The UUID of the horror that is trying to mark the target.
+ * @property { string } [spellUuid] The spell that is causing the horror mark, if applicable.
+ */
 export default class HorrorMarkRollOptions extends EdRollOptions {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
@@ -16,6 +38,10 @@ export default class HorrorMarkRollOptions extends EdRollOptions {
 
   /** @inheritdoc */
   static ROLL_TYPE = "horrorMark";
+
+  // endregion
+
+  // region Static Methods
 
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -39,6 +65,28 @@ export default class HorrorMarkRollOptions extends EdRollOptions {
     } );
   }
 
+  /**
+   * @inheritDoc
+   * @param { EdHorrorMarkRollOptionsInitializationData & Partial<HorrorMarkRollOptions> } data The data to initialize the roll options with.
+   * @returns { HorrorMarkRollOptions } A new instance of HorrorMarkRollOptions.
+   */
+  static fromActor( data, actor, options = {} ) {
+    return /** @type { HorrorMarkRollOptions } */ super.fromActor( data, actor, options );
+  }
+
+  /**
+   * @inheritDoc
+   * @param { EdHorrorMarkRollOptionsInitializationData & Partial<HorrorMarkRollOptions> } data The data to initialize the roll options with.
+   * @returns { HorrorMarkRollOptions } A new instance of HorrorMarkRollOptions.
+   */
+  static fromData( data, options = {} ) {
+    return /** @type { HorrorMarkRollOptions } */ super.fromData( data, options );
+  }
+
+  // endregion
+
+  // region Data Initialization
+
   /** @inheritDoc */
   _getChatFlavorData() {
     const horror = this.horrorUuid ?
@@ -51,7 +99,7 @@ export default class HorrorMarkRollOptions extends EdRollOptions {
   }
 
   /** @inheritDoc */
-  _prepareStepData( data ) {
+  static _prepareStepData( data ) {
     if ( data.step ) return data.step;
 
     const horror = data.horror ?? fromUuidSync( data.horrorUuid );
@@ -84,17 +132,21 @@ export default class HorrorMarkRollOptions extends EdRollOptions {
   }
 
   /** @inheritDoc */
-  _prepareStrainData( data ) {
+  static _prepareStrainData( data ) {
     return null;
   }
 
   /** @inheritDoc */
-  _prepareTargetDifficulty( data ) {
+  static _prepareTargetDifficulty( data ) {
     const actor = data.caster ?? fromUuidSync( data.casterUuid );
     return {
       base: actor.system.characteristics.defenses.mystical.baseValue,
     };
   }
+
+  // endregion
+
+  // region Rendering
 
   /** @inheritDoc */
   async getFlavorTemplateData( context ) {
@@ -105,4 +157,6 @@ export default class HorrorMarkRollOptions extends EdRollOptions {
 
     return newContext;
   }
+
+  // endregion
 }

--- a/module/data/roll/horror-mark.mjs
+++ b/module/data/roll/horror-mark.mjs
@@ -68,7 +68,6 @@ export default class HorrorMarkRollOptions extends EdRollOptions {
   /**
    * @inheritDoc
    * @param { EdHorrorMarkRollOptionsInitializationData & Partial<HorrorMarkRollOptions> } data The data to initialize the roll options with.
-   * @returns { HorrorMarkRollOptions } A new instance of HorrorMarkRollOptions.
    */
   static fromActor( data, actor, options = {} ) {
     return /** @type { HorrorMarkRollOptions } */ super.fromActor( data, actor, options );
@@ -77,9 +76,11 @@ export default class HorrorMarkRollOptions extends EdRollOptions {
   /**
    * @inheritDoc
    * @param { EdHorrorMarkRollOptionsInitializationData & Partial<HorrorMarkRollOptions> } data The data to initialize the roll options with.
-   * @returns { HorrorMarkRollOptions } A new instance of HorrorMarkRollOptions.
    */
   static fromData( data, options = {} ) {
+    data.casterUuid ??= data.caster?.uuid;
+    data.horrorUuid ??= data.horror?.uuid;
+    data.spellUuid ??= data.spell?.uuid;
     return /** @type { HorrorMarkRollOptions } */ super.fromData( data, options );
   }
 

--- a/module/data/roll/initiative.mjs
+++ b/module/data/roll/initiative.mjs
@@ -50,18 +50,12 @@ export default class InitiativeRollOptions extends EdRollOptions {
     } );
   }
 
-  /**
-   * @inheritdoc
-   * @returns { InitiativeRollOptions } A new instance of InitiativeRollOptions.
-   */
+  /** @inheritDoc */
   static fromData( data, options = {} ) {
     return /** @type { InitiativeRollOptions } */ super.fromData( data, options );
   }
 
-  /**
-   * @inheritDoc
-   * @returns { InitiativeRollOptions } A new instance of InitiativeRollOptions.
-   */
+  /** @inheritDoc */
   static fromActor( data, actor, options = {} ) {
     return /** @type { InitiativeRollOptions } */ super.fromActor( data, actor, options );
   }

--- a/module/data/roll/initiative.mjs
+++ b/module/data/roll/initiative.mjs
@@ -1,12 +1,36 @@
 import EdRollOptions from "./common.mjs";
 
+/**
+ * Roll options for initiative rolls.
+ * @augments { EdRollOptions }
+ * @property { string } [replacementEffect] The UUID of an item that replaces the basic DEX attribute step.
+ * @property { Set<string> } [increaseAbilities] A set of UUIDs of items that add steps to the initiative roll.
+ */
 export default class InitiativeRollOptions extends EdRollOptions {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
     "ED.Data.Other.InitiativeRollOptions",
   ];
+
+  /** @inheritdoc */
+  static TEST_TYPE = "effect";
+
+  /** @inheritdoc */
+  static ROLL_TYPE = "initiative";
+
+  /** @inheritdoc */
+  static GLOBAL_MODIFIERS = [
+    "allEffects",
+    ...super.GLOBAL_MODIFIERS,
+  ];
+
+  // endregion
+
+  // region Static Methods
 
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -26,6 +50,26 @@ export default class InitiativeRollOptions extends EdRollOptions {
     } );
   }
 
+  /**
+   * @inheritdoc
+   * @returns { InitiativeRollOptions } A new instance of InitiativeRollOptions.
+   */
+  static fromData( data, options = {} ) {
+    return /** @type { InitiativeRollOptions } */ super.fromData( data, options );
+  }
+
+  /**
+   * @inheritDoc
+   * @returns { InitiativeRollOptions } A new instance of InitiativeRollOptions.
+   */
+  static fromActor( data, actor, options = {} ) {
+    return /** @type { InitiativeRollOptions } */ super.fromActor( data, actor, options );
+  }
+
+  // endregion
+
+  // region Rendering
+
   /** @inheritDoc */
   async getFlavorTemplateData( context ) {
     const newContext = await super.getFlavorTemplateData( context );
@@ -33,5 +77,7 @@ export default class InitiativeRollOptions extends EdRollOptions {
     newContext.increaseAbilities = this.increaseAbilities;
     return newContext;
   }
+
+  // endregion
 
 }

--- a/module/data/roll/recovery.mjs
+++ b/module/data/roll/recovery.mjs
@@ -55,18 +55,12 @@ export default class RecoveryRollOptions extends EdRollOptions {
     } );
   }
 
-  /**
-   * @inheritdoc
-   * @returns { RecoveryRollOptions } A new instance of RecoveryRollOptions.
-   */
+  /** @inheritDoc */
   static fromData( data, options = {} ) {
     return /** @type { RecoveryRollOptions } */ super.fromData( data, options );
   }
 
-  /**
-   * @inheritDoc
-   * @returns { RecoveryRollOptions } A new instance of RecoveryRollOptions.
-   */
+  /** @inheritDoc */
   static fromActor( data, actor, options = {} ) {
     return /** @type { RecoveryRollOptions } */ super.fromActor( data, actor, options );
   }

--- a/module/data/roll/recovery.mjs
+++ b/module/data/roll/recovery.mjs
@@ -1,13 +1,39 @@
 import EdRollOptions from "./common.mjs";
 import ED4E from "../../config/_module.mjs";
 
+/**
+ * Roll options for recovery rolls.
+ * @augments { EdRollOptions }
+ * @property { string } recoveryMode The recovery mode, which can be one
+ * of the keys in {@link module:config~WORKFLOWS~recoveryModes}.
+ * @property { boolean } [ignoreWounds=false] Whether to ignore penalties from wounds during the recovery roll.
+ */
 export default class RecoveryRollOptions extends EdRollOptions {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
     "ED.Data.Other.RecoveryRollOptions",
   ];
+
+  /** @inheritdoc */
+  static TEST_TYPE = "effect";
+
+  /** @inheritdoc */
+  static ROLL_TYPE = "recovery";
+
+  /** @inheritdoc */
+  static GLOBAL_MODIFIERS = [
+    "allEffects",
+    "allRecoveryTests",
+    ...super.GLOBAL_MODIFIERS,
+  ];
+
+  // endregion
+
+  // region Static Methods
 
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -29,16 +55,22 @@ export default class RecoveryRollOptions extends EdRollOptions {
     } );
   }
 
-  /** @inheritDoc */
-  static fromActor( data, actor, options = {} ) {
-    const rollOptions = super.fromActor( data, actor, options ).toObject();
-
-    rollOptions.recoveryMode = data.recoveryMode || "recovery";
-    rollOptions.testType = "effect";
-    rollOptions.rollType = "recovery";
-    rollOptions.ignoreWounds = data.ignoreWounds || false;
-
-    return new this( rollOptions, actor, options );
+  /**
+   * @inheritdoc
+   * @returns { RecoveryRollOptions } A new instance of RecoveryRollOptions.
+   */
+  static fromData( data, options = {} ) {
+    return /** @type { RecoveryRollOptions } */ super.fromData( data, options );
   }
+
+  /**
+   * @inheritDoc
+   * @returns { RecoveryRollOptions } A new instance of RecoveryRollOptions.
+   */
+  static fromActor( data, actor, options = {} ) {
+    return /** @type { RecoveryRollOptions } */ super.fromActor( data, actor, options );
+  }
+
+  // endregion
 
 }

--- a/module/data/roll/weaving.mjs
+++ b/module/data/roll/weaving.mjs
@@ -2,8 +2,23 @@ import EdRollOptions from "./common.mjs";
 import { createContentAnchor } from "../../utils.mjs";
 import { MAGIC } from "../../config/_module.mjs";
 
+/**
+ * @typedef { object } EdThreadWeavingRollOptionsInitializationData
+ * @augments { EdRollOptionsInitializationData }
+ * @property { ItemEd } [weavingAbility] The ability used for thread weaving.
+ * Can be omitted if `weavingAbilityUuid` is provided.
+ * @property { string } [weavingAbilityUuid] The UUID of the ability used for thread weaving.
+ * Can be omitted if `weavingAbility` is provided.
+ * @property { ItemEd } [spell] The spell the threads are woven for.
+ * Can be omitted if `spellUuid` is provided.
+ * @property { string } [spellUuid] The UUID of the spell the threads are woven for.
+ * Can be omitted if `spell` is provided.
+ * @property { ItemEd } [grimoire] The grimoire item, if a grimoire is used to cast the spell.
+ */
 
 export default class ThreadWeavingRollOptions extends EdRollOptions {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
@@ -22,6 +37,10 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
     "allActions",
     ...super.GLOBAL_MODIFIERS,
   ];
+
+  // endregion
+
+  // region Static Methods
 
   static defineSchema() {
     const fields = foundry.data.fields;
@@ -52,6 +71,28 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
     } );
   }
 
+  /**
+   * @inheritDoc
+   * @param { EdThreadWeavingRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
+   * @returns { ThreadWeavingRollOptions } A new instance of ThreadWeavingRollOptions.
+   */
+  static fromActor( data, actor, options = {} ) {
+    return /** @type { ThreadWeavingRollOptions } */ super.fromActor( data, actor, options );
+  }
+
+  /**
+   * @inheritDoc
+   * @param { EdThreadWeavingRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
+   * @returns { ThreadWeavingRollOptions } A new instance of ThreadWeavingRollOptions.
+   */
+  static fromData( data, options = {} ) {
+    return /** @type { ThreadWeavingRollOptions } */ super.fromData( data, options );
+  }
+
+  // endregion
+
+  // region Data Initialization
+
   /** @inheritDoc */
   _getChatFlavorData() {
     return {
@@ -62,10 +103,13 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
   }
 
   /** @inheritDoc */
-  _prepareStepData( data ) {
+  static _prepareStepData( data ) {
     if ( data.step ) return data.step;
 
     let weavingAbility = data.weavingAbility ?? fromUuidSync( data.weavingAbilityUuid );
+    if ( !weavingAbility ) {
+      throw new Error( "ThreadWeavingRollOptions: No weaving ability found." );
+    }
 
     const stepData = weavingAbility.system.baseRollOptions.step || {};
 
@@ -84,18 +128,26 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
     return stepData;
   }
 
-  _prepareStrainData( data ) {
+  /** @inheritDoc */
+  static _prepareStrainData( data ) {
     if ( data.strain ) return data.strain;
 
     let weavingAbility = data.weavingAbility ?? fromUuidSync( data.weavingAbilityUuid );
+    if ( !weavingAbility ) {
+      throw new Error( "ThreadWeavingRollOptions: No weaving ability found." );
+    }
 
     return weavingAbility.system.baseRollOptions.strain;
   }
 
-  _prepareTargetDifficulty( data ) {
+  /** @inheritDoc */
+  static _prepareTargetDifficulty( data ) {
     if ( data.target ) return data.target;
 
     const spell = data.spell ?? fromUuidSync( data.spellUuid );
+    if ( !spell ) {
+      throw new Error( "ThreadWeavingRollOptions: No spell found." );
+    }
 
     return {
       base:      spell.system.spellDifficulty.weaving,
@@ -103,6 +155,10 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
       public:    true,
     };
   }
+
+  // endregion
+
+  // region Rendering
 
   /** @inheritDoc */
   async getFlavorTemplateData( context ) {
@@ -127,5 +183,7 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
 
     return newContext;
   }
+
+  // endregion
 
 }

--- a/module/data/roll/weaving.mjs
+++ b/module/data/roll/weaving.mjs
@@ -80,7 +80,7 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
 
   /**
    * @inheritDoc
-   * @param { EdThreadWeavingRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
+   * @param { EdThreadWeavingRollOptionsInitializationData & Partial<ThreadWeavingRollOptions> } data The data to initialize the roll options with.
    * @returns { ThreadWeavingRollOptions } A new instance of ThreadWeavingRollOptions.
    */
   static fromActor( data, actor, options = {} ) {
@@ -89,7 +89,7 @@ export default class ThreadWeavingRollOptions extends EdRollOptions {
 
   /**
    * @inheritDoc
-   * @param { EdThreadWeavingRollOptionsInitializationData & Partial<EdRollOptions> } data The data to initialize the roll options with.
+   * @param { EdThreadWeavingRollOptionsInitializationData & Partial<ThreadWeavingRollOptions> } data The data to initialize the roll options with.
    * @returns { ThreadWeavingRollOptions } A new instance of ThreadWeavingRollOptions.
    */
   static fromData( data, options = {} ) {

--- a/module/data/roll/weaving.mjs
+++ b/module/data/roll/weaving.mjs
@@ -16,6 +16,13 @@ import { MAGIC } from "../../config/_module.mjs";
  * @property { ItemEd } [grimoire] The grimoire item, if a grimoire is used to cast the spell.
  */
 
+/**
+ * Roll options for weaving threads.
+ * @augments { EdRollOptions }
+ * @property { string } spellUuid The UUID of the spell the threads are woven for.
+ * @property { string } weavingAbilityUuid The UUID of the ability used for thread weaving.
+ * @property { { required: number, extra: number } } threads The number of threads
+ */
 export default class ThreadWeavingRollOptions extends EdRollOptions {
 
   // region Static Properties


### PR DESCRIPTION
Roll options can be optionally initialized automatically by having subclasses implement the appropriate initialization methods. This was done automatically on creation, so it could not be avoided and wasn't documented at all.
This PR factors this automatic initialization out of standard construction and moves it to a dedicated factory method `fromData`. This then allows for better documentation of the init data that does not get persisted in the roll options.
Damage Roll Options will be done in another PR with #1623.