### PR TITLE
Apply transferable effects to target from chat 

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -3311,6 +3311,7 @@
         "invalidRecoveryMode":                     "Ungültiger Erholungsmodus. Bitte überprüfe die Einstellungen.",
         "livingArmorOnly":                         "Es kann nur nur lebendige Rüstung getragen werden.",
         "matrixBrokenCannotWeave":                 "Die Matrix ist beschädigt und kann nicht benutzt werden.",
+        "needTargetsToApplyFromChat":              "Es müssen Ziele ausgewählt werden, um den Effekt aus dem Chat anzuwenden.",
         "noActiveSpellSelected":                   "Die Matrix hat keinen aktiven Zauber ausgewählt.",
         "noLp":                                    "Keine Legendenpunkte angegeben!",
         "noMoreClassLevelsToIncrease":             "Es gibt keine weiteren Ränge/Kreise, die erhöht werden können.",

--- a/lang/en.json
+++ b/lang/en.json
@@ -3312,6 +3312,7 @@
         "invalidRecoveryMode":                     "TODO: Add translation",
         "livingArmorOnly":                         "This namegiver can only wear living armor.",
         "matrixBrokenCannotWeave":                 "TODO: Add translation",
+        "needTargetsToApplyFromChat":              "TODO: Add translation",
         "noActiveSpellSelected":                   "TODO: Add translation",
         "noLp":                                    "TODO: Add translation",
         "noMoreClassLevelsToIncrease":             "TODO: Add translation",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -3311,6 +3311,7 @@
         "invalidRecoveryMode":                     "TODO: Add translation",
         "livingArmorOnly":                         "TODO: Add translation",
         "matrixBrokenCannotWeave":                 "TODO: Add translation",
+        "needTargetsToApplyFromChat":              "TODO: Add translation",
         "noActiveSpellSelected":                   "TODO: Add translation",
         "noLp":                                    "TODO: Add translation",
         "noMoreClassLevelsToIncrease":             "TODO: Add translation",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -3311,6 +3311,7 @@
         "invalidRecoveryMode":                     "TODO: Add translation",
         "livingArmorOnly":                         "TODO: Add translation",
         "matrixBrokenCannotWeave":                 "TODO: Add translation",
+        "needTargetsToApplyFromChat":              "TODO: Add translation",
         "noActiveSpellSelected":                   "TODO: Add translation",
         "noLp":                                    "TODO: Add translation",
         "noMoreClassLevelsToIncrease":             "TODO: Add translation",

--- a/module/applications/effect/eae-sheet.mjs
+++ b/module/applications/effect/eae-sheet.mjs
@@ -190,7 +190,11 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
    * @type {ApplicationClickAction}
    */
   static async #onAddChange() {
-    const submitData = this._processFormData( null, this.form, new FormDataExtended( this.form ) );
+    const submitData = this._processFormData(
+      null,
+      this.form,
+      new foundry.applications.ux.FormDataExtended( this.form )
+    );
     const systemChanges = Object.values( submitData.system.changes ) ?? [];
     systemChanges.push( {} );
     return this.submit( { updateData: { "system.changes": systemChanges } } );

--- a/module/config/rolls.mjs
+++ b/module/config/rolls.mjs
@@ -103,7 +103,7 @@ export const testTypes = {
   },
   effect: {
     label:            "ED.Rolls.Labels.effectTestRoll",
-    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/effect-roll-flavor.hbs",
+    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/arbitrary-roll-flavor.hbs",
   },
 };
 preLocalize( "testTypes", { key: "label" } );

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -2,18 +2,13 @@ import SystemDataModel from "../abstract/system-data-model.mjs";
 
 export default class BaseMessageData extends SystemDataModel {
 
+  // region Static Properties
+
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
     "ED.Data.General.BaseMessage",
   ];
-
-  constructor( data, options ) {
-    super( data, options );
-
-    // Configure Options
-    this.options = Object.freeze( this._initializeOptions( {} ) );
-  }
 
   /**
    * Designates which upstream class in this class' inheritance chain is the base data model.
@@ -30,6 +25,10 @@ export default class BaseMessageData extends SystemDataModel {
     },
   };
 
+  // endregion
+
+  // region Static Methods
+
   /**
    * Iterate over the inheritance chain of this Application. Analogous to {@link ApplicationV2#inheritanceChain}
    * @see BaseMessageData.BASE_DATA_MODEL
@@ -44,6 +43,8 @@ export default class BaseMessageData extends SystemDataModel {
       cls = Object.getPrototypeOf( cls );
     }
   }
+
+  // endregion
 
   /**
    * Initialize the default options for this. Analogous to {@link ApplicationV2#_initializeApplicationOptions}
@@ -112,6 +113,13 @@ export default class BaseMessageData extends SystemDataModel {
   }
 
   // endregion
+
+  constructor( data, options ) {
+    super( data, options );
+
+    // Configure Options
+    this.options = Object.freeze( this._initializeOptions( {} ) );
+  }
 
   // region Event Handlers
 

--- a/module/data/chat/base-message.mjs
+++ b/module/data/chat/base-message.mjs
@@ -21,6 +21,7 @@ export default class BaseMessageData extends SystemDataModel {
 
   static DEFAULT_OPTIONS = {
     actions: {
+      applyEffect:    this._onApplyEffect,
       scrollToSource: this._onScrollToSource,
     },
   };
@@ -187,6 +188,35 @@ export default class BaseMessageData extends SystemDataModel {
     console.warn( `The ${ target.dataset.action } action has not been implemented in ${ this.constructor.name }` );
   }
 
+  /**
+   * @type {ApplicationClickAction}
+   * @this {BaseMessageData}
+   */
+  static async _onApplyEffect( event, button ) {
+    const itemForEffects = /** @type {ItemEd} */ await fromUuid( button.dataset.itemForEffectsUuid );
+    if ( !itemForEffects ) {
+      throw new Error( `No item found for effects with UUID: ${ button.dataset.itemForEffectsUuid }` );
+    }
+
+    const effects = itemForEffects.targetEffects;
+    const targets = Array.from( game.user.targets.map( target => target.document.actor ) );
+    if ( targets.length === 0 ) {
+      ui.notifications.warn( game.i18n.localize(
+        "ED.Notifications.Warn.needTargetsToApplyFromChat",
+      ) );
+      return;
+    }
+
+    for ( const targetActor of targets ) {
+      await targetActor.createActiveEffects( effects );
+    }
+
+  }
+
+  /**
+   * @type {ApplicationClickAction}
+   * @this {BaseMessageData}
+   */
   static async _onScrollToSource( event, button ) {
     this.parent.scrollToMessage( button.dataset.id );
   }

--- a/module/data/chat/damage.mjs
+++ b/module/data/chat/damage.mjs
@@ -95,7 +95,9 @@ export default class DamageMessageData extends BaseMessageData {
 
     const targets = Array.from( game.user.targets.map( target => target.document.actor ) );
     if ( targets.length === 0 ) {
-      ui.notifications.warn( "TODO: You must target at least one token to apply damage." );
+      ui.notifications.warn( game.i18n.localize(
+        "ED.Notifications.Warn.needTargetsToApplyFromChat",
+      ) );
       return;
     }
 

--- a/module/data/roll/ability.mjs
+++ b/module/data/roll/ability.mjs
@@ -64,6 +64,7 @@ export default class AbilityRollOptions extends EdRollOptions {
     const newContext = await super.getFlavorTemplateData( context );
 
     newContext.ability = await fromUuid( this.abilityUuid );
+    newContext.itemForEffects = newContext.ability;
     newContext.rollingActor = await fromUuid( this.rollingActorUuid );
     newContext.rollingActorTokenDocument = await context.rollingActor?.getTokenDocument();
 

--- a/module/data/roll/spellcasting.mjs
+++ b/module/data/roll/spellcasting.mjs
@@ -149,6 +149,7 @@ export default class SpellcastingRollOptions extends EdRollOptions {
     const newContext = await super.getFlavorTemplateData( context );
 
     newContext.spell = await fromUuid( this.spellUuid );
+    newContext.itemForEffects = newContext.spell;
     newContext.spellContentAnchor = createContentAnchor( newContext.spell ).outerHTML;
     newContext.spellcastingAbility = await fromUuid( this.spellcastingAbilityUuid );
     newContext.spellcastingAbilityContentAnchor = createContentAnchor( newContext.spellcastingAbility ).outerHTML;

--- a/module/documents/actor.mjs
+++ b/module/documents/actor.mjs
@@ -349,6 +349,16 @@ export default class ActorEd extends Actor {
   // region Active Effects
 
   /**
+   * Applies the given active effects to the actor.
+   * @param {ActiveEffectData[]} effects The active effects to apply to the actor.
+   * @returns {Promise<Document[]|*>} Returns the created active effects.
+   */
+  async createActiveEffects( effects ) {
+    if ( !effects || effects.length === 0 ) return;
+    return this.createEmbeddedDocuments( "ActiveEffect", effects );
+  }
+
+  /**
    * @inheritDoc
    * @param {string} statusId           A status effect ID defined in CONFIG.statusEffects
    * @param {object} [options]          Additional options which modify how the effect is created

--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -17,7 +17,6 @@ export default class ItemEd extends Item {
 
   // endregion
 
-
   // region Static Properties
 
   /** @inheritDoc */
@@ -27,20 +26,19 @@ export default class ItemEd extends Item {
 
   // endregion
 
-
   // region Properties
 
   /**
    * Retrieve the list of ActiveEffects that are currently applied to this Item.
-   * @type {ActiveEffect[]}
+   * @type {ActiveEffectData[]}
    */
   get appliedEffects() {
-    return this.appliedEffects.filter( effect => effect.active );
+    return this.effects.filter( effect => effect.active );
   }
 
   /**
    * An array of ActiveEffect instances which are present on the Item which have a limited duration.
-   * @type {ActiveEffect[]}
+   * @type {ActiveEffectData[]}
    */
   get temporaryEffects() {
     return this.appliedEffects.filter( effect => effect.active && effect.isTemporary );
@@ -48,14 +46,21 @@ export default class ItemEd extends Item {
 
   /**
    * An array of ActiveEffect instances which are present on the Item which are permanent.
-   * @type {ActiveEffect[]}
+   * @type {ActiveEffectData[]}
    */
   get permanentEffects() {
     return this.appliedEffects.filter( effect => effect.active && effect.system?.permanent );
   }
 
-  // endregion
+  /**
+   * An array of ActiveEffect instances that are set to transfer to the target of this Item.
+   * @type {ActiveEffectData[]}
+   */
+  get targetEffects() {
+    return this.effects.filter( effect => effect.system.transferToTarget );
+  }
 
+  // endregion
 
   // region Data Preparation
 
@@ -119,11 +124,9 @@ export default class ItemEd extends Item {
 
   // endregion
 
-
   // region Effects
 
   // endregion
-
 
   // region Event Handlers
 
@@ -156,7 +159,6 @@ export default class ItemEd extends Item {
   }
 
   // endregion
-
 
   // region Earthdawn Methods
 

--- a/templates/chat/chat-buttons/assign-effect.hbs
+++ b/templates/chat/chat-buttons/assign-effect.hbs
@@ -1,4 +1,4 @@
 <button type="button" class="apply-effect" title="{{ localize "ED.Chat.Button.applyEffectTitle" }}"
-    data-action="applyEffect">
+    data-action="applyEffect" data-item-for-effect-uuid="{{ itemForEffects.uuid }}">
     {{ localize "ED.Chat.Button.applyEffect" }}
 </button>

--- a/templates/chat/chat-buttons/assign-effect.hbs
+++ b/templates/chat/chat-buttons/assign-effect.hbs
@@ -1,4 +1,4 @@
 <button type="button" class="apply-effect" title="{{ localize "ED.Chat.Button.applyEffectTitle" }}"
-    data-action="applyEffect" data-item-for-effect-uuid="{{ itemForEffects.uuid }}">
+    data-action="applyEffect" data-item-for-effects-uuid="{{ itemForEffects.uuid }}">
     {{ localize "ED.Chat.Button.applyEffect" }}
 </button>

--- a/templates/chat/chat-flavor/ability-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/ability-roll-flavor.hbs
@@ -5,10 +5,9 @@
   {{#if (ne target.total 0)}}
   {{> "systems/ed4e/templates/chat/dice-partials/roll-successes.hbs"}}
   {{/if}}
-  {{!-- <div>
-    <p class="undefined">to be reworked with #284</p>
+  <div class="message-buttons flexrow">
     {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
-  </div> --}}
+  </div>
   <div class="modifier-lists flexrow">
     {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
       {{#if target.public}}

--- a/templates/chat/chat-flavor/attack-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/attack-roll-flavor.hbs
@@ -73,22 +73,6 @@
   <!-- Conditional Section: Success-based Options -->
   {{#if (ne numSuccesses 0)}}
 
-    <!-- Active Effects Section -->
-    {{#if activeEffects}}
-      <details class="effects-section">
-        <summary>{{localize "ED.Chat.Button.applyEffectTitle"}}</summary>
-        <span>
-          <ul>
-            {{#each activeEffects}}
-              <li>
-                {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
-              </li>
-            {{/each}}
-          </ul>
-        </span>
-      </details>
-    {{/if}}
-
     <!-- Roll Damage Button -->
     <div class="damage-section">
       {{> "systems/ed4e/templates/chat/chat-buttons/roll-damage.hbs"}}

--- a/templates/chat/chat-flavor/effect-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/effect-roll-flavor.hbs
@@ -5,17 +5,10 @@
 <div class="flexrow message-buttons effect-roll-buttons" data-roll-total={{ result }}>
   {{> "systems/ed4e/templates/chat/chat-buttons/roll-effect.hbs"}}
 </div>
-{{!-- <div>
-  <p class="undefined">to be reworked with #284</p>
-  {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
-</div> --}}
 <div class="modifier-lists flexrow">
   {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
 </div>
+<div class="message-buttons flexrow">
+  {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
+</div>
 {{/if}}
-
-{{!-- 
-todo:
-#284 assign effect button if rolled item contains an effect with the flag "transfer to actor" set to false.
-#711 show target actor name if a target is chosen 
---}}

--- a/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
@@ -42,7 +42,3 @@
   </div>
 
 {{/if}}
-
-<div class="message-buttons flexrow">
-  {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
-</div>

--- a/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
@@ -46,10 +46,3 @@
 <div class="message-buttons flexrow">
   {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
 </div>
-
-{{!-- 
-todo:
-
-#284 assign effect button if rolled item contains an effect with the flag "transfer to actor" set to false.
-#711 show target actor name if a target is chosen 
---}}

--- a/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
@@ -43,10 +43,9 @@
 
 {{/if}}
 
-{{!-- <div>
-  <p class="undefined">to be reworked with #284</p>
+<div class="message-buttons flexrow">
   {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
-</div> --}}
+</div>
 
 {{!-- 
 todo:


### PR DESCRIPTION
Resolves #284

Currently implemented for Ability and Spell rolls.
Additional rolls can easily be added by passing an `itemForEffects` to the rendering context and add the button partial to the chat message template.