### PR TITLE
language-container

### DIFF
--- a/earthdawn4e.css
+++ b/earthdawn4e.css
@@ -477,7 +477,7 @@ h3.label--rail .label__text::after {
   line-height: 1;
   font-weight: 700;
   font-size: 16px;
-  width: 15px;
+  width: 14px;
   height: auto;
 }
 .buffer--minus {
@@ -1645,7 +1645,6 @@ h3.label--rail .label__text::after {
   grid-column: 1;
   grid-row: 2;
   text-align: left;
-  padding: 23px 0 0 5px;
   justify-content: center;
   align-items: center;
 }

--- a/earthdawn4e.css
+++ b/earthdawn4e.css
@@ -533,21 +533,28 @@ h3.label--rail .label__text::after {
 .actor input[type='checkbox']:checked::after {
   color: var(--color-button-check-on);
 }
-.actor .icon--button {
+.actor .icon--button,
+.actor .item-control {
+  --icon-height: 100%;
+  --icon-width: 25px;
+  width: var(--icon-size);
+  height: var(--icon-size);
+  display: inline-flex;
   background: none;
   border: 0;
   padding: 0;
   cursor: pointer;
   color: var(--color-button-icon);
+  font-size: var(--font-size-13);
   min-height: 0;
+  align-items: center;
 }
-.actor .icon--button:hover {
+.actor .icon--button:hover,
+.actor .item-control:hover {
   color: var(--color-button-icon-hover);
+  text-shadow: none;
 }
 .actor .icon--button.icon {
-  --icon-size: 25px;
-  width: var(--icon-size);
-  height: var(--icon-size);
   line-height: 0;
   display: inline-block;
   padding: 0;
@@ -1253,7 +1260,8 @@ h3.label--rail .label__text::after {
 .application.sheet.earthdawn4e.actor .window-content .recovery__grid--container,
 .application.sheet.earthdawn4e.actor .window-content .initiative__grid--container,
 .application.sheet.earthdawn4e.actor .window-content .initiative-npc__grid--container,
-.application.sheet.earthdawn4e.actor .window-content .spell-card__grid--container {
+.application.sheet.earthdawn4e.actor .window-content .spell-card__grid--container,
+.application.sheet.earthdawn4e.actor .window-content .language-card__grid--container {
   column-gap: var(--grid-col-gap-sm);
   text-transform: capitalize;
   font-weight: normal;
@@ -1276,7 +1284,8 @@ h3.label--rail .label__text::after {
 .application.sheet.earthdawn4e.actor .window-content .recovery__grid--container.container__header,
 .application.sheet.earthdawn4e.actor .window-content .initiative__grid--container.container__header,
 .application.sheet.earthdawn4e.actor .window-content .initiative-npc__grid--container.container__header,
-.application.sheet.earthdawn4e.actor .window-content .spell-card__grid--container.container__header {
+.application.sheet.earthdawn4e.actor .window-content .spell-card__grid--container.container__header,
+.application.sheet.earthdawn4e.actor .window-content .language-card__grid--container.container__header {
   background-color: var(--color-secondary-grey);
   color: var(--color-text-banner);
   text-transform: uppercase;
@@ -1401,6 +1410,10 @@ h3.label--rail .label__text::after {
 .application.sheet.earthdawn4e.actor .window-content .class-card__grid--container {
   display: grid;
   grid-template-columns: minmax(25px, 25px) minmax(100px, 1fr) minmax(40px, 40px) minmax(80px, 80px);
+}
+.application.sheet.earthdawn4e.actor .window-content .language-card__grid--container {
+  display: grid;
+  grid-template-columns: minmax(1fr, 1fr);
 }
 .application.sheet.earthdawn4e.actor .window-content .prosemirror .editor-content,
 .application.sheet.earthdawn4e.actor .window-content prose-mirror .editor-content {

--- a/less/global/global.less
+++ b/less/global/global.less
@@ -275,7 +275,7 @@ h3.label--rail .label__text::after {
   line-height: 1;
   font-weight: 700;
   font-size: 16px;
-  width: 15px;
+  width: 14px;
   height: auto;
 }
 

--- a/less/global/icons.less
+++ b/less/global/icons.less
@@ -22,23 +22,31 @@
 
 
   /* generic icon button */
-  .icon--button {
+
+  .icon--button,
+  .item-control {
+    --icon-height: 100%;
+    --icon-width: 25px;
+    width: var(--icon-size);
+    height: var(--icon-size);
+    display: inline-flex;
     background: none;
     border: 0;
     padding: 0;
     cursor: pointer;
     color: var(--color-button-icon);
+    font-size: var(--font-size-13);
     min-height: 0;
+    align-items: center;
   }
 
-  .icon--button:hover {
+  .icon--button:hover,
+  .item-control:hover {
     color: var(--color-button-icon-hover);
+    text-shadow: none;
   }
 
   .icon--button.icon {
-    --icon-size: 25px;
-    width: var(--icon-size);
-    height: var(--icon-size);
     line-height: 0;
     display: inline-block;
     padding: 0;

--- a/less/sheets/actor-sheet-layout.less
+++ b/less/sheets/actor-sheet-layout.less
@@ -506,7 +506,7 @@
         }
 
         /* damage grid placement */
-        .damage__grid--item.damage__title { grid-column: 1; grid-row: 2; text-align: left; padding: 23px 0 0 5px; justify-content: center; align-items: center; }
+        .damage__grid--item.damage__title { grid-column: 1; grid-row: 2; text-align: left; justify-content: center; align-items: center; }
         .damage__grid--item.damage__normal { grid-column: 2; grid-row: 2; display: flex; justify-content: center; align-items: center; }
         .damage__grid--item.damage__stun { grid-column: 3; grid-row: 2; display: flex; justify-content: center; align-items: center; }
         .damage__grid--item.damage__total { grid-column: 4; grid-row: 2; display: flex; justify-content: center; align-items: center; }

--- a/less/sheets/actor-sheet-layout.less
+++ b/less/sheets/actor-sheet-layout.less
@@ -44,7 +44,8 @@
     .recovery__grid--container,
     .initiative__grid--container,
     .initiative-npc__grid--container,
-    .spell-card__grid--container {
+    .spell-card__grid--container,
+    .language-card__grid--container {
       column-gap: var(--grid-col-gap-sm);
       text-transform: capitalize;
       font-weight: normal;
@@ -70,7 +71,7 @@
     .class-card__grid--item:nth-child(4),
     .effect-card__grid--item:nth-child(6) {
       padding: 0 4px 0 0;
-      color: var(--color-button-icon)
+      color: var(--color-button-icon);
     }
 
     .attribute-card__grid--item:nth-child(2),
@@ -209,23 +210,30 @@
         minmax(40px, 40px)
         minmax(80px, 80px);
     }
+
+    .language-card__grid--container {
+      display: grid;
+      grid-template-columns:
+        minmax(1fr, 1fr);
+    }
+
     .prosemirror .editor-content, prose-mirror .editor-content {
       font-size: var(--font-size-15);
     }
 
     /* ======================= Abilities tab ======================= */
-.ability-card__grid--container {
-  display: grid;
-  grid-template-columns:
-    minmax(25px, 25px)
-    minmax(200px, 1fr)
-    minmax(60px, 60px)
-    minmax(40px, 40px)
-    minmax(40px, 40px)
-    minmax(60px, 60px)
-    minmax(60px, 60px)
-    minmax(80px, 80px);
-  }
+    .ability-card__grid--container {
+      display: grid;
+      grid-template-columns:
+        minmax(25px, 25px)
+        minmax(200px, 1fr)
+        minmax(60px, 60px)
+        minmax(40px, 40px)
+        minmax(40px, 40px)
+        minmax(60px, 60px)
+        minmax(60px, 60px)
+        minmax(80px, 80px);
+      }
 
   .ability-card__grid--item:nth-child(2) { text-align: left; }
 

--- a/templates/actor/actor-partials/actor-section-top-pc.hbs
+++ b/templates/actor/actor-partials/actor-section-top-pc.hbs
@@ -22,12 +22,12 @@
                     {{localize "ED.Actor.Characteristics.physicalDefense"}}
                   </label>
                   <div class="buffer-input">
-                    <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
                     <input id="characteristic-defense-physical"
                            class="input__rectangle-input--centered"
                            name="system.characteristics.defenses.physical.value"
                            value="{{actor.system.characteristics.defenses.physical.value}}">
-                    <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
                   </div>
                 </div>
 
@@ -36,12 +36,12 @@
                     {{localize "ED.Actor.Characteristics.mysticalDefense"}}
                   </label>
                   <div class="buffer-input">
-                    <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
                     <input id="characteristic-defense-mystical"
                            class="input__rectangle-input--centered"
                            name="system.characteristics.defenses.mystical.value"
                            value="{{actor.system.characteristics.defenses.mystical.value}}">
-                    <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
                   </div>
                 </div>
 
@@ -50,12 +50,12 @@
                     {{localize "ED.Actor.Characteristics.socialDefense"}}
                   </label>
                   <div class="buffer-input">
-                    <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
                     <input id="characteristic-defense-social"
                            class="input__rectangle-input--centered"
                            name="system.characteristics.defenses.social.value"
                            value="{{actor.system.characteristics.defenses.social.value}}">
-                    <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
                   </div>
                 </div>
               </div>
@@ -73,12 +73,12 @@
                     {{localize "ED.Actor.Characteristics.physicalArmor"}}
                   </label>
                   <div class="buffer-input">
-                    <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
                     <input id="characteristic-armor-physical"
                            class="input__rectangle-input--centered"
                            name="system.characteristics.armor.physical.value"
                            value="{{actor.system.characteristics.armor.physical.value}}">
-                    <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
                   </div>
                 </div>
 
@@ -87,12 +87,12 @@
                     {{localize "ED.Actor.Characteristics.mysticalArmor"}}
                   </label>
                   <div class="buffer-input">
-                    <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
                     <input id="characteristic-armor-mystical"
                            class="input__rectangle-input--centered"
                            name="system.characteristics.armor.mystical.value"
                            value="{{actor.system.characteristics.armor.mystical.value}}">
-                    <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+                    {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
                   </div>
                 </div>
               </div>

--- a/templates/actor/actor-tabs/classes.hbs
+++ b/templates/actor/actor-tabs/classes.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.classes.cssClass}}" data-group="sheet" data-tab="classes">
+<section class="tab {{tabs.classes.cssClass}}" data-group="sheet" data-tab="classes" data-editable="{{@root.editable}}">
 
 <div>
     <div class="class-card__grid--container font__bold text-break__auto">

--- a/templates/actor/actor-tabs/configuration.hbs
+++ b/templates/actor/actor-tabs/configuration.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.configuration.cssClass}}" data-group="sheet" data-tab="configuration">
+<section class="tab {{tabs.configuration.cssClass}}" data-group="sheet" data-tab="configuration" data-editable="{{@root.editable}}">
 <div>
     {{formField systemFields.isMob name="system.isMob" value=actor.system.isMob localize=true}}
 </div>

--- a/templates/actor/actor-tabs/description.hbs
+++ b/templates/actor/actor-tabs/description.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.description.cssClass}}" data-group="sheet" data-tab="description">
+<section class="tab {{tabs.description.cssClass}}" data-group="sheet" data-tab="description" data-editable="{{@root.editable}}">
   <div class="sheet__editor">
     <h2>{{localize "ED.Actor.Header.information"}}</h2>
     {{> "systems/ed4e/templates/global/editor.hbs"}}

--- a/templates/actor/actor-tabs/devotions.hbs
+++ b/templates/actor/actor-tabs/devotions.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.devotions.cssClass}}" data-group="sheet" data-tab="devotions">
+<section class="tab {{tabs.devotions.cssClass}}" data-group="sheet" data-tab="devotions" data-editable="{{@root.editable}}">
 <h2>{{localize "ED.Actor.Header.devotions"}}</h2>
 
 <div class="container__block">

--- a/templates/actor/actor-tabs/equipment.hbs
+++ b/templates/actor/actor-tabs/equipment.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.equipment.cssClass}}" data-group="sheet" data-tab="equipment">
+<section class="tab {{tabs.equipment.cssClass}}" data-group="sheet" data-tab="equipment" data-editable="{{@root.editable}}">
 <h2>{{localize "ED.Actor.Header.equipment"}}</h2>
 
 <div class="container__block">

--- a/templates/actor/actor-tabs/general.hbs
+++ b/templates/actor/actor-tabs/general.hbs
@@ -1,4 +1,4 @@
-<section class="tab general {{tabs.general.cssClass}}" data-group="sheet" data-tab="general">
+<section class="tab general {{tabs.general.cssClass}}" data-group="sheet" data-tab="general" data-editable="{{@root.editable}}">
 
   <div class="layout__row">
 

--- a/templates/actor/actor-tabs/legend.hbs
+++ b/templates/actor/actor-tabs/legend.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="legend">
+<section class="tab {{tab.cssClass}}" data-group="sheet" data-tab="legend" data-editable="{{@root.editable}}">
 <div>
     <div class="legend-card__grid--container font__bold text-break__auto">
         <div class="legend-card__grid--item text__alignment--center">{{localize "ED.Actor.Header.legendCurrent"}}</div>

--- a/templates/actor/actor-tabs/notes.hbs
+++ b/templates/actor/actor-tabs/notes.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.notes.cssClass}}" data-group="sheet" data-tab="notes">
+<section class="tab {{tabs.notes.cssClass}}" data-group="sheet" data-tab="notes" data-editable="{{@root.editable}}">
   <div class="sheet__editor">
     <div class="layout__row">
 
@@ -115,16 +115,48 @@
 
         <!-- Languages -->
         {{#if systemFields.languages}}
-          <h2>{{localize "ED.Actor.Header.languages"}}</h2>
-          <div class="flexrow">
-          <span>
-            <div class="container__header">{{localize "ED.Actor.Header.languagesSpoken"}}</div>
-            {{formField systemFields.languages.fields.speak value=actor.system.languages.speak name="system.languages.speak"}}
-          </span>
-            <span>
-            <div class="container__header">{{localize "ED.Actor.Header.languagesWritten"}}</div>
-              {{formField systemFields.languages.fields.readWrite value=actor.system.languages.readWrite name="system.languages.readWrite"}}
-          </span>
+          <h2 class="recovery__header margin__none one-line__vertical-align">
+            {{localize "ED.Actor.Header.languages"}}
+          </h2>
+
+          <div class="container__block">
+            {{!-- Spoken --}}
+            <div class="language-card__grid--container container__header">
+              <span class="language__header-label">{{localize "ED.Actor.Header.languagesSpoken"}}
+                {{#if @root.editable}}
+                  <button type="button"
+                          class="item-control action-buttons icon--button rollable"
+                          data-action="open-language-select"
+                          data-select="system.languages.speak"
+                          title="{{localize 'ED.Actor.Header.languagesSpoken'}}"
+                          aria-label="{{localize 'ED.Actor.Header.languagesSpoken'}}">
+                    <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
+                  </button>
+                {{/if}}
+              </span>
+            </div>
+            <span class="languages__control" data-field="system.languages.speak">
+              {{formField systemFields.languages.fields.speak value=actor.system.languages.speak}}
+            </span>
+
+            {{!-- Written --}}
+            <div class="language-card__grid--container container__header">
+              <span class="language__header-label">{{localize "ED.Actor.Header.languagesWritten"}}
+                {{#if @root.editable}}
+                  <button type="button"
+                          class="item-control action-buttons icon--button rollable"
+                          data-action="open-language-select"
+                          data-select="system.languages.readWrite"
+                          title="{{localize 'ED.Actor.Header.languagesWritten'}}"
+                          aria-label="{{localize 'ED.Actor.Header.languagesWritten'}}">
+                    <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
+                  </button>
+                {{/if}}
+              </span>
+            </div>
+            <span class="languages__control" data-field="system.languages.readWrite">
+              {{formField systemFields.languages.fields.readWrite value=actor.system.languages.readWrite}}
+            </span>
           </div>
         {{/if}}
 

--- a/templates/actor/actor-tabs/notes.hbs
+++ b/templates/actor/actor-tabs/notes.hbs
@@ -122,18 +122,7 @@
           <div class="container__block">
             {{!-- Spoken --}}
             <div class="language-card__grid--container container__header">
-              <span class="language__header-label">{{localize "ED.Actor.Header.languagesSpoken"}}
-                {{#if @root.editable}}
-                  <button type="button"
-                          class="item-control action-buttons icon--button rollable"
-                          data-action="open-language-select"
-                          data-select="system.languages.speak"
-                          title="{{localize 'ED.Actor.Header.languagesSpoken'}}"
-                          aria-label="{{localize 'ED.Actor.Header.languagesSpoken'}}">
-                    <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
-                  </button>
-                {{/if}}
-              </span>
+              <span class="language__header-label">{{localize "ED.Actor.Header.languagesSpoken"}}</span>
             </div>
             <span class="languages__control" data-field="system.languages.speak">
               {{formField systemFields.languages.fields.speak value=actor.system.languages.speak}}
@@ -141,18 +130,7 @@
 
             {{!-- Written --}}
             <div class="language-card__grid--container container__header">
-              <span class="language__header-label">{{localize "ED.Actor.Header.languagesWritten"}}
-                {{#if @root.editable}}
-                  <button type="button"
-                          class="item-control action-buttons icon--button rollable"
-                          data-action="open-language-select"
-                          data-select="system.languages.readWrite"
-                          title="{{localize 'ED.Actor.Header.languagesWritten'}}"
-                          aria-label="{{localize 'ED.Actor.Header.languagesWritten'}}">
-                    <i class="fas fa-arrow-circle-up" aria-hidden="true"></i>
-                  </button>
-                {{/if}}
-              </span>
+              <span class="language__header-label">{{localize "ED.Actor.Header.languagesWritten"}}</span>
             </div>
             <span class="languages__control" data-field="system.languages.readWrite">
               {{formField systemFields.languages.fields.readWrite value=actor.system.languages.readWrite}}

--- a/templates/actor/actor-tabs/powers.hbs
+++ b/templates/actor/actor-tabs/powers.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.powers.cssClass}}" data-group="sheet" data-tab="powers">
+<section class="tab {{tabs.powers.cssClass}}" data-group="sheet" data-tab="powers" data-editable="{{@root.editable}}">
 <h2>{{localize "ED.Actor.Header.abilities"}}</h2>
   <div class="container__block">
 

--- a/templates/actor/actor-tabs/reputation.hbs
+++ b/templates/actor/actor-tabs/reputation.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.reputation.cssClass}}" data-group="sheet" data-tab="reputation">
+<section class="tab {{tabs.reputation.cssClass}}" data-group="sheet" data-tab="reputation" data-editable="{{@root.editable}}">
 <div class="undefined">
     tbd
 </div>

--- a/templates/actor/actor-tabs/skills.hbs
+++ b/templates/actor/actor-tabs/skills.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.skills.cssClass}}" data-group="sheet" data-tab="skills">
+<section class="tab {{tabs.skills.cssClass}}" data-group="sheet" data-tab="skills" data-editable="{{@root.editable}}">
 <h2>{{localize "ED.Actor.Header.skills"}}</h2>
 
 <div class="container__block">

--- a/templates/actor/actor-tabs/specials.hbs
+++ b/templates/actor/actor-tabs/specials.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.specials.cssClass}}" data-group="sheet" data-tab="specials">
+<section class="tab {{tabs.specials.cssClass}}" data-group="sheet" data-tab="specials" data-editable="{{@root.editable}}">
   
 {{!-- Conditions --}}
 

--- a/templates/actor/actor-tabs/spells.hbs
+++ b/templates/actor/actor-tabs/spells.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.spells.cssClass}}" data-group="sheet" data-tab="spells">
+<section class="tab {{tabs.spells.cssClass}}" data-group="sheet" data-tab="spells" data-editable="{{@root.editable}}">
   <h2>{{localize "ED.Actor.Header.spells"}}</h2>
   <div class="container__block">
     <nav class="tabs navigator__flex" data-group="spellsContent">

--- a/templates/actor/actor-tabs/talents.hbs
+++ b/templates/actor/actor-tabs/talents.hbs
@@ -1,4 +1,4 @@
-<section class="tab {{tabs.talents.cssClass}}" data-group="sheet" data-tab="talents">
+<section class="tab {{tabs.talents.cssClass}}" data-group="sheet" data-tab="talents" data-editable="{{@root.editable}}">
 <h2>{{localize "ED.Actor.Header.talents"}}</h2>
   <div class="container__block">
     {{#if (eq this.actor.type "character")}}

--- a/templates/actor/cards/ability-card.hbs
+++ b/templates/actor/cards/ability-card.hbs
@@ -1,4 +1,3 @@
-
 <div class="card__ability">
     <div class="ability-card__grid--container item-id" data-item-id="{{_id}}">
         <div class="ability-card__grid--item icons__dice {{#if (or (ne this.system.attribute "") (ne this.system.strain 0))}}has-overlay{{/if}}">

--- a/templates/actor/cards/health-character-card.hbs
+++ b/templates/actor/cards/health-character-card.hbs
@@ -84,13 +84,13 @@
         {{localize "ED.Data.Actor.Sentient.FIELDS.characteristics.health.unconscious.label"}}
       </label>
       <div class="buffer-input">
-        <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+        {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
         <input id="characteristic-health-unconscious"
                type="number"
                class="input__rectangle-input--centered"
                name="system.characteristics.health.unconscious"
                value="{{actor.system.characteristics.health.unconscious}}">
-        <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+        {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
       </div>
     </div>
 
@@ -99,13 +99,13 @@
         {{localize "ED.Data.Actor.Sentient.FIELDS.characteristics.health.death.label"}}
       </label>
       <div class="buffer-input">
-        <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+        {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
         <input id="characteristic-health-death"
                type="number"
                class="input__rectangle-input--centered"
                name="system.characteristics.health.death"
                value="{{actor.system.characteristics.health.death}}">
-        <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+        {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
       </div>
     </div>
 
@@ -114,13 +114,13 @@
         {{localize "ED.Data.Actor.Sentient.FIELDS.characteristics.health.woundThreshold.label"}}
       </label>
       <div class="buffer-input">
-        <button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>
+        {{#unless @root.editable}}<button type="button" class="buffer buffer--minus" aria-label="Decrease"></button>{{/unless}}
         <input id="characteristic-wound-threshold"
                type="number"
                class="input__rectangle-input--centered"
                name="system.characteristics.health.woundThreshold"
                value="{{actor.system.characteristics.health.woundThreshold}}">
-        <button type="button" class="buffer buffer--plus" aria-label="Increase"></button>
+        {{#unless @root.editable}}<button type="button" class="buffer buffer--plus" aria-label="Increase"></button>{{/unless}}
       </div>
     </div>
   </div>

--- a/templates/global/card-options-class-upgrade.hbs
+++ b/templates/global/card-options-class-upgrade.hbs
@@ -1,7 +1,9 @@
 <div class="itemControlGroup" data-item-id="{{_id}}">
-  <a class="item-control item-upgrade__class" data-action="upgradeItem" title="{{localize 'ED.Controls.upgrade'}}">
-    <i class="fas fa-arrow-circle-up"></i>
-  </a>
+  {{#if @root.editable}}
+    <a class="item-control item-upgrade__class" data-action="upgradeItem" title="{{localize 'ED.Controls.upgrade'}}">
+      <i class="fas fa-arrow-circle-up"></i>
+    </a>
+  {{/if}}
   {{!-- <a class="item-control item-downgrade" data-action="displayChild" title="{{localize 'ED.Controls.downgrade'}}">
     <i class="fas fa-arrow-circle-down"></i>
   </a> --}}

--- a/templates/global/card-options-enhance.hbs
+++ b/templates/global/card-options-enhance.hbs
@@ -1,7 +1,9 @@
 <div class="itemControlGroup" data-item-id="{{_id}}">
-  <a class="item-control item-upgrade__ability" data-action="upgradeItem" title="{{localize 'ED.Controls.upgrade'}}">
-    <i class="fas fa-arrow-circle-up"></i>
-  </a>
+  {{#if @root.editable}}
+    <a class="item-control item-upgrade__ability" data-action="upgradeItem" title="{{localize 'ED.Controls.upgrade'}}">
+      <i class="fas fa-arrow-circle-up"></i>
+    </a>
+  {{/if}}
   {{!-- <a class="item-control item-downgrade" title="{{localize 'ED.Controls.downgrade'}}">
     <i class="fas fa-arrow-circle-down"></i>
   </a> --}}


### PR DESCRIPTION
Formatting complete on languages, but needs work with .js to finish. Including an upgrade up arrow in the sub headers to add more after chargen (this only appears in edit mode)... this needs coding in .js.

All upgrades are not restricted to edit mode only and all sections are updated to contain the right class to do this in future.

all + - buffers are now on game mode only.

uuid icons are all formatted to appear like all other buttons (including hover over which was not working prior)