### PR TITLE
🐛Fix "movement must be integer"

### DIFF
--- a/module/services/migrations/v082/document-type-migrations/item/namegiver.mjs
+++ b/module/services/migrations/v082/document-type-migrations/item/namegiver.mjs
@@ -9,7 +9,7 @@ export default class NamegiverMigration extends BaseMigration {
     // Apply image migration
     ImageMigration.migrateEarthdawnData( source );
 
-    if ( source.system ) {
+    if ( source.system && source.system.edid === undefined ) {
       // Migrate attributes
       if ( !source.system.attributeValues ) {
         if (


### PR DESCRIPTION
Fixes #2506

Not enough safe guards for namegiver migration. It was trying to migrate system data from the new version of the system. This made  the movement data be invalid from this line:`source.system.movement = {walk:  source.system.movement};` because `source.system.movement` already was the new schema