### PR TITLE
Roll spell effects

### DIFF
--- a/dictionaries/ed4e-words.txt
+++ b/dictionaries/ed4e-words.txt
@@ -47,3 +47,4 @@ uncon
 physical
 mystical
 Social
+spelleffect

--- a/lang/de.json
+++ b/lang/de.json
@@ -376,6 +376,7 @@
         "rollRecovery":                            "{sourceActor} nutzt Erholungsproben für {recoveryMode}",
         "rollSubstitute":                          "{actor} würfelt {attribute} ({step}) um {substitute} zu ersetzen",
         "rollUnarmedDamage":                       "{sourceActor} würfelt waffenlosen Schaden",
+        "spellEffectRollOptions":                  "{sourceActor} wirkt {spell}",
         "spellNoSpecialDescription":               "Zauber hat keine Spezialeffekte",
         "spellcastingRollOptions":                 "{sourceActor} wirkt<br>{spell} mit<br>{spellcastingAbility}",
         "standardDiceRoll":                        "Standard Würfelwurf",
@@ -618,7 +619,6 @@
         "attribute":                               "Attribute",
         "attuning":                                "Abstimmung",
         "damage":                                  "Schaden",
-        "effect":                                  "Effekt",
         "halfmagic":                               "Halbmagie",
         "horrorMark":                              "Dämonenmal",
         "initiative":                              "Initiative",
@@ -626,6 +626,7 @@
         "knockDown":                               "Niederschlag",
         "reaction":                                "Reaktion",
         "recovery":                                "Erholung",
+        "spellEffect":                             "Zauber-Effekt",
         "spellcasting":                            "Spruchzauberei",
         "threadWeaving":                           "Fadenweben",
         "warping":                                 "Verzerrung"
@@ -651,7 +652,7 @@
       },
       "SpellEffectTypes": {
         "damage":                                  "Schaden",
-        "effect":                                  "Effekt",
+        "effect":                                  "Effektwurf",
         "macro":                                   "Makro",
         "special":                                 "Spezial"
       },
@@ -2110,9 +2111,17 @@
             "effect": {
               "details": {
                 "damage": {
+                  "addCircle": {
+                    "hint":                        "Fügt den Kreis der Disziplin des Actors zur Schadensstufe hinzu",
+                    "label":                       "Kreis hinzufügen"
+                  },
                   "armorType": {
                     "hint":                        "Rüstungstyp der gegen den Schaden des Spruches schützt",
                     "label":                       "Rüstungstyp"
+                  },
+                  "attribute": {
+                    "hint":                        "Attribut auf dem die Schadensstufe basiert",
+                    "label":                       "Attribut"
                   },
                   "damageType": {
                     "hint":                        "Art des Schadens der durch den Spruch verursacht wird",
@@ -2126,8 +2135,20 @@
                   }
                 },
                 "effect": {
-                  "hint":                          "Der Spruch verursacht einen ActiveEffect",
-                  "label":                         "ActiveEffect"
+                  "addCircle": {
+                    "hint":                        "Fügt den Kreis der Disziplin des Actors zum Effektwurf hinzu",
+                    "label":                       "Kreis hinzufügen"
+                  },
+                  "attribute": {
+                    "hint":                        "Attribut auf dem die Stufe des Effektwurf basiert",
+                    "label":                       "Attribut"
+                  },
+                  "hint":                          "Details zur Stufe des Effektwurf",
+                  "label":                         "Effektstufe",
+                  "stepModifier": {
+                    "hint":                        "Modifikator der auf Willenskraft-Stufe addiert wird",
+                    "label":                       "Effektstufen Modifikator (WIL)"
+                  }
                 },
                 "hint":                            "Details zum Effekt des Spruches",
                 "label":                           "Effektdetails",
@@ -3151,7 +3172,8 @@
         "substitute":                              "Fähigkeit ersetzen",
         "takeDamage":                              "Schaden nehmen",
         "talentCategory":                          "Talent Kategorie",
-        "versatilityLimit":                        "Vielseitigkeitslimit erricht"
+        "useWillpower":                            "Willenskraft einsetzen",
+        "versatilityLimit":                        "Vielseitigkeitslimit erreicht"
       },
       "ToolTips": {
         "resetAbilityRanks":                       "Setzt alle Ränge auf 0 zurück"
@@ -3163,6 +3185,7 @@
       "damageStun":                                "Betäubungsschaden",
       "damageType":                                "Schadensart",
       "doYouWantToAttuneGrimoireBeforeCasting":    "Möchtest du das Grimoire vor dem Wirken des Zaubers abstimmen?",
+      "doYouWantToUseWillpower":                   "Möchtest du {contentLinkWillpower} einsetzen?",
       "ignoreArmor":                               "Ignoriere Rüstung",
       "knockDownChoice":                           "Wähle die Fähigkeit um dem Niederschlag zu widerstehen",
       "mystical":                                  "Mystischer Schaden",
@@ -3219,7 +3242,9 @@
         "grimoireConfiguration":                   "Grimoire Konfiguration",
         "matrixConfiguration":                     "Matrix Konfiguration",
         "navigator":                               "Navigator",
+        "spellDamageStep":                         "Schadenstufe",
         "spellEffect":                             "Effekt",
+        "spellEffectStep":                         "Effektstufe",
         "spellEnhancement":                        "Zauber Verstärkung",
         "summary":                                 "Zusammenfassung",
         "talentKnacks":                            "Kniffe",
@@ -3356,6 +3381,7 @@
         "bonusDamageFromExtraSuccesses":           "+2 pro extra Erfolg von Angriff",
         "grimoirePenalty":                         "Fremdes Grimoire",
         "manual":                                  "Manuelle Anpassung",
+        "spellEffectOrDamageStepCircle":           "Kreis ({discipline})",
         "stunRecoveryWillpower":                   "Willenskraft"
       },
       "baseValue":                                 "Basis Stufe",

--- a/lang/en.json
+++ b/lang/en.json
@@ -377,6 +377,7 @@
         "rollRecovery":                            "{sourceActor} uses a recovery test for {recoveryMode}",
         "rollSubstitute":                          "{actor} rolls {attribute} ({step}) to replace {substitute}",
         "rollUnarmedDamage":                       "{sourceActor} rolls unarmed damage",
+        "spellEffectRollOptions":                  "TODO: Add translation",
         "spellNoSpecialDescription":               "Spell has no special effects",
         "spellcastingRollOptions":                 "{sourceActor} casts<br>{spell} with<br>{spellcastingAbility}",
         "standardDiceRoll":                        "Standard roll",
@@ -532,7 +533,7 @@
         "forestFire":                              "Forest Fire",
         "houseFire":                               "House Fire",
         "torch":                                   "Torch"
-      },      
+      },
       "Health": {
         "damageStandard":                          "Deadly Damage",
         "damageStun":                              "Stun Damage"
@@ -619,7 +620,6 @@
         "attribute":                               "Attribute",
         "attuning":                                "Attuning",
         "damage":                                  "Damage",
-        "effect":                                  "Effect",
         "halfmagic":                               "Half-Magic",
         "horrorMark":                              "Horror Mark",
         "initiative":                              "Initiative",
@@ -627,6 +627,7 @@
         "knockDown":                               "Knockdown",
         "reaction":                                "Reaction",
         "recovery":                                "Recovery",
+        "spellEffect":                             "TODO: Add translation",
         "spellcasting":                            "Spellcasting",
         "threadWeaving":                           "Thread Weaving",
         "warping":                                 "Warping"
@@ -890,18 +891,6 @@
           "description": {
             "hint":                                "Description",
             "label":                               "Description"
-          }
-        },
-        "Group": {
-          "FIELDS": {
-          }
-        },
-        "Horror": {
-          "FIELDS": {
-          }
-        },
-        "Loot": {
-          "FIELDS": {
           }
         },
         "Namegiver": {
@@ -2006,14 +1995,10 @@
               "hint":                              "Damage step of the power",
               "label":                             "Damage Step"
             },
-            "damageType": {
-              "hint":                              "Damage type of the power",
-              "label":                             "Damage Type"
-            },            
             "element": {
-              "subType": {
-                "hint":                            "Elemental subtype of the power",
-                "label":                           "Element Subtype"
+              "subtype": {
+                "hint":                            "TODO: Add translation",
+                "label":                           "TODO: Add translation"
               },
               "type": {
                 "hint":                            "Element type of the power",
@@ -2127,9 +2112,17 @@
             "effect": {
               "details": {
                 "damage": {
+                  "addCircle": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
                   "armorType": {
                     "hint":                        "Armor type that protects against the spell's damage",
                     "label":                       "Armor Type"
+                  },
+                  "attribute": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
                   },
                   "damageType": {
                     "hint":                        "Type of damage caused by the spell",
@@ -2143,8 +2136,20 @@
                   }
                 },
                 "effect": {
+                  "addCircle": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
+                  "attribute": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
                   "hint":                          "The spell causes an Active Effect",
-                  "label":                         "Active Effect"
+                  "label":                         "Active Effect",
+                  "stepModifier": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  }
                 },
                 "hint":                            "Details of the spell effect",
                 "label":                           "Effect Details",
@@ -2485,10 +2490,6 @@
             "armorType": {
               "hint":                              "Armor type the damage is effective against",
               "label":                             "Armor Type"
-            },
-            "damageAbilities": {
-              "hint":                              "Abilities applied to the damage",
-              "label":                             "Damage Abilities"
             },
             "damageType": {
               "hint":                              "Type of damage",
@@ -3116,7 +3117,6 @@
         "questorDevotionNotFound":                 "Questor Devotion not found",
         "writtenRules":                            "Written Rules"
       },
-
       "Placeholder": {
         "lpDescription":                           "Description of Legend Award"
       },
@@ -3173,6 +3173,7 @@
         "substitute":                              "Substitute Ability",
         "takeDamage":                              "Take Damage",
         "talentCategory":                          "Talent Category",
+        "useWillpower":                            "TODO: Add translation",
         "versatilityLimit":                        "Versatility Limit Reached"
       },
       "ToolTips": {
@@ -3185,6 +3186,7 @@
       "damageStun":                                "Stun Damage",
       "damageType":                                "Damage Type",
       "doYouWantToAttuneGrimoireBeforeCasting":    "Do you want to attune the Grimoire before casting?",
+      "doYouWantToUseWillpower":                   "TODO: Add translation",
       "ignoreArmor":                               "Ignore Armor",
       "knockDownChoice":                           "Choose the Ability to resist Knock Down",
       "mystical":                                  "Mystical Damage",
@@ -3241,7 +3243,9 @@
         "grimoireConfiguration":                   "Grimoire Configuration",
         "matrixConfiguration":                     "Matrix Configuration",
         "navigator":                               "Navigator",
+        "spellDamageStep":                         "TODO: Add translation",
         "spellEffect":                             "Spell Effect",
+        "spellEffectStep":                         "TODO: Add translation",
         "spellEnhancement":                        "Spell Enhancement",
         "summary":                                 "Summary",
         "talentKnacks":                            "Knacks",
@@ -3378,6 +3382,7 @@
         "bonusDamageFromExtraSuccesses":           "Bonus Damage from Extra Successes",
         "grimoirePenalty":                         "Foreign Grimoire",
         "manual":                                  "Manual Adjustment",
+        "spellEffectOrDamageStepCircle":           "TODO: Add translation",
         "stunRecoveryWillpower":                   "Willpower"
       },
       "baseValue":                                 "Base Step",

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -376,6 +376,7 @@
         "rollRecovery":                            "TODO: Add translation",
         "rollSubstitute":                          "TODO: Add translation",
         "rollUnarmedDamage":                       "TODO: Add translation",
+        "spellEffectRollOptions":                  "TODO: Add translation",
         "spellNoSpecialDescription":               "TODO: Add translation",
         "spellcastingRollOptions":                 "TODO: Add translation",
         "standardDiceRoll":                        "TODO: Add translation",
@@ -618,7 +619,6 @@
         "attribute":                               "TODO: Add translation",
         "attuning":                                "TODO: Add translation",
         "damage":                                  "TODO: Add translation",
-        "effect":                                  "TODO: Add translation",
         "halfmagic":                               "TODO: Add translation",
         "horrorMark":                              "TODO: Add translation",
         "initiative":                              "TODO: Add translation",
@@ -626,6 +626,7 @@
         "knockDown":                               "TODO: Add translation",
         "reaction":                                "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
+        "spellEffect":                             "TODO: Add translation",
         "spellcasting":                            "TODO: Add translation",
         "threadWeaving":                           "TODO: Add translation",
         "warping":                                 "TODO: Add translation"
@@ -2110,7 +2111,15 @@
             "effect": {
               "details": {
                 "damage": {
+                  "addCircle": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
                   "armorType": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
+                  "attribute": {
                     "hint":                        "TODO: Add translation",
                     "label":                       "TODO: Add translation"
                   },
@@ -2126,8 +2135,20 @@
                   }
                 },
                 "effect": {
+                  "addCircle": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
+                  "attribute": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
                   "hint":                          "TODO: Add translation",
-                  "label":                         "TODO: Add translation"
+                  "label":                         "TODO: Add translation",
+                  "stepModifier": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  }
                 },
                 "hint":                            "TODO: Add translation",
                 "label":                           "TODO: Add translation",
@@ -3151,6 +3172,7 @@
         "substitute":                              "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation",
+        "useWillpower":                            "TODO: Add translation",
         "versatilityLimit":                        "TODO: Add translation"
       },
       "ToolTips": {
@@ -3163,6 +3185,7 @@
       "damageStun":                                "TODO: Add translation",
       "damageType":                                "TODO: Add translation",
       "doYouWantToAttuneGrimoireBeforeCasting":    "TODO: Add translation",
+      "doYouWantToUseWillpower":                   "TODO: Add translation",
       "ignoreArmor":                               "TODO: Add translation",
       "knockDownChoice":                           "TODO: Add translation",
       "mystical":                                  "TODO: Add translation",
@@ -3219,7 +3242,9 @@
         "grimoireConfiguration":                   "TODO: Add translation",
         "matrixConfiguration":                     "TODO: Add translation",
         "navigator":                               "TODO: Add translation",
+        "spellDamageStep":                         "TODO: Add translation",
         "spellEffect":                             "TODO: Add translation",
+        "spellEffectStep":                         "TODO: Add translation",
         "spellEnhancement":                        "TODO: Add translation",
         "summary":                                 "TODO: Add translation",
         "talentKnacks":                            "TODO: Add translation",
@@ -3356,6 +3381,7 @@
         "bonusDamageFromExtraSuccesses":           "TODO: Add translation",
         "grimoirePenalty":                         "TODO: Add translation",
         "manual":                                  "TODO: Add translation",
+        "spellEffectOrDamageStepCircle":           "TODO: Add translation",
         "stunRecoveryWillpower":                   "TODO: Add translation"
       },
       "baseValue":                                 "TODO: Add translation",

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -376,6 +376,7 @@
         "rollRecovery":                            "TODO: Add translation",
         "rollSubstitute":                          "TODO: Add translation",
         "rollUnarmedDamage":                       "TODO: Add translation",
+        "spellEffectRollOptions":                  "TODO: Add translation",
         "spellNoSpecialDescription":               "TODO: Add translation",
         "spellcastingRollOptions":                 "TODO: Add translation",
         "standardDiceRoll":                        "TODO: Add translation",
@@ -618,7 +619,6 @@
         "attribute":                               "TODO: Add translation",
         "attuning":                                "TODO: Add translation",
         "damage":                                  "TODO: Add translation",
-        "effect":                                  "TODO: Add translation",
         "halfmagic":                               "TODO: Add translation",
         "horrorMark":                              "TODO: Add translation",
         "initiative":                              "TODO: Add translation",
@@ -626,6 +626,7 @@
         "knockDown":                               "TODO: Add translation",
         "reaction":                                "TODO: Add translation",
         "recovery":                                "TODO: Add translation",
+        "spellEffect":                             "TODO: Add translation",
         "spellcasting":                            "TODO: Add translation",
         "threadWeaving":                           "TODO: Add translation",
         "warping":                                 "TODO: Add translation"
@@ -2110,7 +2111,15 @@
             "effect": {
               "details": {
                 "damage": {
+                  "addCircle": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
                   "armorType": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
+                  "attribute": {
                     "hint":                        "TODO: Add translation",
                     "label":                       "TODO: Add translation"
                   },
@@ -2126,8 +2135,20 @@
                   }
                 },
                 "effect": {
+                  "addCircle": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
+                  "attribute": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  },
                   "hint":                          "TODO: Add translation",
-                  "label":                         "TODO: Add translation"
+                  "label":                         "TODO: Add translation",
+                  "stepModifier": {
+                    "hint":                        "TODO: Add translation",
+                    "label":                       "TODO: Add translation"
+                  }
                 },
                 "hint":                            "TODO: Add translation",
                 "label":                           "TODO: Add translation",
@@ -3151,6 +3172,7 @@
         "substitute":                              "TODO: Add translation",
         "takeDamage":                              "TODO: Add translation",
         "talentCategory":                          "TODO: Add translation",
+        "useWillpower":                            "TODO: Add translation",
         "versatilityLimit":                        "TODO: Add translation"
       },
       "ToolTips": {
@@ -3163,6 +3185,7 @@
       "damageStun":                                "TODO: Add translation",
       "damageType":                                "TODO: Add translation",
       "doYouWantToAttuneGrimoireBeforeCasting":    "TODO: Add translation",
+      "doYouWantToUseWillpower":                   "TODO: Add translation",
       "ignoreArmor":                               "TODO: Add translation",
       "knockDownChoice":                           "TODO: Add translation",
       "mystical":                                  "TODO: Add translation",
@@ -3219,7 +3242,9 @@
         "grimoireConfiguration":                   "TODO: Add translation",
         "matrixConfiguration":                     "TODO: Add translation",
         "navigator":                               "TODO: Add translation",
+        "spellDamageStep":                         "TODO: Add translation",
         "spellEffect":                             "TODO: Add translation",
+        "spellEffectStep":                         "TODO: Add translation",
         "spellEnhancement":                        "TODO: Add translation",
         "summary":                                 "TODO: Add translation",
         "talentKnacks":                            "TODO: Add translation",
@@ -3356,6 +3381,7 @@
         "bonusDamageFromExtraSuccesses":           "TODO: Add translation",
         "grimoirePenalty":                         "TODO: Add translation",
         "manual":                                  "TODO: Add translation",
+        "spellEffectOrDamageStepCircle":           "TODO: Add translation",
         "stunRecoveryWillpower":                   "TODO: Add translation"
       },
       "baseValue":                                 "TODO: Add translation",

--- a/module/applications/global/prompt-factory.mjs
+++ b/module/applications/global/prompt-factory.mjs
@@ -4,6 +4,7 @@ import ItemEd from "../../documents/item.mjs";
 import LearnableTemplate from "../../data/item/templates/learnable.mjs";
 import ED4E from "../../config/_module.mjs";
 import DialogEd from "../api/dialog.mjs";
+import { createContentAnchor } from "../../utils.mjs";
 
 
 const DialogClass = DialogEd;
@@ -184,6 +185,7 @@ class ActorPromptFactory extends PromptFactory {
     takeDamage:            this._takeDamagePrompt.bind( this ),
     attribute:             this._attributePrompt.bind( this ),
     halfMagicDiscipline:   this._halfMagicDisciplinePrompt.bind( this ),
+    useWillpower:          this._useWillpowerPrompt.bind( this ),
   };
 
 
@@ -477,6 +479,34 @@ class ActorPromptFactory extends PromptFactory {
       modal:   false,
       buttons: buttons
     } );
+  }
+
+  /**
+   * Creates the use willpower dialog.
+   * @returns {Promise<boolean|ItemEd|null>} A promise that resolves to:
+   * <ul>
+   *   <li>the willpower item, if willpower should be used,</li>
+   *   <li>false, if willpower should not be used,</li>
+   *   <li>null, if the dialog was closed without a choice.</li>
+   *   <li>undefined, if no willpower item was found.</li>
+   * </ul>
+   */
+  async _useWillpowerPrompt() {
+    const willpower = this.document.getSingleItemByEdid(
+      game.settings.get( "ed4e", "edidWillpower" ),
+    );
+    if ( !willpower ) return;
+
+    const useWillpower = await DialogClass.confirm( {
+      rejectClose: false,
+      content:     game.i18n.format(
+        "ED.Dialogs.doYouWantToUseWillpower",
+        {
+          contentLinkWillpower: createContentAnchor( willpower ).outerHTML
+        }
+      ),
+    } );
+    return useWillpower === true ? willpower : useWillpower;
   }
 
   /**

--- a/module/config/rolls.mjs
+++ b/module/config/rolls.mjs
@@ -41,10 +41,6 @@ export const rollTypes = {
     label:            "ED.Config.RollTypes.damage",
     flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/damage-roll-flavor.hbs",
   },
-  effect: {
-    label:            "ED.Config.RollTypes.effect",
-    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/effect-roll-flavor.hbs",
-  },
   halfmagic: {
     label:            "ED.Config.RollTypes.halfmagic",
     flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/halfmagic-roll-flavor.hbs",
@@ -76,6 +72,10 @@ export const rollTypes = {
   spellcasting: {
     label:            "ED.Config.RollTypes.spellcasting",
     flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs",
+  },
+  spellEffect: {
+    label:            "ED.Config.RollTypes.spellEffect",
+    flavorTemplate:   "systems/ed4e/templates/chat/chat-flavor/effect-roll-flavor.hbs",
   },
   threadWeaving: {
     label:            "ED.Config.RollTypes.threadWeaving",

--- a/module/config/system.mjs
+++ b/module/config/system.mjs
@@ -34,6 +34,7 @@ export const defaultEdIds = {
   threadWeaving:   "thread-weaving",
   unarmedCombat:   "unarmed-combat",
   versatility:     "versatility",
+  willpower:       "willpower",
 };
 
 // endregion

--- a/module/data/chat/spellcasting.mjs
+++ b/module/data/chat/spellcasting.mjs
@@ -111,7 +111,8 @@ export default class SpellcastingMessageData extends BaseMessageData {
     const spell = await this.getSpell();
 
     const specialDescription = spell?.system.effect?.details?.special?.description
-      ?? game.i18n.localize( "ED.Chat.Flavor.spellNoSpecialDescription" );
+      || spell?.system.description?.value
+      || game.i18n.localize( "ED.Chat.Flavor.spellNoSpecialDescription" );
     const content = `<div class="flavor-text text--center">
       ${ createContentAnchor( spell ).outerHTML }
       <p>${ specialDescription }</p>

--- a/module/data/chat/spellcasting.mjs
+++ b/module/data/chat/spellcasting.mjs
@@ -1,9 +1,6 @@
 import BaseMessageData from "./base-message.mjs";
 import { CHAT } from "../../config/_module.mjs";
 import { createContentAnchor } from "../../utils.mjs";
-import DamageRollOptions from "../roll/damage.mjs";
-import RollPrompt from "../../applications/global/roll-prompt.mjs";
-import RollProcessor from "../../services/roll-processor.mjs";
 
 export default class SpellcastingMessageData extends BaseMessageData {
 
@@ -61,22 +58,8 @@ export default class SpellcastingMessageData extends BaseMessageData {
    * @this {SpellcastingMessageData}
    */
   static async _onRollDamage( event, button ) {
-    const caster = await this.getCaster();
     const spell = await this.getSpell();
-
-    const rollOptions = DamageRollOptions.fromActor(
-      {
-        damageSourceType: "spell",
-        sourceDocument:   spell,
-        caster,
-      },
-      caster,
-      {
-        rollData: caster.getRollData(),
-      }
-    );
-    const roll = await RollPrompt.waitPrompt( rollOptions );
-    await RollProcessor.process( roll, caster, { rollToMessage: true, } );
+    await spell.system.rollDamage();
   }
 
   /**

--- a/module/data/chat/spellcasting.mjs
+++ b/module/data/chat/spellcasting.mjs
@@ -58,6 +58,8 @@ export default class SpellcastingMessageData extends BaseMessageData {
    * @this {SpellcastingMessageData}
    */
   static async _onRollDamage( event, button ) {
+    event.preventDefault();
+
     const spell = await this.getSpell();
     await spell.system.rollDamage();
   }
@@ -66,7 +68,12 @@ export default class SpellcastingMessageData extends BaseMessageData {
    * @type {ApplicationClickAction}
    * @this {SpellcastingMessageData}
    */
-  static async _onRollEffect( event, button ) {}
+  static async _onRollEffect( event, button ) {
+    event.preventDefault();
+
+    const spell = await this.getSpell();
+    await spell.system.rollEffect();
+  }
 
   /**
    * @type {ApplicationClickAction}

--- a/module/data/item/spell.mjs
+++ b/module/data/item/spell.mjs
@@ -104,11 +104,23 @@ export default class SpellData extends ItemDataModel.mixin(
         } ),
         details: new fields.SchemaField( {
           damage:  new fields.SchemaField( {
+            attribute:    new fields.StringField( {
+              required: true,
+              nullable: false,
+              blank:    true,
+              choices:  ACTORS.attributes,
+              initial:  "wil",
+            } ),
             stepModifier: new fields.NumberField( {
               required: true,
               nullable: false,
               initial:  0,
               integer:  true,
+            } ),
+            addCircle: new fields.BooleanField( {
+              required: true,
+              nullable: false,
+              initial:  false,
             } ),
             damageType: new fields.StringField( {
               required: true,
@@ -358,6 +370,66 @@ export default class SpellData extends ItemDataModel.mixin(
         ? caster.getDisciplineForSpellcastingType( this.spellcastingType )?.system.level
         : 0 );
   }
+
+  /**
+   * Prepares the roll step data for this spell's effect, if it is of type "damage" or "effect".
+   * This includes the base step and any applicable modifiers.
+   * @param {object} options Options for the calculation.
+   * @param {ActorEd} [options.actor] The actor to use for the calculation. If not provided,
+   * uses the containing actor of this spell.
+   * @param {ItemEd} [options.willpower] The willpower item to consider for the roll, if any.
+   * This is only applied if the effect attribute is "wil".
+   * @returns {RollStepData} The prepared roll step data.
+   * @throws {Error} If the effect type is not "damage" or "effect", or if effect details or caster are not available.
+   */
+  getEffectDetailsRollStepData( options = {} ) {
+    if ( ![ "damage", "effect" ].includes( this.effect?.type ) ) throw new Error( "Effect roll step data can only be prepared for effects of type 'damage' or 'effect'." );
+
+    const { actor, willpower } = options;
+    const effectDetails = this.effect?.details[ this.effect.type ];
+    const caster = actor || this.containingActor;
+    if ( !effectDetails || !caster ) throw new Error( "Cannot calculate total effect step without effect details or caster." );
+
+    const attribute = effectDetails.attribute;
+    const attributeStep = caster.system.attributes[ attribute ]?.step;
+    const stepModifier = this.effect.details[ this.effect.type ].stepModifier;
+    const circle = effectDetails.addCircle
+      ? caster.getDisciplineForSpellcastingType( this.spellcastingType )?.system.level
+      : undefined;
+    
+    const modifiers = {};
+    const stepModifierLabel = game.i18n.localize(
+      `ED.Data.Item.Spell.FIELDS.effect.details.${ this.effect.type }.stepModifier.label`
+    );
+    const disciplineName = MAGIC.spellcastingTypes[ this.spellcastingType ];
+    const circleLabel = game.i18n.format(
+      "ED.Rolls.Modifiers.spellEffectOrDamageStepCircle",
+      { discipline: disciplineName }
+    );
+
+    if ( Number.isNumeric( attributeStep ) ) {
+      if ( stepModifier ) modifiers[ stepModifierLabel ] = stepModifier;
+      if ( effectDetails.addCircle ) modifiers[ circleLabel ] = circle;
+      if ( willpower && attribute === "wil" ) modifiers[ willpower.name ] = willpower.system.level;
+      return {
+        base:      attributeStep,
+        modifiers,
+      };
+    } else if ( effectDetails.addCircle ) {
+      if ( stepModifier ) modifiers[ stepModifierLabel ] = stepModifier;
+      return {
+        base:      circle,
+        modifiers,
+      };
+    } else {
+      return {
+        base:      stepModifier,
+        modifiers,
+      };
+    }
+  }
+
+
 
   /**
    * Returns all grimoires of the given actor that contain this spell.

--- a/module/data/roll/_module.mjs
+++ b/module/data/roll/_module.mjs
@@ -7,5 +7,6 @@ export {default as HorrorMarkRollData} from "./horror-mark.mjs";
 export {default as InitiativeRollData} from "./initiative.mjs";
 export {default as RecoveryRollData} from "./recovery.mjs";
 export {default as SpellcastingRollData} from "./spellcasting.mjs";
+export {default as SpellEffectRollData} from "./spelleffect.mjs";
 export {default as WarpingRollData} from "./warping.mjs";
 export {default as WeavingRollData} from "./weaving.mjs";

--- a/module/data/roll/damage.mjs
+++ b/module/data/roll/damage.mjs
@@ -403,7 +403,7 @@ export default class DamageRollOptions extends EdRollOptions {
    * modifiers are found.
    */
   static _getModifiersFromSource( sourceDocument, data ) {
-    if ( [ "arbitrary", "poison", "spell", ].includes( data.damageSourceType ) ) {
+    if ( [ "arbitrary", "poison", ].includes( data.damageSourceType ) ) {
       return undefined;
     }
 
@@ -411,6 +411,14 @@ export default class DamageRollOptions extends EdRollOptions {
       const extraSuccesses = data.attackRoll?.numExtraSuccesses || 0;
       return {
         [ game.i18n.localize( "ED.Rolls.Modifiers.bonusDamageFromExtraSuccesses" ) ]: extraSuccesses * COMBAT.bonusDamagePerExtraSuccess,
+      };
+    }
+
+    if ( data.damageSourceType === "spell" ) {
+      return {
+        [ game.i18n.localize(
+          "ED.Data.Item.Spell.FIELDS.effect.details.damage.stepModifier.label"
+        ) ]: sourceDocument.system.effect.details.damage.stepModifier || 0,
       };
     }
 

--- a/module/data/roll/damage.mjs
+++ b/module/data/roll/damage.mjs
@@ -67,7 +67,7 @@ import { createContentAnchor } from "../../utils.mjs";
  * @property {"spell"} damageSourceType Discriminator for spell damage source.
  * @property {ItemEd} sourceDocument Item of type "spell".
  * @property {ActorEd} caster The actor that cast the spell. The caster's Willpower step is used as the base
- * damage step.
+ * @property {ItemEd} [willpower] The willpower ability of the spell's caster, if used for the damage roll.
  */
 
 /**
@@ -362,27 +362,38 @@ export default class DamageRollOptions extends EdRollOptions {
     let baseStep;
 
     switch ( data.damageSourceType ) {
-      case "arbitrary":
+      case "arbitrary": {
         baseStep = sourceDocument.system.damageTotal || 1;
         break;
-      case "poison":
+      }
+      case "poison": {
         baseStep = sourceDocument.system.effect.damageStep;
         break;
-      case "power":
+      }
+      case "power": {
         baseStep = sourceDocument.system.damageStep;
         break;
-      case "spell":
-        baseStep = data.caster.system.attributes.wil.step;
+      }
+      case "spell": {
+        const caster = data.caster || fromUuidSync( data.rollingActorUuid );
+        baseStep = sourceDocument.system.getEffectDetailsRollStepData( {
+          caster,
+          willpower: data.willpower
+        } ).base;
         break;
-      case "unarmed":
+      }
+      case "unarmed": {
         baseStep = sourceDocument.system.attributes?.str.step;
         break;
-      case "warping":
+      }
+      case "warping": {
         baseStep = sourceDocument.system.level;
         break;
-      case "weapon":
+      }
+      case "weapon": {
         baseStep = sourceDocument.system.damageTotal;
         break;
+      }
       default:
         throw new Error( `Invalid damage source type: ${data.damageSourceType}` );
     }
@@ -415,11 +426,12 @@ export default class DamageRollOptions extends EdRollOptions {
     }
 
     if ( data.damageSourceType === "spell" ) {
-      return {
-        [ game.i18n.localize(
-          "ED.Data.Item.Spell.FIELDS.effect.details.damage.stepModifier.label"
-        ) ]: sourceDocument.system.effect.details.damage.stepModifier || 0,
-      };
+      const caster = data.caster || fromUuidSync( data.rollingActorUuid );
+
+      return sourceDocument.system.getEffectDetailsRollStepData( {
+        caster,
+        willpower: data.willpower
+      } ).modifiers;
     }
 
     if ( data.damageSourceType === "warping" ) {

--- a/module/data/roll/spelleffect.mjs
+++ b/module/data/roll/spelleffect.mjs
@@ -1,0 +1,131 @@
+import EdRollOptions from "./common.mjs";
+import { createContentAnchor } from "../../utils.mjs";
+
+/**
+ * @typedef { object } EdSpellEffectRollOptionsInitializationData
+ * @augments { EdRollOptionsInitializationData }
+ * @property { ItemEd } [spell] The spell causing the effect.
+ * Can be omitted if `spellUuid` in {@link SpellEffectRollOptions} is provided.
+ * @property { ItemEd } [willpower] The willpower ability of the spell's caster, if used for the effect.
+ * Can be omitted if `willpowerUuid` in {@link SpellEffectRollOptions} is provided.
+ * @property { ActorEd } [caster] The actor casting the spell.
+ * Can be omitted if `rollingActorUuid` in {@link SpellEffectRollOptions} is provided.
+ */
+
+/**
+ * Roll options for non-damage spell effects.
+ * @augments { EdRollOptions }
+ * @property { string } spellUuid The UUID of the spell causing the effect.
+ * @property { string } willpowerUuid The UUID of the willpower ability of the spell's caster, if used for the effect.
+ */
+export default class SpellEffectRollOptions extends EdRollOptions {
+
+  // region Static Properties
+
+  /** @inheritdoc */
+  static LOCALIZATION_PREFIXES = [
+    ...super.LOCALIZATION_PREFIXES,
+    "ED.Data.Other.SpellEffectRollOptions",
+  ];
+
+  /** @inheritdoc */
+  static TEST_TYPE = "effect";
+
+  /** @inheritdoc */
+  static ROLL_TYPE = "spellEffect";
+
+  /** @inheritdoc */
+  static GLOBAL_MODIFIERS = [
+    ...super.GLOBAL_MODIFIERS,
+    "allEffects",
+    "allSpellTests",
+  ];
+
+  // endregion
+
+  // region Static Methods
+
+  static defineSchema() {
+    const fields = foundry.data.fields;
+    return this.mergeSchema( super.defineSchema(), {
+      spellUuid: new fields.DocumentUUIDField( {
+        required: true,
+        type:     "Item",
+      } ),
+      willpowerUuid: new fields.DocumentUUIDField( {
+        nullable: true,
+        type:     "Item",
+      } ),
+    } );
+  }
+
+  /**
+   * @inheritdoc
+   * @param {EdSpellEffectRollOptionsInitializationData & Partial<SpellEffectRollOptions>} data The initial data with which to create the roll options.
+   */
+  static fromData( data, options = {} ) {
+    data.spellUuid ??= data.spell?.uuid;
+    data.willpowerUuid ??= data.willpower?.uuid;
+
+    return /** @type {SpellEffectRollOptions} */ super.fromData( data, options );
+  }
+
+  /**
+   * @inheritdoc
+   * @param {EdSpellEffectRollOptionsInitializationData & Partial<SpellEffectRollOptions>} data The initial data with which to create the roll options.
+   */
+  static fromActor( data, actor, options = {} ) {
+    return /** @type {SpellEffectRollOptions} */ super.fromActor( data, actor, options );
+  }
+
+  // endregion
+
+  // region Data Initialization
+
+  /** @inheritDoc */
+  _getChatFlavorData() {
+    return {
+      sourceActor:         createContentAnchor( fromUuidSync( this.rollingActorUuid ) ).outerHTML,
+      spell:               createContentAnchor( fromUuidSync( this.spellUuid ) ).outerHTML,
+    };
+  }
+
+  /** @inheritdoc */
+  static _prepareStepData( data ) {
+    if ( data.step ) return data.step;
+
+    const caster = data.caster ?? fromUuidSync( data.rollingActorUuid );
+    const willpower = data.willpower ?? fromUuidSync( data.willpowerUuid );
+
+    if ( willpower ) {
+      return willpower.system.baseRollOptions.step || {};
+    } else {
+      const spell = data.spell ?? fromUuidSync( data.spellUuid );
+
+      return {
+        base: spell.system.getEffectStepTotal( caster ),
+      };
+    }
+  }
+
+  // endregion
+
+  // region Rendering
+
+  /** @inheritdoc */
+  async getFlavorTemplateData( context ) {
+    const newContext = await super.getFlavorTemplateData( context );
+
+    newContext.spell = await fromUuid( this.spellUuid );
+    newContext.spellContentAnchor = createContentAnchor( newContext.spell ).outerHTML;
+    newContext.willpower = await fromUuid( this.willpowerUuid );
+    newContext.willpowerContentAnchor = newContext.willpower
+      ? createContentAnchor( newContext.willpower ).outerHTML
+      : null;
+
+    return newContext;
+  }
+
+  // endregion
+
+}

--- a/module/data/roll/spelleffect.mjs
+++ b/module/data/roll/spelleffect.mjs
@@ -96,16 +96,24 @@ export default class SpellEffectRollOptions extends EdRollOptions {
 
     const caster = data.caster ?? fromUuidSync( data.rollingActorUuid );
     const willpower = data.willpower ?? fromUuidSync( data.willpowerUuid );
+    const spell = data.spell ?? fromUuidSync( data.spellUuid );
 
-    if ( willpower ) {
-      return willpower.system.baseRollOptions.step || {};
-    } else {
-      const spell = data.spell ?? fromUuidSync( data.spellUuid );
+    return spell.system.getEffectDetailsRollStepData( {
+      actor: caster,
+      willpower
+    } );
+  }
 
-      return {
-        base: spell.system.getEffectStepTotal( caster ),
-      };
-    }
+  /** @inheritdoc */
+  static _prepareStrainData( data ) {
+    if ( data.strain ) return data.strain;
+
+    const willpower = data.willpower ?? fromUuidSync( data.willpowerUuid );
+    if ( !willpower ) return null;
+
+    return {
+      base: willpower.system.strain,
+    };
   }
 
   // endregion

--- a/templates/chat/chat-buttons/roll-effect.hbs
+++ b/templates/chat/chat-buttons/roll-effect.hbs
@@ -1,4 +1,4 @@
-<button type="button" class="roll-effect" title="{{ localize " ED.Chat.Button.rollEffectTitle" }}"
+<button type="button" class="rollEffect" title="{{ localize " ED.Chat.Button.rollEffectTitle" }}"
     data-action="roll-effect">
     {{ localize "ED.Chat.Button.rollEffect" }}
 </button>

--- a/templates/chat/chat-buttons/roll-effect.hbs
+++ b/templates/chat/chat-buttons/roll-effect.hbs
@@ -1,4 +1,4 @@
 <button type="button" class="rollEffect" title="{{ localize " ED.Chat.Button.rollEffectTitle" }}"
-    data-action="roll-effect">
+    data-action="rollEffect">
     {{ localize "ED.Chat.Button.rollEffect" }}
 </button>

--- a/templates/chat/chat-flavor/effect-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/effect-roll-flavor.hbs
@@ -1,14 +1,9 @@
-<div class="custom-flavor">{{ customFlavor }}</div>
+<div class="chat-flavor-header">{{{CONFIG.ED4E.ROLLS.rollTypes.spellEffect.label}}}</div>
+
 {{#if (eq ruleOfOne true)}}
   <div class="roll-failure">{{localize "ED.Rolls.ruleOfOne"}}</div>
 {{else}}
-<div class="flexrow message-buttons effect-roll-buttons" data-roll-total={{ result }}>
-  {{> "systems/ed4e/templates/chat/chat-buttons/roll-effect.hbs"}}
-</div>
 <div class="modifier-lists flexrow">
   {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
-</div>
-<div class="message-buttons flexrow">
-  {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
 </div>
 {{/if}}

--- a/templates/chat/chat-flavor/effect-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/effect-roll-flavor.hbs
@@ -1,9 +1,14 @@
 <div class="chat-flavor-header">{{{CONFIG.ED4E.ROLLS.rollTypes.spellEffect.label}}}</div>
 
+<div class="text--center">{{{spellContentAnchor}}}</div>
+{{#if willpower}}
+  <div class="text--center">{{{willpowerContentAnchor}}}</div>
+{{/if}}
+
 {{#if (eq ruleOfOne true)}}
   <div class="roll-failure">{{localize "ED.Rolls.ruleOfOne"}}</div>
 {{else}}
-<div class="modifier-lists flexrow">
-  {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
-</div>
+  <div class="modifier-lists flexrow">
+    {{> "systems/ed4e/templates/chat/dice-partials/roll-step-modifier.hbs"}}
+  </div>
 {{/if}}

--- a/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
+++ b/templates/chat/chat-flavor/spellcasting-roll-flavor.hbs
@@ -11,6 +11,9 @@
     {{#if (eq spell.system.effect.type "damage")}}
       {{> "systems/ed4e/templates/chat/chat-buttons/roll-damage.hbs"}}
     {{/if}}
+    {{#if (eq spell.system.effect.type "effect")}}
+      {{> "systems/ed4e/templates/chat/chat-buttons/roll-effect.hbs"}}
+    {{/if}}
     {{#if (ed-hasItems spell.effects)}}
       {{> "systems/ed4e/templates/chat/chat-buttons/assign-effect.hbs"}}
     {{/if}}

--- a/templates/item/item-partials/item-details/descriptions/item-description-spell.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-spell.hbs
@@ -13,7 +13,7 @@
   {{!-- Spellcasting Difficulty --}}
   {{!--formGroup systemFields.spellcastingDifficulty name="system.spellcastingDifficulty" value=item.system.spellcastingDifficulty localize=true--}}
   {{!-- effect --}}
-  {{formGroup systemFields.effect.fields.details.fields.special.fields.description name="system.effect.details.special.description" value=item.system.effect.details.special.description}}
+  {{!--formGroup systemFields.effect.fields.details.fields.special.fields.description name="system.effect.details.special.description" value=item.system.effect.details.special.description--}}
   {{!-- keywords --}}
   {{formGroup systemFields.keywords name="system.keywords" value=item.system.keywords localize=true}}
   {{!-- duration --}}

--- a/templates/item/item-partials/item-details/details/item-details-spell.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-spell.hbs
@@ -30,6 +30,7 @@
         systemFields.effect.fields.details.fields.effect.fields.attribute
         name="system.effect.details.effect.attribute"
         value=item.system.effect.details.effect.attribute
+        disabled=true
       }}
       {{formGroup
         systemFields.effect.fields.details.fields.effect.fields.stepModifier

--- a/templates/item/item-partials/item-details/details/item-details-spell.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-spell.hbs
@@ -11,11 +11,6 @@
 
     {{#if (eq item.system.effect.type "damage")}}
       {{formGroup
-        systemFields.effect.fields.details.fields.damage.fields.stepModifier
-        name="system.effect.details.damage.stepModifier"
-        value=item.system.effect.details.damage.stepModifier
-      }}
-      {{formGroup
         systemFields.effect.fields.details.fields.damage.fields.damageType
         name="system.effect.details.damage.damageType"
         value=item.system.effect.details.damage.damageType
@@ -25,12 +20,31 @@
         name="system.effect.details.damage.armorType"
         value=item.system.effect.details.damage.armorType
       }}
+      <fieldset>
+        <legend>{{localize "ED.Item.Header.spellDamageStep"}}</legend>
+        {{formGroup
+          systemFields.effect.fields.details.fields.damage.fields.attribute
+          name="system.effect.details.damage.attribute"
+          value=item.system.effect.details.damage.attribute
+        }}
+        {{formGroup
+          systemFields.effect.fields.details.fields.damage.fields.stepModifier
+          name="system.effect.details.damage.stepModifier"
+          value=item.system.effect.details.damage.stepModifier
+        }}
+        {{formGroup
+          systemFields.effect.fields.details.fields.damage.fields.addCircle
+          name="system.effect.details.damage.addCircle"
+          value=item.system.effect.details.damage.addCircle
+        }}
+      </fieldset>
     {{else if (eq item.system.effect.type "effect")}}
+      <fieldset>
+        <legend>{{localize "ED.Item.Header.spellEffectStep"}}</legend>
       {{formGroup
         systemFields.effect.fields.details.fields.effect.fields.attribute
         name="system.effect.details.effect.attribute"
         value=item.system.effect.details.effect.attribute
-        disabled=true
       }}
       {{formGroup
         systemFields.effect.fields.details.fields.effect.fields.stepModifier
@@ -42,6 +56,7 @@
         name="system.effect.details.effect.addCircle"
         value=item.system.effect.details.effect.addCircle
       }}
+      </fieldset>
     {{else if (eq item.system.effect.type "macro")}}
       {{formGroup
         systemFields.effect.fields.details.fields.macro.fields.macroUuid

--- a/templates/item/item-partials/item-details/details/item-details-spell.hbs
+++ b/templates/item/item-partials/item-details/details/item-details-spell.hbs
@@ -25,6 +25,22 @@
         name="system.effect.details.damage.armorType"
         value=item.system.effect.details.damage.armorType
       }}
+    {{else if (eq item.system.effect.type "effect")}}
+      {{formGroup
+        systemFields.effect.fields.details.fields.effect.fields.attribute
+        name="system.effect.details.effect.attribute"
+        value=item.system.effect.details.effect.attribute
+      }}
+      {{formGroup
+        systemFields.effect.fields.details.fields.effect.fields.stepModifier
+        name="system.effect.details.effect.stepModifier"
+        value=item.system.effect.details.effect.stepModifier
+      }}
+      {{formGroup
+        systemFields.effect.fields.details.fields.effect.fields.addCircle
+        name="system.effect.details.effect.addCircle"
+        value=item.system.effect.details.effect.addCircle
+      }}
     {{else if (eq item.system.effect.type "macro")}}
       {{formGroup
         systemFields.effect.fields.details.fields.macro.fields.macroUuid


### PR DESCRIPTION
Closes #888.

Adds handling for rolling spell effects. They are their own rolltype now.

The roll step is defined in the effect details, equally for damage and effect step. Options are the attribute step (WIL by default), a plain modifier, and the caster circle in the relevant discipline.

Willpower is asked to be used if the attribute for the step is set to "wil", both in effect and damage rolls.