### PR TITLE
header-repair

### DIFF
--- a/earthdawn4e.css
+++ b/earthdawn4e.css
@@ -273,14 +273,23 @@ slide-toggle[checked] .slide-toggle-thumb {
   font-size: 1rem;
   margin: 0;
 }
-.application h4 {
+.application .editor p {
+  font-family: 'ArnoPro-Regular', serif;
+}
+.sheet .h1,
+.sheet h2 {
+  font-family: 'Warhorse-DecoBB', serif;
+}
+.sheet h2 {
+  font-family: 'Warhorse-DecoBB', serif;
+  font-size: 1rem;
+  margin: 0;
+}
+.sheet h3 {
   padding: 10px 0 0 0;
   font-family: revert;
   font-size: 0.9rem;
   margin: 0;
-}
-.application .editor p {
-  font-family: 'ArnoPro-Regular', serif;
 }
 .text--center {
   text-align: center;
@@ -377,10 +386,10 @@ slide-toggle[checked] .slide-toggle-thumb {
   visibility: visible;
   pointer-events: auto;
 }
-h4.label--rail {
+h3.label--rail {
   position: relative;
 }
-h4.label--rail::before {
+h3.label--rail::before {
   content: "";
   position: absolute;
   left: 0;
@@ -390,7 +399,7 @@ h4.label--rail::before {
   background: var(--color-gold-3);
   transform: translateY(-80%);
 }
-h4.label--rail .label__text {
+h3.label--rail .label__text {
   position: relative;
   background: transparent;
 }
@@ -966,7 +975,7 @@ h4.label--rail .label__text {
   position: relative;
   z-index: 4;
 }
-.application.sheet.earthdawn4e.actor .window-content .tab h3 {
+.application.sheet.earthdawn4e.actor .window-content .tab h2 {
   background: var(--background-banner-actor);
   color: var(--color-text-banner);
   width: 100%;
@@ -1306,20 +1315,20 @@ h4.label--rail .label__text {
 .application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .health__block {
   grid-template-columns: repeat(5, minmax(30px, 1fr));
 }
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .defenses__block > h4,
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .defenses__block > h4,
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .armor__block > h4,
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .armor__block > h4,
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .health__block > h4,
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .health__block > h4 {
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .defenses__block > h3,
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .defenses__block > h3,
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .armor__block > h3,
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .armor__block > h3,
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .health__block > h3,
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .health__block > h3 {
   margin: 0;
   padding: 0;
   line-height: 1.1;
   text-transform: uppercase;
   text-align: center;
 }
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .health__block > h4,
-.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .health__block > h4 {
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics__grid-container .health__block > h3,
+.application.sheet.earthdawn4e.actor .window-content .top .image-characteristics-mob__grid-container .health__block > h3 {
   grid-column: 1 / -1;
   grid-row: 1;
 }

--- a/earthdawn4e.css
+++ b/earthdawn4e.css
@@ -276,20 +276,19 @@ slide-toggle[checked] .slide-toggle-thumb {
 .application .editor p {
   font-family: 'ArnoPro-Regular', serif;
 }
-.sheet .h1,
+.sheet h1,
 .sheet h2 {
   font-family: 'Warhorse-DecoBB', serif;
+  margin: 0;
 }
 .sheet h2 {
-  font-family: 'Warhorse-DecoBB', serif;
   font-size: 1rem;
-  margin: 0;
 }
 .sheet h3 {
-  padding: 10px 0 0 0;
-  font-family: revert;
   font-size: 0.9rem;
   margin: 0;
+  padding-top: 10px;
+  font-family: inherit;
 }
 .text--center {
   text-align: center;

--- a/less/global/global.less
+++ b/less/global/global.less
@@ -109,22 +109,21 @@
 // End legancy
 
 .sheet {
-  .h1, h2 {
+  h1, h2 {
     .WarhorseDeco();
+    margin: 0;
   }
   h2 {
-    .WarhorseDeco();
     font-size: 1rem;
-    margin: 0;
   }
   h3 {
-    padding: 10px 0 0 0;
-    font-family: revert;
     font-size: 0.9rem;
     margin: 0;
+    padding-top: 10px;
+    font-family: inherit;
   }
-  
 }
+
 
 //###########################################################
 //                       Text

--- a/less/global/global.less
+++ b/less/global/global.less
@@ -80,6 +80,7 @@
 //###########################################################
 //                       Fonts
 //###########################################################
+// Legacy
 .application {
   .font__bold {
     font-weight: bold;
@@ -101,15 +102,28 @@
     font-size: 1rem;
     margin: 0;
   }
-  h4 {
+  .editor p {
+    .ArnoProRegular()
+  }
+}
+// End legancy
+
+.sheet {
+  .h1, h2 {
+    .WarhorseDeco();
+  }
+  h2 {
+    .WarhorseDeco();
+    font-size: 1rem;
+    margin: 0;
+  }
+  h3 {
     padding: 10px 0 0 0;
     font-family: revert;
     font-size: 0.9rem;
     margin: 0;
   }
-  .editor p {
-    .ArnoProRegular()
-  }
+  
 }
 
 //###########################################################
@@ -238,10 +252,10 @@
 //                       Container Formatting
 //###########################################################
 
-h4.label--rail {
+h3.label--rail {
   position: relative;
 }
-h4.label--rail::before {
+h3.label--rail::before {
   content: "";
   position: absolute;
   left: 0; right: 0; top: 50%;
@@ -249,7 +263,7 @@ h4.label--rail::before {
   background: var(--color-gold-3);
   transform: translateY(-80%);
 }
-h4.label--rail .label__text {
+h3.label--rail .label__text {
   position: relative;
   background: transparent;
 }

--- a/less/sheets/actor-sheet-layout.less
+++ b/less/sheets/actor-sheet-layout.less
@@ -15,7 +15,7 @@
       z-index: 4;
     }
 
-    .tab h3 {
+    .tab h2 {
       .header-bar();
     }
 
@@ -442,9 +442,9 @@
         }
 
         /* headings */
-        .defenses__block > h4,
-        .armor__block > h4,
-        .health__block > h4 {
+        .defenses__block > h3,
+        .armor__block > h3,
+        .health__block > h3 {
           margin: 0;
           padding: 0;
           line-height: 1.1;
@@ -452,7 +452,7 @@
           text-align: center;
         }
 
-        .health__block > h4 {
+        .health__block > h3 {
           grid-column: 1 / -1;
           grid-row: 1;
         }

--- a/templates/actor/actor-partials/actor-section-name.hbs
+++ b/templates/actor/actor-partials/actor-section-name.hbs
@@ -1,9 +1,9 @@
 <section class="section__name">
     <div class="header-section__name">
         <div class="sheet-header__indent--left">
-            <h3 class="header__no-border header-name__no-border">
+            <h2 class="header__no-border header-name__no-border">
                 <input type="text" name="name" value="{{actor.name}}" placeholder="Name / Race">
-            </h3>
+            </h2>
         </div>
     </div>
 </section>

--- a/templates/actor/actor-partials/actor-section-navigator.hbs
+++ b/templates/actor/actor-partials/actor-section-navigator.hbs
@@ -1,9 +1,9 @@
 <div class="input--centered">
     <div id="actor-navigation" class="navigator">
         <hr>
-        <h4>
+        <h3>
             {{localize "ED.Actor.Header.navigator"}}
-        </h4>
+        </h3>
         {{#if (eq this.data.type "character")}}
         <nav class="actor-sheet-tabs navigator__flex">
             <a class="navigator__tab" data-tab="actor-general-tab">{{localize "ED.Actor.Navigator.general"}}</a>

--- a/templates/actor/actor-partials/actor-section-top-pc.hbs
+++ b/templates/actor/actor-partials/actor-section-top-pc.hbs
@@ -12,9 +12,9 @@
           <div class="top-columns__grid--item top-col--left">
 
             <div class="defenses__block">
-              <h4 class="header--centered label--rail">
+              <h3 class="header--centered label--rail">
                 <span class="label__text">{{localize "ED.Actor.Header.defenses"}}</span>
-              </h4>
+              </h3>
 
               <div class="defenses__grid--container">
                 <div class="defenses__grid--item">
@@ -63,9 +63,9 @@
 
             <!-- ARMOR -->
             <div class="armor__block">
-              <h4 class="header--centered label--rail">
+              <h3 class="header--centered label--rail">
                 <span class="label__text">{{localize "ED.Actor.Header.armor"}}</span>
-              </h4>
+              </h3>
 
               <div class="armor__grid--container">
                 <div class="armor__grid--item">

--- a/templates/actor/actor-partials/actor-section-top-sentient.hbs
+++ b/templates/actor/actor-partials/actor-section-top-sentient.hbs
@@ -16,9 +16,9 @@
           <div class="top-columns__grid--item top-col--left">
 
             <div class="defenses__block">
-              <h4 class="header--centered label--rail">
+              <h3 class="header--centered label--rail">
                 <span class="label__text">{{localize "ED.Actor.Header.defenses"}}</span>
-              </h4>
+              </h3>
 
               <div class="defenses__grid--container">
                 <div class="defenses__grid--item">
@@ -66,9 +66,9 @@
             </div>
 
             <div class="armor__block">
-              <h4 class="header--centered label--rail">
+              <h3 class="header--centered label--rail">
                 <span class="label__text">{{localize "ED.Actor.Header.armor"}}</span>
-              </h4>
+              </h3>
 
               <div class="armor__grid--container">
                 <div class="armor__grid--item">

--- a/templates/actor/actor-tabs/description.hbs
+++ b/templates/actor/actor-tabs/description.hbs
@@ -1,6 +1,6 @@
 <section class="tab {{tabs.description.cssClass}}" data-group="sheet" data-tab="description">
   <div class="sheet__editor">
-    <h3>{{localize "ED.Actor.Header.information"}}</h3>
+    <h2>{{localize "ED.Actor.Header.information"}}</h2>
     {{> "systems/ed4e/templates/global/editor.hbs"}}
   </div>
 </section>

--- a/templates/actor/actor-tabs/devotions.hbs
+++ b/templates/actor/actor-tabs/devotions.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.devotions.cssClass}}" data-group="sheet" data-tab="devotions">
-<h3>{{localize "ED.Actor.Header.devotions"}}</h3>
+<h2>{{localize "ED.Actor.Header.devotions"}}</h2>
     <div class="container__block">
         <div class="ability-card__grid--container container__header text-break__auto">
             <div class="ability-card__grid--item"></div>

--- a/templates/actor/actor-tabs/equipment.hbs
+++ b/templates/actor/actor-tabs/equipment.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.equipment.cssClass}}" data-group="sheet" data-tab="equipment">
-<h3>{{localize "ED.Actor.Header.equipment"}}</h3>
+<h2>{{localize "ED.Actor.Header.equipment"}}</h2>
 <div class="container__block">
     {{#if (eq this.actor.type "character")}}
         <div class="encumbrance__container">

--- a/templates/actor/actor-tabs/general.hbs
+++ b/templates/actor/actor-tabs/general.hbs
@@ -6,9 +6,9 @@
 
       <!-- Attributes -->
       
-      <h3>
+      <h2>
         <label>{{localize "ED.Actor.Header.attributes"}}</label>
-      </h3>
+      </h2>
         <div class="container__block container__custom">
           <div class="attribute-card__grid--container container__header">
             <div class="attribute-card__grid--item"></div>
@@ -31,7 +31,7 @@
 
 
       <!-- Karma -->
-      <h3 class="karma-devotion__header margin__none one-line__vertical-align">
+      <h2 class="karma-devotion__header margin__none one-line__vertical-align">
         <span class="karma-devotion__header-label">
           {{localize "ED.Actor.Header.karma"}}
         </span>
@@ -51,7 +51,7 @@
             </a>
           {{/if}}
         </span>
-      </h3>
+      </h2>
     <div class="container__block container__custom">
       <div class="karma-devotion__grid--container container__header">
         <div class="karma-devotion__grid--item">{{localize "ED.Data.Actor.Sentient.FIELDS.karma.value.label"}}</div>
@@ -72,9 +72,9 @@
     </div>
 
     <!-- Devotion -->
-    <h3 class="karma-devotion__header one-line__vertical-align margin__none">
+    <h2 class="karma-devotion__header one-line__vertical-align margin__none">
       <span class="karma-devotion__header-label">{{localize "ED.Actor.Header.devotion"}}</span>
-    </h3>
+    </h2>
     <div class="container__block container__custom">
       <div class="karma-devotion__grid--container container__header">
         <div class="karma-devotion__grid--item">{{localize "ED.Data.Actor.Sentient.FIELDS.devotion.value.label"}}</div>
@@ -101,7 +101,7 @@
     </div>
     </div>
   
-    <h3 class="recovery__header margin__none one-line__vertical-align">
+    <h2 class="recovery__header margin__none one-line__vertical-align">
       <span class="recovery__header-label">
         {{localize "ED.Actor.Header.recovery"}}
       </span>
@@ -115,7 +115,7 @@
             </button>
           </a>
       </span>
-    </h3>
+    </h2>
     <div class="container__block container__custom">
       <div class="recovery__grid--container container__header">
         <div class="recovery__grid--item">{{localize "ED.Data.Actor.Sentient.FIELDS.characteristics.recoveryTestsResource.value.label"}}</div>

--- a/templates/actor/actor-tabs/legend.hbs
+++ b/templates/actor/actor-tabs/legend.hbs
@@ -31,9 +31,9 @@
 </div>
 
 <div class="undefined">
-    <h4>
+    <h3>
         Attributes
-    </h4>
+    </h3>
     <div>
         <table>
             <tr>

--- a/templates/actor/actor-tabs/notes.hbs
+++ b/templates/actor/actor-tabs/notes.hbs
@@ -7,7 +7,7 @@
 
         <!-- Namegiver -->
         {{#unless (or (eq actor.type "dragon") (eq actor.type "horror") (eq actor.type "spirit") (eq actor.type "creature"))}}
-          <h3>{{localize "ED.Actor.Header.namegiver"}}</h3>
+          <h2>{{localize "ED.Actor.Header.namegiver"}}</h2>
 
           <div class="container__block">
             {{#each actor.itemTypes.namegiver}}
@@ -24,7 +24,7 @@
         {{/unless}}
 
         <!-- Circles -->
-        <h3>{{localize "ED.Actor.Header.vocations"}}</h3>
+        <h2>{{localize "ED.Actor.Header.vocations"}}</h2>
         <div class="class-card__grid--body"></div>
 
         <!-- Disciplines Header -->
@@ -78,7 +78,7 @@
 
         <!-- Languages -->
         {{#if systemFields.languages}}
-          <h3>{{localize "ED.Actor.Header.languages"}}</h3>
+          <h2>{{localize "ED.Actor.Header.languages"}}</h2>
           <div class="flexrow">
           <span>
             <div class="container__header">{{localize "ED.Actor.Header.languagesSpoken"}}</div>
@@ -96,7 +96,7 @@
       <!-- Right Column: Biography -->
       <div class="layout__col--2">
 
-        <h3>{{localize "ED.Actor.Header.biography"}}</h3>
+        <h2>{{localize "ED.Actor.Header.biography"}}</h2>
         {{> "systems/ed4e/templates/global/editor.hbs"}}
 
         {{#if (ne actor.type "character")}}

--- a/templates/actor/actor-tabs/powers.hbs
+++ b/templates/actor/actor-tabs/powers.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.powers.cssClass}}" data-group="sheet" data-tab="powers">
-<h3>{{localize "ED.Actor.Header.abilities"}}</h3>
+<h2>{{localize "ED.Actor.Header.abilities"}}</h2>
   <div class="container__block">
 
 {{!-- Attacks --}}

--- a/templates/actor/actor-tabs/skills.hbs
+++ b/templates/actor/actor-tabs/skills.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.skills.cssClass}}" data-group="sheet" data-tab="skills">
-<h3>{{localize "ED.Actor.Header.skills"}}</h3>
+<h2>{{localize "ED.Actor.Header.skills"}}</h2>
     <div class="container__block">
         <div class="ability-card__grid--container container__header text-break__auto">
             <div class="ability-card__grid--item"></div>

--- a/templates/actor/actor-tabs/specials.hbs
+++ b/templates/actor/actor-tabs/specials.hbs
@@ -2,7 +2,7 @@
   
 {{!-- Conditions --}}
 
-<h3 class="margin__right">{{localize "ED.Actor.Header.conditions"}}</h3>
+<h2 class="margin__right">{{localize "ED.Actor.Header.conditions"}}</h2>
 <div class="conditions__grid--container">
 
   <label class="conditions__grid--item">
@@ -71,11 +71,11 @@
   </label>
 </div>
   
-  <h3>{{localize "ED.Actor.Header.effectsTemporary"}}
+  <h2>{{localize "ED.Actor.Header.effectsTemporary"}}
     <a class="effect-add align-right-button" data-action="createChild" data-type="effect" data-effect-permanent="" title="{{localize " earthdawn.n.newItem" }}">
       <i class="fas fa-plus"></i>
     </a>
-  </h3>
+  </h2>
     <div class="container__block">
       <div class="effect-card__grid--container container__header text-break__auto">
         <div class="effect-card__grid--item"></div>
@@ -94,11 +94,11 @@
       </div>
     </div>
 
-  <h3>{{localize "ED.Actor.Header.effectsPermanent"}}
+  <h2>{{localize "ED.Actor.Header.effectsPermanent"}}
     <a class="effect-add align-right-button" data-action="createChild" data-type="effect" data-effect-permanent="true" title="{{localize " earthdawn.n.newItem" }}">
       <i class="fas fa-plus"></i>
     </a>
-  </h3>
+  </h2>
     <div class="container__block">
       <div class="effect-card__grid--container container__header text-break__auto">
         <div class="effect-card__grid--item"></div>

--- a/templates/actor/actor-tabs/spells.hbs
+++ b/templates/actor/actor-tabs/spells.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.spells.cssClass}}" data-group="sheet" data-tab="spells">
-  <h3>{{localize "ED.Actor.Header.spells"}}</h3>
+  <h2>{{localize "ED.Actor.Header.spells"}}</h2>
   <div class="container__block">
     <nav class="tabs navigator__flex" data-group="spellsContent">
       {{#each tabsSpells as |tab|}}

--- a/templates/actor/actor-tabs/talents.hbs
+++ b/templates/actor/actor-tabs/talents.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.talents.cssClass}}" data-group="sheet" data-tab="talents">
-<h3>{{localize "ED.Actor.Header.talents"}}</h3>
+<h2>{{localize "ED.Actor.Header.talents"}}</h2>
   <div class="container__block">
     {{#if (eq this.actor.type "character")}}
       {{#if splitTalents}}

--- a/templates/actor/cards/health-character-card.hbs
+++ b/templates/actor/cards/health-character-card.hbs
@@ -1,7 +1,7 @@
 <section class="health__block">
-  <h4 class="header--centered label--rail">
+  <h3 class="header--centered label--rail">
     <span class="label__text">{{localize "ED.Actor.Header.healthRating"}}</span>
-  </h4>
+  </h3>
 
   <div class="damage__grid--container">
 

--- a/templates/actor/cards/health-none-character-card.hbs
+++ b/templates/actor/cards/health-none-character-card.hbs
@@ -1,7 +1,7 @@
 <section class="health__block">
-  <h4 class="header--centered label--rail">
+  <h3 class="header--centered label--rail">
     <span class="label__text">{{localize "ED.Actor.Header.healthRating"}}</span>
-  </h4>
+  </h3>
 
   {{#if (eq actor.system.isMob false)}}
   <div class="damage__grid--container">

--- a/templates/actor/cards/special-abilities-characters.hbs
+++ b/templates/actor/cards/special-abilities-characters.hbs
@@ -1,5 +1,5 @@
 <div>
-      <h3>{{localize "ED.Actor.Header.defaultAttacks"}}</h3>
+      <h2>{{localize "ED.Actor.Header.defaultAttacks"}}</h2>
       <div>
 
 
@@ -27,7 +27,7 @@
     <br>
     <br>
     <div>
-      <h3 class="undefined">{{localize "ED.Actor.Header.specialAbility"}}</h3>
+      <h2 class="undefined">{{localize "ED.Actor.Header.specialAbility"}}</h2>
       <div class="undefined">
         how shall this look like? Similar to rollable items?	
         {{#each actor.itemTypes.specialAbility}}

--- a/templates/actor/cards/special-abilities-npc.hbs
+++ b/templates/actor/cards/special-abilities-npc.hbs
@@ -1,5 +1,5 @@
 <div>
-      <h3>{{localize "ED.Actor.Header.favorites"}}</h3>
+      <h2>{{localize "ED.Actor.Header.favorites"}}</h2>
       <div>
         {{formField systemFields.actions name="system.actions" type="number" value=actor.system.actions localize=true}}
       </div>
@@ -7,7 +7,7 @@
     <br>
     <br>
     <div>
-      <h3 class="undefined">{{localize "ED.Actor.Header.favorites"}}</h3>
+      <h2 class="undefined">{{localize "ED.Actor.Header.favorites"}}</h2>
       <div class="undefined">
         there shall be favorites
       </div>

--- a/templates/actor/cards/spell-card.hbs
+++ b/templates/actor/cards/spell-card.hbs
@@ -11,7 +11,7 @@
   {{!-- Header Section --}}
   <div class="spell-card__header" data-action="editChild" data-uuid="{{this.uuid}}" data-tooltip="{{localize 'ED.Controls.edit'}}">
     <div class="spell-card__name-section">
-      <h4 class="spell-card__name">{{name}}</h4>
+      <h3 class="spell-card__name">{{name}}</h3>
       <div class="spell-card__type">
         {{localize (lookup @root.config.spellcastingTypes system.spellcastingType)}}
       </div>

--- a/templates/actor/creature-sheet.hbs
+++ b/templates/actor/creature-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         {{!-- CREATE A SYSTEM SETTING TO DIVIDE POWERS; MANEUVER AND ATTACKS INTO DIFFERENT TABS --}}
          <div>

--- a/templates/actor/dragon-sheet.hbs
+++ b/templates/actor/dragon-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         {{!-- CREATE A SYSTEM SETTING TO DIVIDE POWERS; MANEUVER AND ATTACKS INTO DIFFERENT TABS --}}
          <div>

--- a/templates/actor/generation/attribute-assignment.hbs
+++ b/templates/actor/generation/attribute-assignment.hbs
@@ -1,7 +1,7 @@
 <section class="tab {{tabs.attributes.cssClass}} scrollable" data-group="primary" data-tab="attributes">
 
  <!-- Class explainer -->
-  <h4>{{localize "ED.Dialogs.CharGen.chooseAttributes"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.chooseAttributes"}}</h3>
   <p class="explainer-text">
     {{{localize "ED.Dialogs.CharGen.chooseAttributesRules"}}}
   </p>
@@ -75,7 +75,7 @@
 
   <!-- Previews -->
   <div class="char-gen-characteristics-preview flexcol">
-    <h4>{{localize "ED.Dialogs.CharGen.Title.preview"}}</h4>
+    <h3>{{localize "ED.Dialogs.CharGen.Title.preview"}}</h3>
 
     <div class="health-and-characteristics flexrow">
       <!-- health preview -->

--- a/templates/actor/generation/class-selection.hbs
+++ b/templates/actor/generation/class-selection.hbs
@@ -1,7 +1,7 @@
 
 <section class="tab {{tabs.classes.cssClass}} scrollable" data-group="primary" data-tab="classes">
  <!-- Class explainer -->
-  <h4>{{localize "ED.Dialogs.CharGen.chooseClass"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.chooseClass"}}</h3>
   <p class="explainer-text">
     {{{localize "ED.Dialogs.CharGen.chooseClassRules"}}}
   </p>
@@ -34,7 +34,7 @@
   </section>
 
   <!-- Abilities explainer -->
-  <h4>{{localize "ED.Dialogs.CharGen.abilities"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.abilities"}}</h3>
   <p class="explainer-text">
     {{#if isAdept}}
       {{{localize "ED.Dialogs.CharGen.chooseTalentsRules"}}}
@@ -146,7 +146,7 @@
 {{#if isAdept}}
   <!-- Namegiver Abilities -->
   <div class="namegiver-abilities">
-    <h4>{{localize "ED.Dialogs.CharGen.Title.namegiverAbilities"}}</h4>
+    <h3>{{localize "ED.Dialogs.CharGen.Title.namegiverAbilities"}}</h3>
     <table>
       {{#each namegiverAbilities}}
         <tr class="flexrow" data-ability-uuid="{{this}}">

--- a/templates/actor/generation/equipment-selection.hbs
+++ b/templates/actor/generation/equipment-selection.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.equipment.cssClass}} scrollable" data-group="primary" data-tab="equipment">
-  <h4>{{localize "ED.Dialogs.CharGen.Title.equipment"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.Title.equipment"}}</h3>
   <div>
     <p>{{{chooseEquipmentRules}}}</p>
   </div>

--- a/templates/actor/generation/language-selection.hbs
+++ b/templates/actor/generation/language-selection.hbs
@@ -1,5 +1,5 @@
 <section class="tab {{tabs.languages.cssClass}} scrollable" data-group="primary" data-tab="languages">
-  <h4>{{localize "ED.Dialogs.CharGen.Title.languages"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.Title.languages"}}</h3>
 
   <!-- Skills explainer -->
   <p class="explainer-text">

--- a/templates/actor/generation/namegiver-selection.hbs
+++ b/templates/actor/generation/namegiver-selection.hbs
@@ -1,10 +1,10 @@
 <section class="tab {{tabs.namegiver.cssClass}} scrollable" data-group="primary" data-tab="namegiver">
-  <h4>{{localize "ED.Dialogs.CharGen.Title.overview"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.Title.overview"}}</h3>
   <div>
     <p>{{{charGenRules}}}</p>
   </div>
   <label for="char-gen-namegiver-select">
-    <h4>{{localize "ED.Dialogs.CharGen.chooseNamegiver"}}</h4>
+    <h3>{{localize "ED.Dialogs.CharGen.chooseNamegiver"}}</h3>
     <select id="char-gen-namegiver-select" name="namegiver">
       <option value="">&ndash;&ndash;&ndash;</option>
       {{selectOptions namegivers selected=namegiver valueAttr="uuid" labelAttr="name"}}

--- a/templates/actor/generation/skill-selection.hbs
+++ b/templates/actor/generation/skill-selection.hbs
@@ -1,6 +1,6 @@
 <section class="tab {{tabs.skills.cssClass}} scrollable" data-group="primary" data-tab="skills">
 
-  <h4>{{localize "ED.Dialogs.CharGen.chooseSkills"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.chooseSkills"}}</h3>
 
   <!-- Skills explainer -->
   <p class="explainer-text">

--- a/templates/actor/generation/spell-selection.hbs
+++ b/templates/actor/generation/spell-selection.hbs
@@ -1,6 +1,6 @@
 <section class="tab {{tabs.spells.cssClass}} scrollable" data-group="primary" data-tab="spells">
 
-  <h4>{{localize "ED.Dialogs.CharGen.chooseSpells"}}</h4>
+  <h3>{{localize "ED.Dialogs.CharGen.chooseSpells"}}</h3>
 
   <!-- Skills explainer -->
   <p class="explainer-text">

--- a/templates/actor/group-sheet.hbs
+++ b/templates/actor/group-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         
          <div>

--- a/templates/actor/horror-sheet.hbs
+++ b/templates/actor/horror-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         {{!-- CREATE A SYSTEM SETTING TO DIVIDE POWERS; MANEUVER AND ATTACKS INTO DIFFERENT TABS --}}
          <div>

--- a/templates/actor/loot-sheet.hbs
+++ b/templates/actor/loot-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         
          <div>

--- a/templates/actor/spirit-sheet.hbs
+++ b/templates/actor/spirit-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         {{!-- CREATE A SYSTEM SETTING TO DIVIDE POWERS; MANEUVER AND ATTACKS INTO DIFFERENT TABS --}}
          <div>

--- a/templates/actor/trap-sheet.hbs
+++ b/templates/actor/trap-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         
          <div>

--- a/templates/actor/vehicle-sheet.hbs
+++ b/templates/actor/vehicle-sheet.hbs
@@ -3,8 +3,8 @@
         <title>{{actor.name}}</title>
     </header>
     <div  class="body border">
-        <h3 id="Name" class="char-name"><input name="name" type="text"
-                value="{{actor.name}}" placeholder="Name" /></h3>
+        <h2 id="Name" class="char-name"><input name="name" type="text"
+                value="{{actor.name}}" placeholder="Name" /></h2>
         <img src="{{actor.img}}" data-edit="img" title="{{actor.name}}" height="128" width="128" />
         
          <div>


### PR DESCRIPTION
altered the h1,2,3,4 removing 4 from sheet use and moving everything up one category. This will only apply to sheets, allowing us to alter it for journals.

h1 to be a large warhorse (for item headers)
h2 smaller warhorse for all headers on actor sheets
h3 larger uppercase standard font (see defenses, armor and health), these will see more use in items, while at the moment are only just on the top.
