### PR TITLE
🚑️ Evaluate duration formula fields on active effects

### DIFF
--- a/module/applications/effect/eae-sheet.mjs
+++ b/module/applications/effect/eae-sheet.mjs
@@ -1,5 +1,4 @@
 import { getEdIds } from "../../settings.mjs";
-import FormulaField from "../../data/fields/formula-field.mjs";
 import ED4E from "../../config/_module.mjs";
 import ClassTemplate from "../../data/item/templates/class.mjs";
 
@@ -68,33 +67,10 @@ export default class EarthdawnActiveEffectSheet extends ActiveEffectConfig {
   // region Form Handling
 
   /** @inheritDoc */
-  _prepareSubmitData( event, form, formData ) {
-    const submitData = super._prepareSubmitData( event, form, formData );
-    submitData.duration = submitData.system.duration;
-    // submitData.changes = this._prepareChangesSubmitData( submitData.system.changes );
-    return submitData;
-  }
-
-  /** @inheritDoc */
   _processFormData( event, form, formData ) {
     const data = super._processFormData( event, form, formData );
     return this._toggleTransfer( event, data );
   }
-
-  /**
-   * Prepares the changes data for submission by evaluating the formula fields.
-   * @param {object[]} changes - The changes data to be prepared.
-   * @returns {object[]} The prepared changes data with evaluated formulas.
-   */
-  _prepareChangesSubmitData( changes ) {
-    return changes.map( change => {
-      return {
-        ...change,
-        value: FormulaField.evaluate( change.value, this.document.system.formulaData, { warn: true } ),
-      };
-    } );
-  }
-
 
   /**
    * Toggles the transfer property based on the changed property in the form.

--- a/module/data/effects/eae.mjs
+++ b/module/data/effects/eae.mjs
@@ -117,6 +117,7 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
    */
   async _getFormulaData() {
     if ( this.appliedToAbility ) return ( await fromUuid( this.abilityUuid ) )?.getRollData() ?? {};
+    if ( this.parent?.isItemEffect ) return ( await fromUuid( this.source.documentOriginUuid ) )?.getRollData() ?? {};
     return this.parent?.target?.getRollData() ?? {};
   }
 
@@ -172,7 +173,7 @@ export default class EarthdawnActiveEffectData extends ActiveEffectDataModel {
    * @type {Document | object | null | *}
    */
   get documentOrigin() {
-    return fromUuidSync( this.documentOriginUuid );
+    return fromUuidSync( this.source.documentOriginUuid );
   }
 
   // endregion

--- a/module/data/fields/formula-field.mjs
+++ b/module/data/fields/formula-field.mjs
@@ -60,7 +60,7 @@ export default class FormulaField extends foundry.data.fields.StringField {
    * @param {object} options  Additional options for {@link Roll#replaceFormulaData}
    * @returns {number}        The evaluated result
    */
-  static evaluate( formula, data= {}, options={} ) {
+  static evaluate( formula, data= {}, options={ warn: true, } ) {
     return Roll.safeEval(
       Roll.replaceFormulaData( formula, data , options )
     );


### PR DESCRIPTION
Duration formula fields should now use and evaluate correctly against the right roll data.
If a key mentioned with `@` is not present in the roll data, an appropriate warning is shown. 
If incorrect formula syntax is used (like omitting the `@`) only a data validation error is shown for now.