### PR TITLE
🗃️ Add Spell Knack Data Model

### DIFF
--- a/lang/de.json
+++ b/lang/de.json
@@ -2244,6 +2244,26 @@
             }
           }
         },
+        "SpellKnack": {
+          "FIELDS": {
+            "bloodMagic": {
+              "hint":                              "Ist die Überanstrung Blutmagieschaden?",
+              "label":                             "Blutmagie"
+            },
+            "linkable": {
+              "hint":                              "Kann dieser Kniff mit anderen Kniffen verknüpft gewirkt werden?",
+              "label":                             "Verknüpfbar"
+            },
+            "linkableKnacks": {
+              "hint":                              "Kniffe mit denen dieser Kniff verknüpft werden kann",
+              "label":                             "Verknüpfbare Kniffe"
+            },
+            "strain": {
+              "hint":                              "Überanstrengungsschaden der durch das Wirken dieses Kniffs verursacht wird",
+              "label":                             "Überanstrengung"
+            }
+          }
+        },
         "Talent": {
           "FIELDS": {
             "knacks": {

--- a/lang/en.json
+++ b/lang/en.json
@@ -2245,6 +2245,26 @@
             }
           }
         },
+        "SpellKnack": {
+          "FIELDS": {
+            "bloodMagic": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "linkable": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "linkableKnacks": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "strain": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            }
+          }
+        },
         "Talent": {
           "FIELDS": {
             "knacks": {

--- a/lang/fr.json
+++ b/lang/fr.json
@@ -2244,6 +2244,26 @@
             }
           }
         },
+        "SpellKnack": {
+          "FIELDS": {
+            "bloodMagic": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "linkable": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "linkableKnacks": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "strain": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            }
+          }
+        },
         "Talent": {
           "FIELDS": {
             "knacks": {

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -2244,6 +2244,26 @@
             }
           }
         },
+        "SpellKnack": {
+          "FIELDS": {
+            "bloodMagic": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "linkable": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "linkableKnacks": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            },
+            "strain": {
+              "hint":                              "TODO: Add translation",
+              "label":                             "TODO: Add translation"
+            }
+          }
+        },
         "Talent": {
           "FIELDS": {
             "knacks": {

--- a/module/applications/item/item-sheet.mjs
+++ b/module/applications/item/item-sheet.mjs
@@ -106,6 +106,9 @@ export default class ItemSheetEd extends DocumentSheetMixinEd( ItemSheetV2 ) {
       {
         item:                   this.document,
         options:                this.options,
+      },
+      {
+        recursive: false,
       }
     );
 

--- a/module/data/abstract/system-data-model.mjs
+++ b/module/data/abstract/system-data-model.mjs
@@ -112,7 +112,7 @@ export default class SystemDataModel extends foundry.abstract.TypeDataModel {
 
   /**
    * Get the actor that contains this data model or undefined if it is not embedded.
-   * @type {*|undefined}
+   * @type {ActorEd|undefined}
    */
   get containingActor() {
     if ( !this.parent ) return undefined;

--- a/module/data/common/_module.mjs
+++ b/module/data/common/_module.mjs
@@ -16,6 +16,7 @@ import {
   LanguageConstraintData,
   NamegiverConstraintData,
   RelationConstraintData,
+  SpellConstraintData,
 } from "./restrict-require.mjs";
 
 export {
@@ -33,5 +34,6 @@ export {
   RelationConstraintData,
   SectionMetricData,
   SpecialMetricData,
+  SpellConstraintData,
   TargetMetricData,
 };

--- a/module/data/common/restrict-require.mjs
+++ b/module/data/common/restrict-require.mjs
@@ -30,6 +30,7 @@ export class ConstraintData extends SparseDataModel {
       [LanguageConstraintData.TYPE]:   LanguageConstraintData,
       [NamegiverConstraintData.TYPE]:  NamegiverConstraintData,
       [RelationConstraintData.TYPE]:   RelationConstraintData,
+      [SpellConstraintData.TYPE]:      SpellConstraintData,
     } );
   }
 
@@ -172,6 +173,21 @@ export class RelationConstraintData extends ConstraintData {
   static defineSchema() {
     return this.mergeSchema( super.defineSchema(), {
       relation: new fields.StringField(),
+    } );
+  }
+
+}
+
+export class SpellConstraintData extends ConstraintData {
+
+  static {
+    Object.defineProperty( this, "TYPE", { value: "spell", } );
+  }
+
+  /** @inheritdoc */
+  static defineSchema() {
+    return this.mergeSchema( super.defineSchema(), {
+      spell: new EdIdField(),
     } );
   }
 

--- a/module/data/item/knack-ability.mjs
+++ b/module/data/item/knack-ability.mjs
@@ -4,7 +4,7 @@ import KnackTemplate from "./templates/knack-item.mjs";
 
 /**
  * Data model template with information on Knack items.
- * @property {string} sourceTalent          talent the knack is derived from
+ * @property {string} sourceItem          talent the knack is derived from
  * @property {string} restrictions          restrictions of the knack
  * @property {object} requirements          requirement of the knack
  * @property {boolean} standardEffect       standard effect used
@@ -49,7 +49,7 @@ export default class KnackAbilityData extends AbilityTemplate.mixin(
    * @type {number}
    */
   get parentRank() {
-    const parentTalent = this.containingActor?.itemTypes.talent.find( ( talent ) => talent.system.edid === this.sourceTalent );
+    const parentTalent = this.containingActor?.itemTypes.talent.find( ( talent ) => talent.system.edid === this.sourceItem );
     return parentTalent?.system.level;
   }
   

--- a/module/data/item/spell-knacks.mjs
+++ b/module/data/item/spell-knacks.mjs
@@ -79,8 +79,8 @@ export default class SpellKnackData extends SpellData.mixin(
   async _copySourceSpellData( data ) {
     const actor = this.containingActor;
     const sourceSpell = actor
-      ? await actor.getSingleItemByEdid( this.sourceTalent, "spell" )
-      : await getSingleGlobalItemByEdid( this.sourceTalent, "spell" );
+      ? await actor.getSingleItemByEdid( this.sourceItem, "spell" )
+      : await getSingleGlobalItemByEdid( this.sourceItem, "spell" );
     if ( !sourceSpell ) return;
 
     // Ensure edid is not changed

--- a/module/data/item/spell-knacks.mjs
+++ b/module/data/item/spell-knacks.mjs
@@ -59,15 +59,19 @@ export default class SpellKnackData extends SpellData.mixin(
   async _preCreate( data, options, user ) {
     if ( await super._preCreate( data, options, user ) === false ) return false;
 
-    await this._copySourceSpellData( data );
-    this.updateSource( data );
+    if ( this._isChangingSourceItem( data ) ) {
+      await this._copySourceSpellData( data );
+      this.updateSource( data );
+    }
   }
 
   /** @inheritDoc */
   async _preUpdate( changes, options, user ) {
     if ( await super._preUpdate( changes, options, user ) === false ) return false;
 
-    await this._copySourceSpellData( changes );
+    if ( this._isChangingSourceItem( changes ) ) {
+      await this._copySourceSpellData( changes );
+    }
   }
 
   /**

--- a/module/data/item/spell-knacks.mjs
+++ b/module/data/item/spell-knacks.mjs
@@ -1,12 +1,18 @@
 import ItemDescriptionTemplate from "./templates/item-description.mjs";
+import SpellData from "./spell.mjs";
+import EdIdField from "../fields/edid-field.mjs";
+import { getSingleGlobalItemByEdid } from "../../utils.mjs";
 import KnackTemplate from "./templates/knack-item.mjs";
 
 /**
  * Data model template with information on Spell items.
  */
-export default class SpellKnackData extends KnackTemplate.mixin(
-  ItemDescriptionTemplate
+export default class SpellKnackData extends SpellData.mixin(
+  ItemDescriptionTemplate,
+  KnackTemplate,
 )  {
+
+  // region Static Properties
 
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
@@ -14,10 +20,86 @@ export default class SpellKnackData extends KnackTemplate.mixin(
     "ED.Data.Item.SpellKnack",
   ];
 
+  // endregion
+
+  // region Static Methods
+
   /** @inheritDoc */
   static defineSchema() {
+    const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
-            
+      bloodMagic: new fields.BooleanField( {
+        required: true,
+        initial:  false,
+      } ),
+      linkable: new fields.BooleanField( {
+        required: true,
+        initial:  false,
+      } ),
+      linkableKnacks: new fields.ArrayField(
+        new EdIdField(),
+        {
+          initial: [],
+        }
+      ),
+      strain: new fields.NumberField( {
+        required: true,
+        min:      0,
+        integer:  true,
+        initial:  0,
+      } ),
     } );
   }
+
+  // endregion
+
+  // region Life Cycle Events
+
+  /** @inheritDoc */
+  async _preCreate( data, options, user ) {
+    if ( await super._preCreate( data, options, user ) === false ) return false;
+
+    await this._copySourceSpellData( data );
+    this.updateSource( data );
+  }
+
+  /** @inheritDoc */
+  async _preUpdate( changes, options, user ) {
+    if ( await super._preUpdate( changes, options, user ) === false ) return false;
+
+    await this._copySourceSpellData( changes );
+  }
+
+  /**
+   * Writes the data of the source spell into `data` for fields that are not provided in `data`.
+   * Does nothing if no source spell is found.
+   * @param {object} data The data being provided for creating or updating the spell knack.
+   * @returns {Promise<void>}
+   */
+  async _copySourceSpellData( data ) {
+    const actor = this.containingActor;
+    const sourceSpell = actor
+      ? await actor.getSingleItemByEdid( this.sourceTalent, "spell" )
+      : await getSingleGlobalItemByEdid( this.sourceTalent, "spell" );
+    if ( !sourceSpell ) return;
+
+    // Ensure edid is not changed
+    data.system ??= {};
+    data.system.edid = this.edid;
+
+    foundry.utils.mergeObject(
+      data.system,
+      sourceSpell.system.toObject( true ),
+      {
+        inplace:          true,
+        insertKeys:       true,
+        insertValues:     true,
+        overwrite:        false,
+        performDeletions: false,
+      }
+    );
+  }
+
+  // endregion
+
 }

--- a/module/data/item/talent.mjs
+++ b/module/data/item/talent.mjs
@@ -322,8 +322,8 @@ export default class TalentData extends IncreasableAbilityTemplate.mixin(
       "system.knacks.available": [ ...this.knacks.available, document.uuid ],
     } );
     const knack = await fromUuid( document.uuid );
-    if ( !knack.system?.sourceTalent ) knack.update( {
-      "system.sourceTalent": item.edid,
+    if ( !knack.system?.sourceItem ) knack.update( {
+      "system.sourceItem": item.edid,
     } );
     return true;
   }

--- a/module/data/item/templates/knack-item.mjs
+++ b/module/data/item/templates/knack-item.mjs
@@ -15,11 +15,17 @@ export default class KnackTemplate extends SystemDataModel.mixin(
   TargetTemplate,
 ) {
 
+  // region Static Properties
+
   /** @inheritdoc */
   static LOCALIZATION_PREFIXES = [
     ...super.LOCALIZATION_PREFIXES,
     "ED.Data.Item.Knack",
   ];
+
+  // endregion
+
+  // region Static Methods
 
   /** @inheritDoc */
   static defineSchema() {
@@ -46,9 +52,25 @@ export default class KnackTemplate extends SystemDataModel.mixin(
     } );
   }
 
-  /* -------------------------------------------- */
-  /*  LP Tracking                                 */
-  /* -------------------------------------------- */
+  // endregion
+
+  // region Checkers
+
+  /**
+   * Check whether the creation or update data changes the source item of the knack.
+   * @param {object} update The create or update data
+   * @returns {boolean} True if the source item is changed, false otherwise
+   */
+  _isChangingSourceItem( update ) {
+    const data = foundry.utils.expandObject( update );
+    const newEdid = data?.system?.sourceItem;
+
+    return newEdid && newEdid !== this.sourceItem;
+  }
+
+  // endregion
+
+  // region LP Tracking
 
   /** @inheritDoc */
   get canBeLearned() {
@@ -192,13 +214,15 @@ export default class KnackTemplate extends SystemDataModel.mixin(
     return learnedItem;
   }
 
-  /* -------------------------------------------- */
-  /*  Migrations                                  */
-  /* -------------------------------------------- */
+  // endregion
+
+  // region Migration
 
   /** @inheritDoc */
   static migrateData( source ) {
     super.migrateData( source );
     // specific migration functions
   }
+
+  // endregion
 }

--- a/module/data/item/templates/knack-item.mjs
+++ b/module/data/item/templates/knack-item.mjs
@@ -38,7 +38,11 @@ export default class KnackTemplate extends SystemDataModel.mixin(
         integer:  true,
       } ),
       requirements:     new fields.ArrayField(
-        new fields.TypedSchemaField( ConstraintData.TYPES ) ),
+        new fields.TypedSchemaField( ConstraintData.TYPES )
+      ),
+      restrictions:   new fields.ArrayField(
+        new fields.TypedSchemaField( ConstraintData.TYPES )
+      ),
     } );
   }
 

--- a/module/data/item/templates/knack-item.mjs
+++ b/module/data/item/templates/knack-item.mjs
@@ -25,7 +25,7 @@ export default class KnackTemplate extends SystemDataModel.mixin(
   static defineSchema() {
     const fields = foundry.data.fields;
     return this.mergeSchema( super.defineSchema(), {
-      sourceTalent: new EdIdField(),
+      sourceItem: new EdIdField(),
       minLevel:         new fields.NumberField( {
         required: true,
         positive: true,
@@ -64,7 +64,7 @@ export default class KnackTemplate extends SystemDataModel.mixin(
     const actor = this.parent._actor;
 
     return {
-      talent:     actor.itemTypes.talent.find( ( talent ) => talent.system.edid === this.sourceTalent ),
+      talent:     actor.itemTypes.talent.find( ( talent ) => talent.system.edid === this.sourceItem ),
       requiredLp: this.requiredLpForLearning,
       hasDamage:  actor.hasDamage( "standard" ),
       hasWounds:  actor.hasWounds( "standard" ),
@@ -144,9 +144,9 @@ export default class KnackTemplate extends SystemDataModel.mixin(
       return;
     }
 
-    const parentTalent = actor.itemTypes.talent.find( ( talent ) => talent.system.edid === item.system.sourceTalent );
+    const parentTalent = actor.itemTypes.talent.find( ( talent ) => talent.system.edid === item.system.sourceItem );
     if ( !parentTalent ) {
-      const talentSourceEdid = item.system.sourceTalent;
+      const talentSourceEdid = item.system.sourceItem;
       ui.notifications.warn( game.i18n.format(
         "ED.Notifications.Warn.noSourceTalent",
         { talentSourceEdid: talentSourceEdid },

--- a/module/services/migrations/v082/field-migrations/knack-source.mjs
+++ b/module/services/migrations/v082/field-migrations/knack-source.mjs
@@ -4,16 +4,16 @@ export default class KnackSourceTalentMigration extends BaseMigration {
 
   static migrateEarthdawnData( source, item, migrationId = "" ) {
     /**
-     * if knack is owned. search for embedded item with name === sourceTalentName. 
+     * if knack is owned. search for embedded item with name === sourceItemName. 
      * if found look up sourceTalentName.system.edid 
-     * add ed id to source.system.sourceTalent
+     * add ed id to source.system.sourceItem
      */
 
     if ( source.items?.length > 0 ) {
       if ( item.system?.sourceTalentName ) {
         const embeddedItem = source.items.find( i => i.name === item.system.sourceTalentName );
         if ( embeddedItem?.system.edid !== "none" ) {
-          source.system.sourceTalent = embeddedItem.system.edid;
+          source.system.sourceItem = embeddedItem.system.edid;
         } else {
           console.log( `Knack Source Migration: No ED ID found for ${item.system.sourceTalentName} in ${source.name}` );
         }

--- a/module/utils.mjs
+++ b/module/utils.mjs
@@ -51,9 +51,9 @@ export function getAllEdIds( type ) {
  * Adapted from ({@link https://gitlab.com/peginc/swade/-/wikis/Savage-Worlds-ID|SWADE system}).
  * Returns an array of items that match a given EDID and optionally an item type.
  * Searched documents are world and compendium items.
- * @param {string} edid           The EDID of the item(s) which you want to retrieve
- * @param {string} type           Optionally, a type name to restrict the search
- * @returns {Item[]|undefined}    An array containing the found items
+ * @param {string} edid                    The EDID of the item(s) which you want to retrieve
+ * @param {string} type                    Optionally, a type name to restrict the search
+ * @returns {Promise<Item[]|undefined>}    An array containing the found items
  */
 export async function getGlobalItemsByEdid( edid, type ) {
   return getAllDocuments(
@@ -70,9 +70,9 @@ export async function getGlobalItemsByEdid( edid, type ) {
  * Adapted from ({@link https://gitlab.com/peginc/swade/-/wikis/Savage-Worlds-ID|SWADE system}).
  * Fetch an item that matches a given EDID and optionally an item type.
  * Searched documents are world and compendium items.
- * @param {string} edid         The EDID of the item(s) which you want to retrieve
- * @param {string} type         Optionally, a type name to restrict the search
- * @returns {Item|undefined}    The matching item, or undefined if none was found.
+ * @param {string} edid                  The EDID of the item(s) which you want to retrieve
+ * @param {string} type                  Optionally, a type name to restrict the search
+ * @returns {Promise<Item|undefined>}    The matching item, or undefined if none was found.
  */
 export async function getSingleGlobalItemByEdid( edid, type ) {
   return getGlobalItemsByEdid( edid, type ).then( item => item[0] );

--- a/templates/actor/actor-tabs/talents.hbs
+++ b/templates/actor/actor-tabs/talents.hbs
@@ -19,17 +19,17 @@
           {{#each (ed-getTalentCategory actor.itemTypes.talent "discipline") as |talent i|}}
             {{> "systems/ed4e/templates/actor/cards/ability-card.hbs" }}
             {{#each actor.itemTypes.knackAbility}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-ability-card.hbs"}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackManeuver}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-maneuver-card.hbs"}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackKarma}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-karma-card.hbs"}}
               {{/if}}
             {{/each}}
@@ -51,17 +51,17 @@
           {{#each (ed-getTalentCategory actor.itemTypes.talent "optional") as |talent i|}}
             {{> "systems/ed4e/templates/actor/cards/ability-card.hbs" }}
             {{#each actor.itemTypes.knackAbility}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-ability-card.hbs" knack=this talent=talent}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackManeuver}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-maneuver-card.hbs"}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackKarma}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-karma-card.hbs"}}
               {{/if}}
             {{/each}}
@@ -83,17 +83,17 @@
           {{#each (ed-getTalentCategory actor.itemTypes.talent "free") as |talent i|}}
             {{> "systems/ed4e/templates/actor/cards/ability-card.hbs" }}
             {{#each actor.itemTypes.knackAbility}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-ability-card.hbs" knack=this talent=talent}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackManeuver}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-maneuver-card.hbs"}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackKarma}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-karma-card.hbs"}}
               {{/if}}
             {{/each}}
@@ -115,17 +115,17 @@
           {{#each (ed-getTalentCategory actor.itemTypes.talent "other") as |talent i|}}
             {{> "systems/ed4e/templates/actor/cards/ability-card.hbs" }}
             {{#each actor.itemTypes.knackAbility}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-ability-card.hbs" knack=this talent=talent}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackManeuver}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-maneuver-card.hbs"}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackKarma}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-karma-card.hbs"}}
               {{/if}}
             {{/each}}
@@ -147,17 +147,17 @@
           {{#each (ed-getTalentCategory actor.itemTypes.talent "versatility") as |talent i|}}
             {{> "systems/ed4e/templates/actor/cards/ability-card.hbs" }}
             {{#each actor.itemTypes.knackAbility}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-ability-card.hbs" knack=this talent=talent}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackManeuver}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-maneuver-card.hbs"}}
               {{/if}}
             {{/each}}
             {{#each actor.itemTypes.knackKarma}}
-              {{#if (eq this.system.sourceTalent talent.system.edid)}}
+              {{#if (eq this.system.sourceItem talent.system.edid)}}
                 {{> "systems/ed4e/templates/actor/cards/knack-karma-card.hbs"}}
               {{/if}}
             {{/each}}

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackAbility.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackAbility.hbs
@@ -10,7 +10,7 @@
     {{!-- Source --}}
     <div class="knack-ability__source-min-level">
         <div class="knack-ability__source">
-            {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent localize=true}}
+            {{formField systemFields.sourceItem name="system.sourceItem" value=item.system.sourceItem localize=true}}
         </div>
         <div class="knack-ability__min-level">
             {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackKarma.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackKarma.hbs
@@ -5,7 +5,7 @@
   {{!-- Source --}}
   <div class="knack-ability__source-min-level">
     <div class="knack-ability__source">
-      {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent localize=true}}
+      {{formField systemFields.sourceItem name="system.sourceItem" value=item.system.sourceItem localize=true}}
     </div>
     <div class="knack-ability__min-level">
       {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}

--- a/templates/item/item-partials/item-details/descriptions/item-description-knackManeuver.hbs
+++ b/templates/item/item-partials/item-details/descriptions/item-description-knackManeuver.hbs
@@ -5,7 +5,7 @@
   {{!-- Source --}}
   <div class="knack-ability__source-min-level">
     <div class="knack-ability__source">
-      {{formField systemFields.sourceTalent name="system.sourceTalent" value=item.system.sourceTalent localize=true}}
+      {{formField systemFields.sourceItem name="system.sourceItem" value=item.system.sourceItem localize=true}}
     </div>
     <div class="knack-ability__min-level">
       {{formInput systemFields.minLevel name="system.minLevel" value=item.system.minLevel}}


### PR DESCRIPTION
Closes #446 .

Opting for a simple approach here: spell knacks inherit from SpellData and mixin the KnackTemplate.

Whenever the knack is created or updated with the source spell edid, its system data is pulled and copied into the knack. This way, spell knacks are just normal spells with changed data, that belong to another spell.